### PR TITLE
fix: restore configured cursor after terminal reset

### DIFF
--- a/Pine/DECSCUSRStreamTracker.swift
+++ b/Pine/DECSCUSRStreamTracker.swift
@@ -1,0 +1,270 @@
+//
+//  DECSCUSRStreamTracker.swift
+//  Pine
+//
+//  Bounded recognition of cursor-shape control sequences in PTY output.
+//
+
+import Foundation
+
+/// Tracks only grammatically valid `CSI Ps SP q` (DECSCUSR) commands.
+///
+/// The state is intentionally fixed-size: control-string payloads, parameter
+/// text, and malformed sequences are never buffered. Keeping this parser
+/// separate from SwiftTerm lets Pine distinguish the standard `Ps = 0`
+/// "restore the user's default" command from an explicit block request while
+/// still forwarding every byte to SwiftTerm unchanged.
+nonisolated struct DECSCUSRStreamTracker: Sendable {
+    enum Directive: Equatable, Sendable {
+        case preferred
+        case explicit(parameter: Int)
+    }
+
+    private enum State: Sendable {
+        case ground
+        case escape
+        case escapeIntermediate
+        case csiParameter
+        case csiIntermediate
+        case csiIgnore
+        case controlString(allowsBellTermination: Bool)
+        case controlStringEscape(allowsBellTermination: Bool)
+    }
+
+    private enum CSIParameter: Sendable {
+        case omitted
+        case value(Int)
+        case invalid
+    }
+
+    private var state = State.ground
+    private var csiParameter = CSIParameter.omitted
+    private var csiHasSingleSpaceIntermediate = false
+
+    /// Consumes one arbitrary PTY chunk and returns its last supported
+    /// DECSCUSR directive. Parser state survives chunk boundaries.
+    mutating func consume(_ bytes: ArraySlice<UInt8>) -> Directive? {
+        var latestDirective: Directive?
+
+        for byte in bytes {
+            switch state {
+            case .controlString(let allowsBellTermination):
+                consumeControlStringByte(
+                    byte,
+                    allowsBellTermination: allowsBellTermination
+                )
+            case .controlStringEscape(let allowsBellTermination):
+                consumeControlStringEscapeByte(
+                    byte,
+                    allowsBellTermination: allowsBellTermination
+                )
+            default:
+                if consumeAnywhereControl(byte) {
+                    continue
+                }
+                consumeSequenceByte(byte, latestDirective: &latestDirective)
+            }
+        }
+
+        return latestDirective
+    }
+
+    /// Handles controls that cancel or start a sequence from any non-string
+    /// state. C1 controls are treated as controls, never as UTF-8 payload.
+    private mutating func consumeAnywhereControl(_ byte: UInt8) -> Bool {
+        switch byte {
+        case 0x1B: // ESC
+            state = .escape
+        case 0x9B: // C1 CSI
+            beginCSI()
+        case 0x90, 0x98, 0x9E, 0x9F: // DCS, SOS, PM, APC
+            state = .controlString(allowsBellTermination: false)
+        case 0x9D: // C1 OSC
+            state = .controlString(allowsBellTermination: true)
+        case 0x18, 0x1A, 0x9C: // CAN, SUB, C1 ST
+            state = .ground
+        case 0x80...0x9F:
+            state = .ground
+        default:
+            return false
+        }
+        return true
+    }
+
+    private mutating func consumeSequenceByte(
+        _ byte: UInt8,
+        latestDirective: inout Directive?
+    ) {
+        switch state {
+        case .ground:
+            break
+        case .escape:
+            consumeEscapeByte(byte)
+        case .escapeIntermediate:
+            consumeEscapeIntermediateByte(byte)
+        case .csiParameter:
+            consumeCSIParameterByte(byte, latestDirective: &latestDirective)
+        case .csiIntermediate:
+            consumeCSIIntermediateByte(byte, latestDirective: &latestDirective)
+        case .csiIgnore:
+            consumeCSIIgnoreByte(byte)
+        case .controlString, .controlStringEscape:
+            // These states are handled before the anywhere-control path.
+            break
+        }
+    }
+
+    private mutating func consumeEscapeByte(_ byte: UInt8) {
+        switch byte {
+        case 0x5B: // [
+            beginCSI()
+        case 0x5D: // ] (OSC)
+            state = .controlString(allowsBellTermination: true)
+        case 0x50, 0x58, 0x5E, 0x5F: // P (DCS), X (SOS), ^ (PM), _ (APC)
+            state = .controlString(allowsBellTermination: false)
+        case 0x20...0x2F:
+            state = .escapeIntermediate
+        case 0x00...0x1F, 0x7F:
+            // Executable C0 controls and DEL do not end ESC collection.
+            break
+        default:
+            state = .ground
+        }
+    }
+
+    private mutating func consumeEscapeIntermediateByte(_ byte: UInt8) {
+        switch byte {
+        case 0x20...0x2F, 0x00...0x1F, 0x7F:
+            break
+        default:
+            state = .ground
+        }
+    }
+
+    private mutating func beginCSI() {
+        state = .csiParameter
+        csiParameter = .omitted
+        csiHasSingleSpaceIntermediate = false
+    }
+
+    private mutating func consumeCSIParameterByte(
+        _ byte: UInt8,
+        latestDirective: inout Directive?
+    ) {
+        switch byte {
+        case 0x30...0x39:
+            appendCSIDigit(Int(byte - 0x30))
+        case 0x3A...0x3F:
+            // Subparameters, separators, and private prefixes are not the
+            // single numeric parameter accepted by Pine.
+            csiParameter = .invalid
+        case 0x20...0x2F:
+            state = .csiIntermediate
+            csiHasSingleSpaceIntermediate = byte == 0x20
+        case 0x40...0x7E:
+            finishCSI(finalByte: byte, latestDirective: &latestDirective)
+        case 0x00...0x1F, 0x7F:
+            break
+        default:
+            state = .ground
+        }
+    }
+
+    private mutating func appendCSIDigit(_ digit: Int) {
+        switch csiParameter {
+        case .omitted:
+            csiParameter = .value(digit)
+        case .value(let value):
+            // Seven is sufficient to represent every unsupported value and
+            // avoids integer overflow for attacker-controlled digit runs.
+            csiParameter = .value(min(7, value * 10 + digit))
+        case .invalid:
+            break
+        }
+    }
+
+    private mutating func consumeCSIIntermediateByte(
+        _ byte: UInt8,
+        latestDirective: inout Directive?
+    ) {
+        switch byte {
+        case 0x20...0x2F:
+            csiHasSingleSpaceIntermediate = false
+        case 0x30...0x3F:
+            state = .csiIgnore
+        case 0x40...0x7E:
+            finishCSI(finalByte: byte, latestDirective: &latestDirective)
+        case 0x00...0x1F, 0x7F:
+            break
+        default:
+            state = .ground
+        }
+    }
+
+    private mutating func consumeCSIIgnoreByte(_ byte: UInt8) {
+        switch byte {
+        case 0x40...0x7E:
+            state = .ground
+        case 0x00...0x3F, 0x7F:
+            break
+        default:
+            state = .ground
+        }
+    }
+
+    private mutating func finishCSI(
+        finalByte: UInt8,
+        latestDirective: inout Directive?
+    ) {
+        defer { state = .ground }
+        guard finalByte == 0x71, // q
+              csiHasSingleSpaceIntermediate else { return }
+
+        switch csiParameter {
+        case .omitted, .value(0):
+            latestDirective = .preferred
+        case .value(let parameter) where (1...6).contains(parameter):
+            latestDirective = .explicit(parameter: parameter)
+        case .value, .invalid:
+            break
+        }
+    }
+
+    private mutating func consumeControlStringByte(
+        _ byte: UInt8,
+        allowsBellTermination: Bool
+    ) {
+        switch byte {
+        case 0x9C, 0x18, 0x1A: // C1 ST, CAN, SUB
+            state = .ground
+        case 0x07 where allowsBellTermination: // OSC BEL terminator
+            state = .ground
+        case 0x1B:
+            state = .controlStringEscape(
+                allowsBellTermination: allowsBellTermination
+            )
+        default:
+            break
+        }
+    }
+
+    private mutating func consumeControlStringEscapeByte(
+        _ byte: UInt8,
+        allowsBellTermination: Bool
+    ) {
+        switch byte {
+        case 0x5C, 0x9C, 0x18, 0x1A: // ESC \\ / C1 ST / CAN / SUB
+            state = .ground
+        case 0x07 where allowsBellTermination:
+            state = .ground
+        case 0x1B:
+            break
+        default:
+            // A non-ST byte remains payload. In particular, an ESC-[ pair
+            // inside OSC/DCS must never be reinterpreted as CSI.
+            state = .controlString(
+                allowsBellTermination: allowsBellTermination
+            )
+        }
+    }
+}

