### PR TITLE
fix: scope agent activity to project terminals

### DIFF
--- a/Pine/Agent/AgentDetectionCoordinator.swift
+++ b/Pine/Agent/AgentDetectionCoordinator.swift
@@ -762,6 +762,12 @@ nonisolated final class AgentDetectionCoordinator {
                     )
                 }
                 tab.agentSession = current
+                if let current {
+                    terminalManager.captureProjectAgentOwnership(
+                        of: current,
+                        in: tab
+                    )
+                }
             }
             terminalManager.refreshAgentTasks()
         }

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -2094,8 +2094,8 @@ final class ProjectManager {
     /// routinely create brand-new files (` .untracked`), `git add` files
     /// (`.staged`), and modify already-staged files (`.mixed`); dropping any
     /// of those would make the panel miss the most common agent action.
-    private func correlateAgentActivity(rootURL: URL) {
-        let active = terminal.agentDetector.activeSessions
+    func correlateAgentActivity(rootURL: URL) {
+        let active = terminal.projectOwnedActiveAgentSessions
         guard !active.isEmpty else {
             attributedModifiedPaths = []
             agentActivitySeeded = false
@@ -2124,8 +2124,8 @@ final class ProjectManager {
 
     /// `true` for working-tree states that represent a change an agent could
     /// have made. `.deleted` is excluded (the file no longer exists to open).
-    /// `internal` so the attribution filter is unit-testable (the integration
-    /// through `correlateAgentActivity` reads main-actor state with no DI seam).
+    /// `internal` so the attribution filter is unit-testable alongside the
+    /// exact project-terminal ownership projection.
     static func isAttributableStatus(_ status: GitFileStatus) -> Bool {
         switch status {
         case .untracked, .modified, .staged, .added, .conflict, .mixed:
@@ -2150,11 +2150,9 @@ final class ProjectManager {
     /// synchronously per file on the main thread at termination would stall
     /// the UI (S2/S3 from the #1075 review).
     func finalizeAgentSessionsForHistory() {
-        let doneSessions = terminal.agentDetector.detectedSessions.filter {
-            $0.state == .done
-        }
-        guard !doneSessions.isEmpty else { return }
         guard let root = workspace.rootURL else { return }
+        let doneSessions = terminal.takeProjectOwnedCompletedAgentSessions()
+        guard !doneSessions.isEmpty else { return }
         for session in doneSessions {
             let relativePaths = session.filesModified.compactMap { relativePath(from: $0, root: root) }
             agentHistory.finalize(

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -24,6 +24,47 @@ nonisolated struct PineAgentSettledLaunchIdentity: Hashable, Sendable {
     let sessionID: UUID
 }
 
+/// Immutable process-generation witness carried by one exact terminal binding.
+///
+/// This mirrors every field compared by
+/// ``AgentProcessEvidence/identifiesSameProcess(as:)``. Activity and History
+/// ownership must not weaken that comparison to a PID, executable name, or
+/// detector-local generation alone.
+nonisolated private struct ProjectTerminalAgentProcessGeneration:
+    Hashable, Sendable {
+    let processIdentifier: Int32
+    let processGeneration: UInt64
+    let startIdentifier: String
+    let observedStartedAt: Date
+    let startIsAuthoritative: Bool
+
+    init?(_ evidence: AgentProcessEvidence?) {
+        guard let evidence,
+              evidence.startIsAuthoritative,
+              let processIdentifier = evidence.processIdentifier,
+              processIdentifier > 1,
+              evidence.processGeneration > 0,
+              let startIdentifier = evidence.startIdentifier,
+              !startIdentifier.isEmpty,
+              evidence.observedStartedAt.timeIntervalSinceReferenceDate
+                .isFinite else {
+            return nil
+        }
+        self.processIdentifier = processIdentifier
+        self.processGeneration = evidence.processGeneration
+        self.startIdentifier = startIdentifier
+        self.observedStartedAt = evidence.observedStartedAt
+        self.startIsAuthoritative = evidence.startIsAuthoritative
+    }
+}
+
+/// One Pine session bound to one authoritative process generation.
+nonisolated private struct ProjectTerminalAgentSessionGeneration:
+    Hashable, Sendable {
+    let sessionID: UUID
+    let process: ProjectTerminalAgentProcessGeneration
+}
+
 @MainActor
 struct PineAgentLaunchAuthorization {
     fileprivate let identities: Set<PineAgentLaunchIdentity>
@@ -73,6 +114,18 @@ struct PineAgentLaunchAuthorization {
 @MainActor
 @Observable
 final class TerminalManager {
+    private enum OwnedAgentHistoryRecord {
+        case owned(AgentSession)
+        case quarantined
+        case finalized
+    }
+
+    /// Mirrors `AgentHistoryStore`'s bounded public history. Entries are
+    /// retained only after an exact tab binding and become value-only
+    /// tombstones after conflict/finalization, so detached sessions are not
+    /// held forever.
+    private static let maxOwnedAgentHistoryGenerations = 500
+
     /// Reference to the pane manager for creating/finding terminal panes.
     weak var paneManager: PaneManager? {
         didSet { installPaneCallbacks() }
@@ -123,6 +176,14 @@ final class TerminalManager {
     private var settledAgentLaunches: [
         UUID: PineAgentSettledLaunchIdentity
     ] = [:]
+    @ObservationIgnored
+    private var ownedAgentHistoryLedger: [
+        ProjectTerminalAgentSessionGeneration: OwnedAgentHistoryRecord
+    ] = [:]
+    @ObservationIgnored
+    private var ownedAgentHistoryOrder: [
+        ProjectTerminalAgentSessionGeneration
+    ] = []
 
     #if DEBUG
     /// Exact route-update count used to prove a tab move publishes one durable
@@ -176,6 +237,10 @@ final class TerminalManager {
     /// Receives an already validated identity from `ProjectRegistry`; this
     /// method performs no filesystem work on MainActor.
     func configureAgentTaskProject(_ project: AgentTaskProjectIdentity) {
+        if let agentTaskProject, agentTaskProject != project {
+            ownedAgentHistoryLedger.removeAll()
+            ownedAgentHistoryOrder.removeAll()
+        }
         agentTaskProject = project
     }
 
@@ -959,6 +1024,162 @@ final class TerminalManager {
 
     var allTerminalTabs: [TerminalTab] {
         paneManager?.allTerminalTabs ?? []
+    }
+
+    /// Live Activity candidates for this exact project/worktree. The detector
+    /// intentionally remains machine-wide until #1421; ownership comes only
+    /// from authoritative sessions currently attached to this manager's pane
+    /// inventory and attested by an earlier coordinator capture. The ledger
+    /// cannot contribute a detached candidate; it only validates the current
+    /// object/identity binding.
+    var projectOwnedActiveAgentSessions: [AgentSession] {
+        guard agentTaskProject != nil else { return [] }
+        return exactCurrentAgentBindings()
+            .map(\.session)
+            .filter { $0.state != .done && $0.liveness == .live }
+    }
+
+    /// Captures one exact coordinator-established terminal binding for later
+    /// History finalization. Detached sessions cannot enter through this API:
+    /// the same tab object must still belong to this pane tree and point to the
+    /// same session object at capture time.
+    func captureProjectAgentOwnership(
+        of session: AgentSession,
+        in tab: TerminalTab
+    ) {
+        guard agentTaskProject != nil,
+              allTerminalTabs.contains(where: { $0 === tab }),
+              tab.agentSession === session,
+              session.liveness == .live,
+              session.state != .done,
+              let identity = projectTerminalIdentity(for: session) else {
+            return
+        }
+
+        let conflicts = ownedAgentHistoryLedger.keys.filter { existing in
+            (existing.sessionID == identity.sessionID
+                && existing.process != identity.process)
+                || (existing.process == identity.process
+                    && existing.sessionID != identity.sessionID)
+        }
+        if !conflicts.isEmpty {
+            for conflict in conflicts {
+                ownedAgentHistoryLedger[conflict] = .quarantined
+            }
+            ownedAgentHistoryLedger[identity] = .quarantined
+            touchOwnedAgentHistoryIdentity(identity)
+            trimOwnedAgentHistoryLedger()
+            return
+        }
+
+        switch ownedAgentHistoryLedger[identity] {
+        case .quarantined?, .finalized?:
+            break
+        case .owned(let existing)? where existing !== session:
+            ownedAgentHistoryLedger[identity] = .quarantined
+        case .owned?, nil:
+            ownedAgentHistoryLedger[identity] = .owned(session)
+        }
+        touchOwnedAgentHistoryIdentity(identity)
+        trimOwnedAgentHistoryLedger()
+    }
+
+    /// Atomically consumes exact, terminated owner generations. Retaining a
+    /// finalized tombstone prevents a repeated coordinator/application
+    /// callback from recreating the same History entry without keeping the
+    /// observable session alive.
+    func takeProjectOwnedCompletedAgentSessions() -> [AgentSession] {
+        var completed: [(ProjectTerminalAgentSessionGeneration, AgentSession)] = []
+        for identity in ownedAgentHistoryOrder {
+            guard case .owned(let session) = ownedAgentHistoryLedger[identity],
+                  session.state == .done,
+                  session.liveness == .terminated else {
+                continue
+            }
+            completed.append((identity, session))
+        }
+        for (identity, _) in completed {
+            ownedAgentHistoryLedger[identity] = .finalized
+        }
+        return completed.map(\.1)
+    }
+
+    /// Exact current bindings with conflicts removed fail-closed. Repeating
+    /// one session/generation in two tabs deduplicates; reusing a session ID
+    /// for another generation or a generation for another session excludes
+    /// every conflicting representation.
+    private func exactCurrentAgentBindings() -> [(
+        identity: ProjectTerminalAgentSessionGeneration,
+        session: AgentSession
+    )] {
+        var bindings: [
+            ProjectTerminalAgentSessionGeneration: AgentSession
+        ] = [:]
+        var conflicting = Set<ProjectTerminalAgentSessionGeneration>()
+        for tab in allTerminalTabs {
+            guard let session = tab.agentSession,
+                  let identity = projectTerminalIdentity(for: session) else {
+                continue
+            }
+            if let existing = bindings[identity], existing !== session {
+                conflicting.insert(identity)
+            }
+            bindings[identity] = session
+        }
+
+        let identities = Array(bindings.keys)
+        conflicting.formUnion(identities.filter { identity in
+            identities.contains { other in
+                other != identity
+                    && (other.sessionID == identity.sessionID
+                        || other.process == identity.process)
+            }
+        })
+        return identities
+            .filter { !conflicting.contains($0) }
+            .sorted { $0.sessionID.uuidString < $1.sessionID.uuidString }
+            .compactMap { identity in
+                guard let session = bindings[identity],
+                      case .owned(let captured) = ownedAgentHistoryLedger[
+                        identity
+                      ],
+                      captured === session else {
+                    return nil
+                }
+                return (identity, session)
+            }
+    }
+
+    private func projectTerminalIdentity(
+        for session: AgentSession
+    ) -> ProjectTerminalAgentSessionGeneration? {
+        guard let process = ProjectTerminalAgentProcessGeneration(
+            session.processEvidence
+        ) else {
+            return nil
+        }
+        return ProjectTerminalAgentSessionGeneration(
+            sessionID: session.id,
+            process: process
+        )
+    }
+
+    private func touchOwnedAgentHistoryIdentity(
+        _ identity: ProjectTerminalAgentSessionGeneration
+    ) {
+        ownedAgentHistoryOrder.removeAll { $0 == identity }
+        ownedAgentHistoryOrder.append(identity)
+    }
+
+    private func trimOwnedAgentHistoryLedger() {
+        let overflow = ownedAgentHistoryOrder.count
+            - Self.maxOwnedAgentHistoryGenerations
+        guard overflow > 0 else { return }
+        let evicted = ownedAgentHistoryOrder.prefix(overflow)
+        for identity in evicted {
+            ownedAgentHistoryLedger[identity] = nil
+        }
+        ownedAgentHistoryOrder.removeFirst(overflow)
     }
 
     var hasActiveProcesses: Bool {

--- a/PineTests/AgentProjectTerminalOwnershipTests.swift
+++ b/PineTests/AgentProjectTerminalOwnershipTests.swift
@@ -1,0 +1,567 @@
+//
+//  AgentProjectTerminalOwnershipTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Agent Project Terminal Ownership")
+@MainActor
+struct AgentProjectTerminalOwnershipTests {
+    @Test("Activity candidates stay inside exact owning project terminals")
+    func activityCandidatesAreProjectScoped() throws {
+        let fixtureA = try makeProjectFixture(name: "A", terminalCount: 2)
+        let fixtureB = try makeProjectFixture(name: "B", terminalCount: 1)
+        defer {
+            try? FileManager.default.removeItem(at: fixtureA.root)
+            try? FileManager.default.removeItem(at: fixtureB.root)
+        }
+
+        let firstA = exactSession(
+            id: try #require(UUID(
+                uuidString: "00000000-0000-0000-0000-000000000001"
+            )),
+            type: .claudeCode,
+            pid: 101,
+            generation: 1
+        )
+        let secondA = exactSession(
+            id: try #require(UUID(
+                uuidString: "00000000-0000-0000-0000-000000000002"
+            )),
+            type: .codex,
+            pid: 102,
+            generation: 2
+        )
+        let onlyB = exactSession(
+            id: try #require(UUID(
+                uuidString: "00000000-0000-0000-0000-000000000003"
+            )),
+            type: .pi,
+            pid: 201,
+            generation: 1
+        )
+        fixtureA.tabs[0].agentSession = firstA
+        fixtureA.tabs[1].agentSession = secondA
+        fixtureB.tabs[0].agentSession = onlyB
+        fixtureA.project.terminal.captureProjectAgentOwnership(
+            of: firstA,
+            in: fixtureA.tabs[0]
+        )
+        fixtureA.project.terminal.captureProjectAgentOwnership(
+            of: secondA,
+            in: fixtureA.tabs[1]
+        )
+        fixtureB.project.terminal.captureProjectAgentOwnership(
+            of: onlyB,
+            in: fixtureB.tabs[0]
+        )
+
+        // Both per-project detectors see an unrelated machine-wide process.
+        // It is deliberately not attached to either project's terminal tree.
+        fixtureA.project.terminal.agentDetector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 900, command: "gemini"),
+        ])
+        fixtureB.project.terminal.agentDetector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 900, command: "gemini"),
+        ])
+        #expect(fixtureA.project.terminal.agentDetector.activeSessions.count == 1)
+        #expect(fixtureB.project.terminal.agentDetector.activeSessions.count == 1)
+
+        recordNewChange("A.swift", in: fixtureA)
+        recordNewChange("B.swift", in: fixtureB)
+
+        let actionA = try #require(fixtureA.project.agentActivity.actions.first)
+        let actionB = try #require(fixtureB.project.agentActivity.actions.first)
+        #expect(candidateIDs(actionA) == Set([firstA.id, secondA.id]))
+        #expect(candidateIDs(actionB) == Set([onlyB.id]))
+        #expect(!candidateIDs(actionA).contains(onlyB.id))
+        #expect(!candidateIDs(actionB).contains(firstA.id))
+        #expect(!candidateIDs(actionB).contains(secondA.id))
+        if case .ambiguous = actionA.attribution {
+            // Expected: both owner-local sessions remain candidates.
+        } else {
+            Issue.record("Project A attribution should be ambiguous")
+        }
+        if case .inferred = actionB.attribution {
+            // Expected: the sibling has exactly one owner-local candidate.
+        } else {
+            Issue.record("Project B attribution should be inferred")
+        }
+
+        // Window availability changes do not widen the project boundary, and
+        // reopening the same manager recovers the same exact bindings.
+        fixtureA.project.terminal.setAgentTaskWindowOpen(false)
+        #expect(
+            Set(fixtureA.project.terminal.projectOwnedActiveAgentSessions.map(\.id))
+                == Set([firstA.id, secondA.id])
+        )
+        fixtureA.project.terminal.setAgentTaskWindowOpen(true)
+        #expect(
+            Set(fixtureA.project.terminal.projectOwnedActiveAgentSessions.map(\.id))
+                == Set([firstA.id, secondA.id])
+        )
+        #expect(
+            fixtureB.project.terminal.projectOwnedActiveAgentSessions.map(\.id)
+                == [onlyB.id]
+        )
+    }
+
+    @Test("Unavailable precise ownership fails closed and exact reattach is stable")
+    func unavailableOwnershipAndReattach() throws {
+        let fixture = try makeProjectFixture(name: "Unavailable", terminalCount: 1)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let tab = fixture.tabs[0]
+
+        let missingEvidence = AgentSession(agentType: .codex)
+        tab.agentSession = missingEvidence
+        #expect(fixture.project.terminal.projectOwnedActiveAgentSessions.isEmpty)
+        fixture.project.terminal.captureProjectAgentOwnership(
+            of: missingEvidence,
+            in: tab
+        )
+
+        let fallback = AgentSession(agentType: .claudeCode)
+        _ = fallback.bindProcessEvidence(AgentProcessEvidence(
+            processIdentifier: 301,
+            processGeneration: 1,
+            startIdentifier: "coarse-301",
+            observedStartedAt: Date(timeIntervalSince1970: 301),
+            startIsAuthoritative: false
+        ))
+        tab.agentSession = fallback
+        #expect(fixture.project.terminal.projectOwnedActiveAgentSessions.isEmpty)
+
+        let exact = exactSession(type: .aider, pid: 302, generation: 2)
+        tab.agentSession = exact
+        // A forged authoritative-looking object in a tab is not ownership:
+        // only the coordinator capture can attest the exact binding.
+        #expect(fixture.project.terminal.projectOwnedActiveAgentSessions.isEmpty)
+        fixture.project.terminal.captureProjectAgentOwnership(
+            of: exact,
+            in: tab
+        )
+        #expect(
+            fixture.project.terminal.projectOwnedActiveAgentSessions.first
+                === exact
+        )
+        exact.applyLiveness(.stale)
+        #expect(fixture.project.terminal.projectOwnedActiveAgentSessions.isEmpty)
+
+        tab.agentSession = nil
+        #expect(fixture.project.terminal.projectOwnedActiveAgentSessions.isEmpty)
+        exact.applyLiveness(.live)
+        tab.agentSession = exact
+        #expect(
+            fixture.project.terminal.projectOwnedActiveAgentSessions.first
+                === exact
+        )
+
+        let nonFinite = AgentSession(agentType: .pi)
+        _ = nonFinite.bindProcessEvidence(AgentProcessEvidence(
+            processIdentifier: 303,
+            processGeneration: 3,
+            startIdentifier: "coarse-303",
+            observedStartedAt: Date(timeIntervalSinceReferenceDate: .infinity),
+            startIsAuthoritative: true
+        ))
+        tab.agentSession = nonFinite
+        fixture.project.terminal.captureProjectAgentOwnership(
+            of: nonFinite,
+            in: tab
+        )
+        #expect(fixture.project.terminal.projectOwnedActiveAgentSessions.isEmpty)
+
+        let terminatedBeforeCapture = exactSession(
+            type: .codex,
+            pid: 304,
+            generation: 4
+        )
+        markDone(terminatedBeforeCapture)
+        tab.agentSession = terminatedBeforeCapture
+        fixture.project.terminal.captureProjectAgentOwnership(
+            of: terminatedBeforeCapture,
+            in: tab
+        )
+
+        markDone(missingEvidence)
+        markDone(fallback)
+        #expect(
+            fixture.project.terminal.takeProjectOwnedCompletedAgentSessions()
+                .isEmpty
+        )
+    }
+
+    @Test("Coordinator production reconciliation attests the exact binding")
+    func coordinatorAutomaticallyAttestsBinding() throws {
+        let fixture = try makeProjectFixture(name: "Coordinator", terminalCount: 1)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let tab = fixture.tabs[0]
+        let coordinator = AgentDetectionCoordinator(
+            detector: fixture.project.terminal.agentDetector,
+            terminalManager: fixture.project.terminal
+        )
+        let agent = coordinatorProcess(
+            pid: 350,
+            command: "codex",
+            startedAt: 350
+        )
+        setCoordinatorOwnership(agent, on: tab)
+
+        #expect(fixture.project.terminal.projectOwnedActiveAgentSessions.isEmpty)
+        coordinator.applySnapshotForTesting(processes: [agent])
+
+        let session = try #require(tab.agentSession)
+        #expect(
+            fixture.project.terminal.projectOwnedActiveAgentSessions.first
+                === session
+        )
+        recordNewChange("Coordinator.swift", in: fixture)
+        let action = try #require(fixture.project.agentActivity.actions.first)
+        #expect(candidateIDs(action) == [session.id])
+    }
+
+    @Test("ProjectRegistry background reopen preserves exact ownership boundary")
+    func registryBackgroundReopenPreservesOwnership() throws {
+        let root = try makeTemporaryRoot(name: "Registry")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: root))
+        let paneID = project.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: root
+        )
+        let tab = try #require(
+            project.paneManager.terminalState(for: paneID)?.activeTab
+        )
+        let session = exactSession(type: .pi, pid: 360, generation: 1)
+        tab.agentSession = session
+        project.terminal.captureProjectAgentOwnership(of: session, in: tab)
+        #expect(project.terminal.projectOwnedActiveAgentSessions == [session])
+
+        registry.closeProjectWindow(root)
+        let canonical = ProjectRegistry.canonicalProjectURL(root)
+        #expect(registry.backgroundProjects.contains(canonical))
+        #expect(project.terminal.projectOwnedActiveAgentSessions == [session])
+
+        let reopened = try #require(registry.projectManager(for: root))
+        #expect(reopened === project)
+        #expect(!registry.backgroundProjects.contains(canonical))
+        #expect(reopened.allTerminalTabs.contains(where: { $0 === tab }))
+        #expect(reopened.terminal.projectOwnedActiveAgentSessions == [session])
+    }
+
+    @Test("Sequential process-generation conflict remains quarantined")
+    func sequentialProcessConflictFailsClosed() throws {
+        let fixture = try makeProjectFixture(name: "Sequential", terminalCount: 1)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let tab = fixture.tabs[0]
+        let first = exactSession(type: .codex, pid: 450, generation: 8)
+        let conflicting = exactSession(
+            type: .claudeCode,
+            pid: 450,
+            generation: 8
+        )
+
+        tab.agentSession = first
+        fixture.project.terminal.captureProjectAgentOwnership(
+            of: first,
+            in: tab
+        )
+        #expect(fixture.project.terminal.projectOwnedActiveAgentSessions == [first])
+
+        tab.agentSession = nil
+        tab.agentSession = conflicting
+        fixture.project.terminal.captureProjectAgentOwnership(
+            of: conflicting,
+            in: tab
+        )
+
+        #expect(fixture.project.terminal.projectOwnedActiveAgentSessions.isEmpty)
+        markDone(first)
+        markDone(conflicting)
+        #expect(
+            fixture.project.terminal.takeProjectOwnedCompletedAgentSessions()
+                .isEmpty
+        )
+    }
+
+    @Test("Maximize keeps hidden owned terminal sessions in project scope")
+    func maximizePreservesHiddenTerminalOwnership() throws {
+        let fixture = try makeProjectFixture(name: "Maximize", terminalCount: 1)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let secondPaneID = try #require(
+            fixture.project.paneManager.createTerminalPane(
+                relativeTo: fixture.paneID,
+                axis: .horizontal,
+                workingDirectory: fixture.root
+            )
+        )
+        let hiddenTab = try #require(
+            fixture.project.paneManager.terminalState(for: secondPaneID)?.activeTab
+        )
+        let visible = exactSession(type: .codex, pid: 460, generation: 1)
+        let hidden = exactSession(type: .pi, pid: 461, generation: 2)
+        fixture.tabs[0].agentSession = visible
+        hiddenTab.agentSession = hidden
+        fixture.project.terminal.captureProjectAgentOwnership(
+            of: visible,
+            in: fixture.tabs[0]
+        )
+        fixture.project.terminal.captureProjectAgentOwnership(
+            of: hidden,
+            in: hiddenTab
+        )
+
+        fixture.project.paneManager.maximize(paneID: fixture.paneID)
+
+        #expect(fixture.project.paneManager.maximizedPaneID == fixture.paneID)
+        #expect(fixture.project.paneManager.terminalPaneIDs == [fixture.paneID])
+        #expect(
+            Set(fixture.project.terminal.projectOwnedActiveAgentSessions.map(\.id))
+                == Set([visible.id, hidden.id])
+        )
+    }
+
+    @Test("Duplicate binding deduplicates and conflicting identity fails closed")
+    func duplicateAndConflictingBindings() throws {
+        let fixture = try makeProjectFixture(name: "Conflicts", terminalCount: 3)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let evidence = AgentProcessEvidence(
+            processIdentifier: 401,
+            processGeneration: 7,
+            startIdentifier: "coarse-401",
+            observedStartedAt: Date(timeIntervalSince1970: 401),
+            startIsAuthoritative: true
+        )
+        let first = AgentSession(agentType: .codex)
+        let second = AgentSession(agentType: .claudeCode)
+        _ = first.bindProcessEvidence(evidence)
+        _ = second.bindProcessEvidence(evidence)
+
+        fixture.tabs[0].agentSession = first
+        fixture.tabs[1].agentSession = first
+        #expect(fixture.project.terminal.projectOwnedActiveAgentSessions.isEmpty)
+        fixture.project.terminal.captureProjectAgentOwnership(
+            of: first,
+            in: fixture.tabs[0]
+        )
+        fixture.project.terminal.captureProjectAgentOwnership(
+            of: first,
+            in: fixture.tabs[1]
+        )
+        #expect(fixture.project.terminal.projectOwnedActiveAgentSessions == [first])
+
+        fixture.tabs[2].agentSession = second
+        #expect(fixture.project.terminal.projectOwnedActiveAgentSessions.isEmpty)
+        fixture.project.terminal.captureProjectAgentOwnership(
+            of: second,
+            in: fixture.tabs[2]
+        )
+        markDone(first)
+        markDone(second)
+        #expect(
+            fixture.project.terminal.takeProjectOwnedCompletedAgentSessions()
+                .isEmpty
+        )
+    }
+
+    @Test("Terminated generation finalizes once in only its owning project")
+    func terminatedGenerationFinalizesOnce() throws {
+        let owner = try makeProjectFixture(name: "HistoryOwner", terminalCount: 2)
+        let sibling = try makeProjectFixture(name: "HistorySibling", terminalCount: 1)
+        defer {
+            try? FileManager.default.removeItem(at: owner.root)
+            try? FileManager.default.removeItem(at: sibling.root)
+        }
+        let session = exactSession(
+            type: .codex,
+            pid: 501,
+            generation: 9,
+            filesModified: [owner.root.appendingPathComponent("Owned.swift")]
+        )
+
+        // Duplicate representation inside the owning pane tree is one exact
+        // session/process generation, never two History candidates.
+        owner.tabs[0].agentSession = session
+        owner.tabs[1].agentSession = session
+        owner.project.terminal.captureProjectAgentOwnership(
+            of: session,
+            in: owner.tabs[0]
+        )
+        owner.project.terminal.captureProjectAgentOwnership(
+            of: session,
+            in: owner.tabs[1]
+        )
+
+        markDone(session)
+        owner.tabs[0].agentSession = nil
+        owner.tabs[1].agentSession = nil
+
+        owner.project.finalizeAgentSessionsForHistory()
+        owner.project.finalizeAgentSessionsForHistory()
+        sibling.project.finalizeAgentSessionsForHistory()
+
+        #expect(owner.project.agentHistory.entries.map(\.sessionID) == [session.id])
+        #expect(owner.project.agentHistory.entries.first?.affectedFiles == ["Owned.swift"])
+        #expect(sibling.project.agentHistory.entries.isEmpty)
+    }
+
+    @Test("History ownership ledger stays bounded")
+    func historyOwnershipLedgerIsBounded() throws {
+        let fixture = try makeProjectFixture(name: "Bounded", terminalCount: 1)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let tab = fixture.tabs[0]
+        var sessions: [AgentSession] = []
+
+        for index in 1...501 {
+            let session = exactSession(
+                type: .codex,
+                pid: Int32(1_000 + index),
+                generation: UInt64(index)
+            )
+            tab.agentSession = session
+            fixture.project.terminal.captureProjectAgentOwnership(
+                of: session,
+                in: tab
+            )
+            sessions.append(session)
+        }
+        for session in sessions {
+            markDone(session)
+        }
+
+        let completed = fixture.project.terminal
+            .takeProjectOwnedCompletedAgentSessions()
+        #expect(completed.count == 500)
+        #expect(!completed.contains(where: { $0 === sessions[0] }))
+        #expect(completed.contains(where: { $0 === sessions[500] }))
+        #expect(
+            fixture.project.terminal.takeProjectOwnedCompletedAgentSessions()
+                .isEmpty
+        )
+    }
+
+    private func makeProjectFixture(
+        name: String,
+        terminalCount: Int
+    ) throws -> ProjectOwnershipFixture {
+        let root = try makeTemporaryRoot(name: name)
+        let project = ProjectManager()
+        project.loadDirectory(url: root)
+        let paneID = project.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: root
+        )
+        let state = try #require(project.paneManager.terminalState(for: paneID))
+        while state.terminalTabs.count < terminalCount {
+            state.addTab(workingDirectory: root)
+        }
+        return ProjectOwnershipFixture(
+            project: project,
+            root: root,
+            paneID: paneID,
+            tabs: state.terminalTabs
+        )
+    }
+
+    private func makeTemporaryRoot(name: String) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "pine-agent-project-ownership-\(name)-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        return root
+    }
+
+    private func exactSession(
+        id: UUID = UUID(),
+        type: AgentType,
+        pid: Int32,
+        generation: UInt64,
+        filesModified: [URL] = []
+    ) -> AgentSession {
+        let session = AgentSession(
+            id: id,
+            agentType: type,
+            state: .executing,
+            filesModified: filesModified
+        )
+        _ = session.bindProcessEvidence(AgentProcessEvidence(
+            processIdentifier: pid,
+            processGeneration: generation,
+            startIdentifier: "coarse-\(pid)-\(generation)",
+            observedStartedAt: Date(
+                timeIntervalSince1970: TimeInterval(pid) + Double(generation)
+            ),
+            startIsAuthoritative: true
+        ))
+        return session
+    }
+
+    private func recordNewChange(
+        _ path: String,
+        in fixture: ProjectOwnershipFixture
+    ) {
+        fixture.project.gitProvider.fileStatuses = ["seed.txt": .modified]
+        fixture.project.correlateAgentActivity(rootURL: fixture.root)
+        fixture.project.gitProvider.fileStatuses[path] = .modified
+        fixture.project.correlateAgentActivity(rootURL: fixture.root)
+    }
+
+    private func candidateIDs(_ action: AgentAction) -> Set<UUID> {
+        Set(action.attribution.candidates.map(\.sessionID))
+    }
+
+    private func markDone(_ session: AgentSession) {
+        session.recordLifecycleState(
+            .done,
+            accuracy: .processTerminationOnly
+        )
+        session.applyLiveness(.terminated)
+    }
+}
+
+@MainActor
+private func setCoordinatorOwnership(
+    _ process: DetectedProcess,
+    on tab: TerminalTab
+) {
+    let identity = process.preciseStartedAt.flatMap {
+        TerminalProcessStartIdentity(processID: process.pid, startedAt: $0)
+    }
+    tab.agentProcessIdentityResolverForTesting = { processID in
+        processID == process.pid ? identity : nil
+    }
+    tab.foregroundProcessIDOverrideForTesting = process.processGroupID
+    tab.foregroundStartOverrideForTesting = identity
+}
+
+nonisolated private func coordinatorProcess(
+    pid: Int32,
+    command: String,
+    startedAt: TimeInterval
+) -> DetectedProcess {
+    DetectedProcess(
+        pid: pid,
+        parentProcessID: 1,
+        processGroupID: pid,
+        command: command,
+        cpuTime: 0,
+        startIdentifier: "generation-\(startedAt)",
+        preciseStartedAt: Date(timeIntervalSince1970: startedAt)
+    )
+}
+
+@MainActor
+private struct ProjectOwnershipFixture {
+    let project: ProjectManager
+    let root: URL
+    let paneID: PaneID
+    let tabs: [TerminalTab]
+}


### PR DESCRIPTION
Closes #1416.

## Summary
- derive Agent Activity candidates only from exact live terminal bindings owned by the current project
- retain a bounded, project-local ownership ledger for one-time Agent History finalization
- fail closed for detached, non-authoritative, duplicate-conflicting, or cross-project sessions
- preserve exact ownership across background close and reopen

## Verification
- 168/168 tests passed across the 8 affected suites
- SwiftLint strict: 0 violations in 740 files
- git diff --check: clean

## Environment
- macOS 27.0 (26A5406e)
- Xcode 27.0 beta (27A5194q)
- macOS SDK 27.0 (26A5353p)
- macOS 26 runtime unavailable on this machine