--- a/Pine/TerminalCursorSettings.swift
+++ b/Pine/TerminalCursorSettings.swift
@@ -74,7 +74,8 @@ private extension CursorStyle {
 ///
 /// The six concrete SwiftTerm styles are stored through their stable
 /// `tagName`. Live tabs observe a cursor-only notification so unrelated theme,
-/// focus, redraw, and renderer events never overwrite a TUI's DECSCUSR style.
+/// focus, redraw, and renderer events never overwrite a TUI's explicit
+/// DECSCUSR style. A DECSCUSR default-reset command restores this preference.
 @MainActor
 @Observable
 final class TerminalCursorSettings {
@@ -158,8 +159,8 @@ final class TerminalCursorSettings {
 
 extension Notification.Name {
     /// Posted only when the user changes cursor shape or blinking. Live tabs
-    /// apply the new preference once; subsequent DECSCUSR sequences remain in
-    /// control until the user changes the preference again (#1409).
+    /// apply the new preference once; subsequent explicit DECSCUSR sequences
+    /// remain in control until the user changes the preference again (#1409).
     static let terminalCursorStyleChanged = Notification.Name(
         "terminalCursorStyleChanged"
     )

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -184,6 +184,14 @@ nonisolated enum AcknowledgedPTYWriter {
 final class PineTerminalView: LocalProcessTerminalView {
     private var redrawBackgroundColor: CGColor?
     private var initialMetalRedrawWorkItems: [DispatchWorkItem] = []
+    /// Serializes Pine's cursor policy with SwiftTerm's PTY parser. Process
+    /// output may arrive away from MainActor while Settings changes arrive on
+    /// the main thread, so both the streaming parser and preferred style live
+    /// behind the same lock as the corresponding Terminal mutation.
+    private let cursorStyleLock = NSLock()
+    private var cursorSequenceTracker = DECSCUSRStreamTracker()
+    private var preferredCursorStyle: CursorStyle?
+    private var activeCursorDirective: DECSCUSRStreamTracker.Directive?
     #if DEBUG
     /// Per-view seam for exercising the production CoreGraphics fallback
     /// without mutating process-wide launch arguments or environment.
@@ -392,7 +400,7 @@ final class PineTerminalView: LocalProcessTerminalView {
         let contentBefore = slice.isEmpty || !shouldInspectContent
             ? nil
             : VisibleContentState(terminal: getTerminal())
-        super.dataReceived(slice: slice)
+        feedTrackingCursorStyle(slice: slice)
         guard let contentBefore,
               VisibleContentState(terminal: getTerminal()) != contentBefore,
               claimFirstVisibleContent() else { return }
@@ -403,6 +411,65 @@ final class PineTerminalView: LocalProcessTerminalView {
             DispatchQueue.main.async { [weak self] in
                 self?.scheduleFirstVisibleContentRecoveryIfNeeded()
             }
+        }
+    }
+
+    /// Atomically updates Pine's cached preference and SwiftTerm's live
+    /// cursor. A settings change also becomes the current authority until a
+    /// later valid explicit DECSCUSR command arrives.
+    func applyPreferredCursorStyle(_ style: CursorStyle) {
+        cursorStyleLock.lock()
+        defer { cursorStyleLock.unlock() }
+        preferredCursorStyle = style
+        activeCursorDirective = .preferred
+        getTerminal().setCursorStyle(style)
+    }
+
+    /// Runs SwiftTerm and Pine's cursor-policy resolution on the exact same
+    /// delivery path. Enforcing the last valid directive after `super` avoids
+    /// an asynchronous repair frame and also prevents unsupported or embedded
+    /// lookalikes from superseding a valid reset/explicit command.
+    private func feedTrackingCursorStyle(slice: ArraySlice<UInt8>) {
+        cursorStyleLock.lock()
+        defer { cursorStyleLock.unlock() }
+
+        if let directive = cursorSequenceTracker.consume(slice) {
+            activeCursorDirective = directive
+        }
+        super.dataReceived(slice: slice)
+
+        switch activeCursorDirective {
+        case .preferred:
+            if let preferredCursorStyle {
+                getTerminal().setCursorStyle(preferredCursorStyle)
+            }
+        case .explicit(let parameter):
+            if let style = Self.cursorStyle(forDECSCUSRParameter: parameter) {
+                getTerminal().setCursorStyle(style)
+            }
+        case nil:
+            break
+        }
+    }
+
+    private static func cursorStyle(
+        forDECSCUSRParameter parameter: Int
+    ) -> CursorStyle? {
+        switch parameter {
+        case 1:
+            return .blinkBlock
+        case 2:
+            return .steadyBlock
+        case 3:
+            return .blinkUnderline
+        case 4:
+            return .steadyUnderline
+        case 5:
+            return .blinkBar
+        case 6:
+            return .steadyBar
+        default:
+            return nil
         }
     }
 
@@ -1877,10 +1944,12 @@ final class TerminalTab: Identifiable, Hashable {
         self.themeNotificationCenter = themeSettings.notificationCenter
         self.cursorSettings = cursorSettings
         self.cursorNotificationCenter = cursorSettings.notificationCenter
-        self.terminalView = PineTerminalView(
+        let terminalView = PineTerminalView(
             frame: TerminalContainerView.defaultTerminalFrame,
             options: TerminalOptions(cursorStyle: cursorSettings.cursorStyle)
         )
+        terminalView.applyPreferredCursorStyle(cursorSettings.cursorStyle)
+        self.terminalView = terminalView
         self.terminalView.setAccessibilityElement(true)
         self.terminalView.setAccessibilityRole(.textArea)
         self.terminalView.setAccessibilityIdentifier(AccessibilityID.terminalSurface)
@@ -1947,7 +2016,11 @@ final class TerminalTab: Identifiable, Hashable {
     /// or system-appearance updates: terminal applications may use DECSCUSR to
     /// own the cursor until the next user-initiated settings change.
     internal func applyPreferredCursorStyle() {
-        terminalView.getTerminal().setCursorStyle(cursorSettings.cursorStyle)
+        guard let terminalView = terminalView as? PineTerminalView else {
+            terminalView.getTerminal().setCursorStyle(cursorSettings.cursorStyle)
+            return
+        }
+        terminalView.applyPreferredCursorStyle(cursorSettings.cursorStyle)
     }
 
     /// Applies the terminal's appearance-aware colors and keeps SwiftTerm's

--- a/PineTests/TerminalMetalRendererTests.swift
+++ b/PineTests/TerminalMetalRendererTests.swift
@@ -177,6 +177,12 @@ struct TerminalMetalRendererTests {
         settings.cursorShape = .verticalBar
         let bar = try coreGraphicsCursorFootprint(in: caret)
         settings.cursorShape = .underline
+        feed("\u{1B}[2 q", to: view)
+        feed("\u{1B}[0 q", to: view)
+        #expect(
+            view.getTerminal().options.cursorStyle.tagName
+                == "steadyUnderline"
+        )
         let underline = try coreGraphicsCursorFootprint(in: caret)
         settings.cursorShape = .block
         let block = try coreGraphicsCursorFootprint(in: caret)
@@ -236,7 +242,8 @@ struct TerminalMetalRendererTests {
             shape: .underline,
             settings: settings,
             terminalView: view,
-            metalView: metalView
+            metalView: metalView,
+            exerciseDefaultReset: true
         )
         let block = try await metalCursorFootprint(
             shape: .block,
@@ -810,9 +817,18 @@ struct TerminalMetalRendererTests {
         shape: TerminalCursorShape,
         settings: TerminalCursorSettings,
         terminalView: PineTerminalView,
-        metalView: MTKView
+        metalView: MTKView,
+        exerciseDefaultReset: Bool = false
     ) async throws -> CursorFootprint {
         settings.cursorShape = shape
+        if exerciseDefaultReset {
+            feed("\u{1B}[2 q", to: terminalView)
+            feed("\u{1B}[0 q", to: terminalView)
+            #expect(
+                terminalView.getTerminal().options.cursorStyle.tagName
+                    == "steadyUnderline"
+            )
+        }
         metalView.needsDisplay = false
         metalView.drawableSize = metalView.bounds.size
         terminalView.window?.displayIfNeeded()

--- a/PineTests/TerminalThemeSettingsTests.swift
+++ b/PineTests/TerminalThemeSettingsTests.swift
@@ -406,6 +406,25 @@ struct TerminalThemeSettingsTests {
         }
 
         #expect(propagated)
+
+        feed("\u{1B}[2 q", to: projectView)
+        feed("\u{1B}[2 q", to: quickView)
+        #expect(projectTerminal.options.cursorStyle.tagName == "steadyBlock")
+        #expect(quickTerminal.options.cursorStyle.tagName == "steadyBlock")
+
+        // Codex/crossterm restores the user's cursor with Ps=0 when its TUI
+        // exits. Project and Quick Terminal tabs share this exact policy.
+        feed("\u{1B}[0 q", to: projectView)
+        feed("\u{1B}[0 q", to: quickView)
+        #expect(projectTerminal.options.cursorStyle.tagName == "steadyUnderline")
+        #expect(quickTerminal.options.cursorStyle.tagName == "steadyUnderline")
+        #expect(cursorSettings.cursorStyle.tagName == "steadyUnderline")
+        #expect(
+            fixture.defaults.string(
+                forKey: TerminalCursorSettings.Keys.cursorStyle
+            ) == "steadyUnderline"
+        )
+
         #expect(projectTab.terminalView === projectView)
         #expect(quickTab.terminalView === quickView)
         #expect(projectView.getTerminal() === projectTerminal)
@@ -497,11 +516,166 @@ struct TerminalThemeSettingsTests {
             ) == nil
         )
     }
+
+    @Test("Codex default cursor reset restores the persisted preference")
+    func decscusrDefaultResetRestoresPreference() throws {
+        let fixture = try TerminalCursorSettingsFixture()
+        let settings = fixture.makeSettings()
+        settings.setCursorStyle(.steadyUnderline)
+        let tab = TerminalTab(name: "cursor-reset", cursorSettings: settings)
+        let view = try #require(tab.terminalView as? PineTerminalView)
+        let terminal = view.getTerminal()
+
+        feed("\u{1B}[2 q", to: view)
+        #expect(terminal.options.cursorStyle.tagName == "steadyBlock")
+
+        feed("\u{1B}[0 q", to: view)
+
+        #expect(terminal.options.cursorStyle.tagName == "steadyUnderline")
+        #expect(settings.cursorStyle.tagName == "steadyUnderline")
+        #expect(
+            fixture.defaults.string(
+                forKey: TerminalCursorSettings.Keys.cursorStyle
+            ) == "steadyUnderline"
+        )
+    }
+
+    @Test("Default cursor resets survive every ESC and C1 chunk boundary")
+    func decscusrDefaultResetSurvivesEveryChunkBoundary() throws {
+        let fixture = try TerminalCursorSettingsFixture()
+        let settings = fixture.makeSettings()
+        settings.setCursorStyle(.steadyUnderline)
+        let tab = TerminalTab(name: "cursor-splits", cursorSettings: settings)
+        let view = try #require(tab.terminalView as? PineTerminalView)
+        let terminal = view.getTerminal()
+        let resetSequences: [[UInt8]] = [
+            Array("\u{1B}[0 q".utf8),
+            Array("\u{1B}[ q".utf8),
+            [0x9B, 0x30, 0x20, 0x71],
+            [0x9B, 0x20, 0x71],
+        ]
+
+        for sequence in resetSequences {
+            for splitIndex in 0...sequence.count {
+                tab.applyPreferredCursorStyle()
+                feed("\u{1B}[2 q", to: view)
+                #expect(terminal.options.cursorStyle.tagName == "steadyBlock")
+
+                feed(Array(sequence.prefix(splitIndex)), to: view)
+                feed(Array(sequence.dropFirst(splitIndex)), to: view)
+
+                #expect(
+                    terminal.options.cursorStyle.tagName == "steadyUnderline",
+                    "Failed at split \(splitIndex) for \(sequence)"
+                )
+            }
+        }
+    }
+
+    @Test("The last supported DECSCUSR wins in stream order")
+    func decscusrUsesLastSupportedDirective() throws {
+        let fixture = try TerminalCursorSettingsFixture()
+        let settings = fixture.makeSettings()
+        settings.setCursorStyle(.steadyUnderline)
+        let tab = TerminalTab(name: "cursor-ordering", cursorSettings: settings)
+        let view = try #require(tab.terminalView as? PineTerminalView)
+        let terminal = view.getTerminal()
+
+        feed("\u{1B}[0 q\u{1B}[6 q", to: view)
+        #expect(terminal.options.cursorStyle.tagName == "steadyBar")
+
+        feed("\u{1B}[2 q\u{1B}[0 q", to: view)
+        #expect(terminal.options.cursorStyle.tagName == "steadyUnderline")
+
+        // SwiftTerm currently reads the first value of a multi-parameter
+        // command. Pine must keep the last grammatically supported directive
+        // authoritative even when such a lookalike follows it.
+        feed("\u{1B}[0 q\u{1B}[0;1 q", to: view)
+        #expect(terminal.options.cursorStyle.tagName == "steadyUnderline")
+
+        feed("\u{1B}[6 q", to: view)
+        feed("\u{1B}[0;1 q", to: view)
+        #expect(terminal.options.cursorStyle.tagName == "steadyBar")
+    }
+
+    @Test("DECSCUSR tracker rejects text, control strings, and invalid grammar")
+    func decscusrTrackerRejectsLookalikes() throws {
+        let explicitBar = Array("\u{1B}[6 q".utf8)
+        let invalidSequences: [[UInt8]] = [
+            Array("visible [0 q text".utf8),
+            Array("\u{1B}[7 q".utf8),
+            Array("\u{1B}[0;1 q".utf8),
+            Array("\u{1B}[; q".utf8),
+            Array("\u{1B}[?0 q".utf8),
+            Array("\u{1B}[0! q".utf8),
+            Array("\u{1B}[0  q".utf8),
+            Array("\u{1B}[0q".utf8),
+            Array("\u{1B}[0 p".utf8),
+        ]
+
+        for invalidSequence in invalidSequences {
+            var tracker = DECSCUSRStreamTracker()
+            let stream = explicitBar + invalidSequence
+            #expect(
+                tracker.consume(stream[...]) == .explicit(parameter: 6),
+                "Invalid sequence changed the decision: \(invalidSequence)"
+            )
+        }
+
+        let embeddedSequences: [[UInt8]] = [
+            // 7-bit OSC containing an ESC-[ lookalike, terminated by BEL.
+            [0x1B, 0x5D, 0x30, 0x3B, 0x1B, 0x5B, 0x30, 0x20, 0x71, 0x07],
+            // C1 OSC containing a C1 CSI lookalike, terminated by C1 ST.
+            [0x9D, 0x30, 0x3B, 0x9B, 0x30, 0x20, 0x71, 0x9C],
+            // 7-bit DCS payload containing an ESC-[ lookalike and ESC-\\ ST.
+            [0x1B, 0x50, 0x71, 0x1B, 0x5B, 0x30, 0x20, 0x71, 0x1B, 0x5C],
+            // C1 DCS payload containing a C1 CSI lookalike and C1 ST.
+            [0x90, 0x71, 0x9B, 0x30, 0x20, 0x71, 0x9C],
+        ]
+
+        for embeddedSequence in embeddedSequences {
+            var tracker = DECSCUSRStreamTracker()
+            #expect(tracker.consume(embeddedSequence[...]) == nil)
+            let reset = Array("\u{1B}[0 q".utf8)
+            #expect(tracker.consume(reset[...]) == .preferred)
+        }
+
+        let fixture = try TerminalCursorSettingsFixture()
+        let settings = fixture.makeSettings()
+        settings.setCursorStyle(.steadyUnderline)
+        let tab = TerminalTab(name: "cursor-negatives", cursorSettings: settings)
+        let view = try #require(tab.terminalView as? PineTerminalView)
+        feed(explicitBar, to: view)
+
+        for lookalike in invalidSequences + embeddedSequences {
+            feed(lookalike, to: view)
+            #expect(
+                view.getTerminal().options.cursorStyle.tagName == "steadyBar",
+                "Lookalike changed the live cursor: \(lookalike)"
+            )
+        }
+
+        // A hostile parameter run cannot overflow or grow parser storage.
+        var oversized = Array("\u{1B}[".utf8)
+        oversized.append(contentsOf: repeatElement(0x39, count: 4_096))
+        oversized.append(contentsOf: [0x20, 0x71])
+        var boundedTracker = DECSCUSRStreamTracker()
+        let boundedStream = explicitBar + oversized
+        #expect(
+            boundedTracker.consume(boundedStream[...])
+                == .explicit(parameter: 6)
+        )
+    }
 }
 
 @MainActor
 private func feed(_ text: String, to view: PineTerminalView) {
     let bytes = Array(text.utf8)
+    view.dataReceived(slice: bytes[...])
+}
+
+@MainActor
+private func feed(_ bytes: [UInt8], to view: PineTerminalView) {
     view.dataReceived(slice: bytes[...])
 }
 


### PR DESCRIPTION
Closes #1432.

## Summary
- recognize bounded streaming DECSCUSR reset sequences across split PTY chunks
- restore Pine’s configured cursor for Ps=0 or an omitted parameter
- keep explicit application cursor styles Ps=1...6 authoritative
- reject text, OSC/DCS payloads, invalid grammar, and multi-parameter lookalikes
- share the same behavior across project and Quick Terminal tabs without recreating the PTY or view

## Root cause
Codex/crossterm emits `ESC[0 q` to restore the user-default cursor. Pinned SwiftTerm 1.18 normalizes 0 to 1 and renders a blinking block, while Pine Settings correctly retains Underline.

## Verification
- TerminalThemeSettingsTests: 21/21 passed
- TerminalMetalRendererTests: 24/24 passed; Metal renderer active
- CoreGraphics and Metal cursor geometry covered
- SwiftLint: 0 violations in 740 files
- git diff --check: clean

## Environment
- macOS 27.0 (26A5406e)
- Xcode 27.0 beta (27A5194q)
- macOS SDK 27.0 (26A5353p)
- macOS 26 runtime unavailable on this machine