### PR TITLE
fix: suspend background project editor services

### DIFF
--- a/Pine/Agent/AgentDetectionCoordinator.swift
+++ b/Pine/Agent/AgentDetectionCoordinator.swift
@@ -24,6 +24,199 @@ nonisolated enum AgentMonotonicCounter {
     }
 }
 
+/// Captures one machine-wide process snapshot and fans it out to every
+/// project-local detector. Production owns one instance in `ProjectRegistry`;
+/// standalone terminal-manager tests keep using a private instance.
+nonisolated final class AgentProcessSnapshotPoller {
+    private let processRunner: ProcessRunner
+    private let pollInterval: TimeInterval
+    private let initialPollDelay: TimeInterval
+    private let uptimeProvider: @Sendable () -> TimeInterval
+    private let pollQueue = DispatchQueue(
+        label: "com.pine.agent-detection",
+        qos: .utility
+    )
+    private let lifecycleGate = AgentPollingLifecycleGate()
+    private let testingRun = AgentPollingRun(generation: 0)
+    private let sink: AgentProcessSnapshotSink
+    private var timer: DispatchSourceTimer?
+
+    @MainActor private(set) var isRunning = false
+
+    @MainActor
+    init(
+        processRunner: @escaping ProcessRunner = runRealProcess,
+        pollInterval: TimeInterval = 2.0,
+        initialPollDelay: TimeInterval? = nil,
+        uptimeProvider: @escaping @Sendable () -> TimeInterval = {
+            ProcessInfo.processInfo.systemUptime
+        }
+    ) {
+        self.processRunner = processRunner
+        self.pollInterval = pollInterval
+        self.initialPollDelay = initialPollDelay ?? pollInterval
+        self.uptimeProvider = uptimeProvider
+        self.sink = AgentProcessSnapshotSink()
+    }
+
+    @MainActor
+    func subscribe(_ coordinator: AgentDetectionCoordinator) {
+        sink.insert(coordinator)
+        startIfNeeded()
+    }
+
+    @MainActor
+    func unsubscribe(_ coordinator: AgentDetectionCoordinator) {
+        sink.remove(coordinator)
+        if sink.isEmpty {
+            stopPolling()
+        }
+    }
+
+    @MainActor
+    private func startIfNeeded() {
+        guard !isRunning, !sink.isEmpty else { return }
+        guard let generation = lifecycleGate.begin() else { return }
+        isRunning = true
+        let run = AgentPollingRun(generation: generation)
+        let timer = DispatchSource.makeTimerSource(queue: pollQueue)
+        timer.schedule(
+            deadline: .now() + initialPollDelay,
+            repeating: pollInterval
+        )
+        timer.setEventHandler(handler: makePollHandler(run: run))
+        timer.resume()
+        self.timer = timer
+    }
+
+    @MainActor
+    private func stopPolling() {
+        guard isRunning else { return }
+        isRunning = false
+        lifecycleGate.end()
+        timer?.cancel()
+        timer = nil
+    }
+
+    nonisolated private func makePollHandler(
+        run: AgentPollingRun
+    ) -> () -> Void {
+        { [weak self] in self?.captureSnapshot(run: run) }
+    }
+
+    nonisolated private func captureSnapshot(run: AgentPollingRun) {
+        // Do not queue repeated `ps` results behind a busy MainActor. A later
+        // timer tick can capture fresher state after this delivery completes.
+        guard let sequence = run.beginSnapshot() else { return }
+        let snapshot = makeSnapshot(
+            generation: run.generation,
+            sequence: sequence
+        )
+        let sink = self.sink
+        let lifecycleGate = self.lifecycleGate
+        let work = DispatchWorkItem {
+            MainActor.assumeIsolated {
+                defer { run.completeSnapshot() }
+                guard lifecycleGate.accepts(run.generation) else { return }
+                sink.apply(snapshot)
+            }
+        }
+        DispatchQueue.main.async(execute: work)
+    }
+
+    nonisolated private func makeSnapshot(
+        generation: UInt64,
+        sequence: UInt64
+    ) -> AgentProcessSnapshot {
+        let result = processRunner(
+            "/bin/sh",
+            ["-c", AgentDetectionCoordinator.psSnapshotCommand],
+            "",
+            3.0
+        )
+        let observation = AgentObservationStamp(
+            wallTime: Date(),
+            uptime: uptimeProvider(),
+            generation: generation,
+            sequence: sequence
+        )
+        return AgentDetectionCoordinator.enrichProcessStarts(
+            AgentDetectionCoordinator.makeSnapshot(
+                from: result,
+                observation: observation
+            )
+        )
+    }
+
+    #if DEBUG
+    @MainActor
+    func runSnapshotForTesting() {
+        sink.apply(captureSnapshotForTesting())
+    }
+
+    @MainActor
+    fileprivate func captureSnapshotForTesting() -> AgentProcessSnapshot {
+        makeSnapshot(
+            generation: testingRun.generation,
+            sequence: testingRun.nextSequence() ?? UInt64.max
+        )
+    }
+
+    @MainActor
+    var subscriberCountForTesting: Int { sink.count }
+    #endif
+
+    deinit {
+        lifecycleGate.end()
+        timer?.cancel()
+    }
+}
+
+@MainActor
+private final class AgentProcessSnapshotSink {
+    private final class WeakCoordinator {
+        weak var value: AgentDetectionCoordinator?
+
+        init(_ value: AgentDetectionCoordinator) {
+            self.value = value
+        }
+    }
+
+    private var coordinators: [ObjectIdentifier: WeakCoordinator] = [:]
+
+    var count: Int {
+        pruneReleasedCoordinators()
+        return coordinators.count
+    }
+
+    var isEmpty: Bool {
+        pruneReleasedCoordinators()
+        return coordinators.isEmpty
+    }
+
+    func insert(_ coordinator: AgentDetectionCoordinator) {
+        pruneReleasedCoordinators()
+        coordinators[ObjectIdentifier(coordinator)] = WeakCoordinator(
+            coordinator
+        )
+    }
+
+    func remove(_ coordinator: AgentDetectionCoordinator) {
+        coordinators.removeValue(forKey: ObjectIdentifier(coordinator))
+    }
+
+    func apply(_ snapshot: AgentProcessSnapshot) {
+        pruneReleasedCoordinators()
+        for coordinator in coordinators.values.compactMap(\.value) {
+            coordinator.receive(snapshot)
+        }
+    }
+
+    private func pruneReleasedCoordinators() {
+        coordinators = coordinators.filter { $0.value.value != nil }
+    }
+}
+
 /// Polls `ps` off the main thread and drives `AgentDetector` lifecycle,
 /// then maps detected agent pids to terminal tabs via `tcgetpgrp`.
 ///
@@ -57,18 +250,18 @@ nonisolated enum AgentMonotonicCounter {
 nonisolated final class AgentDetectionCoordinator {
     let detector: AgentDetector
     weak var terminalManager: TerminalManager?
-    private let processRunner: ProcessRunner
-    private let pollInterval: TimeInterval
+    private let poller: AgentProcessSnapshotPoller
     private let uptimeProvider: @Sendable () -> TimeInterval
-    private let pollQueue = DispatchQueue(label: "com.pine.agent-detection", qos: .utility)
-    private let lifecycleGate = AgentPollingLifecycleGate()
     private let testingRun = AgentPollingRun(generation: 0)
-    private var timer: DispatchSourceTimer?
 
     /// Whether polling is active. Read/written only from `@MainActor` methods
     /// (`start`/`stop`); the background polling path does not touch it.
     private(set) var isRunning = false
+    #if DEBUG
+    @MainActor private(set) var receivedSnapshotCountForTesting = 0
+    #endif
 
+    @MainActor
     init(
         detector: AgentDetector,
         terminalManager: TerminalManager?,
@@ -80,40 +273,32 @@ nonisolated final class AgentDetectionCoordinator {
     ) {
         self.detector = detector
         self.terminalManager = terminalManager
-        self.processRunner = processRunner
-        self.pollInterval = pollInterval
         self.uptimeProvider = uptimeProvider
+        self.poller = AgentProcessSnapshotPoller(
+            processRunner: processRunner,
+            pollInterval: pollInterval,
+            uptimeProvider: uptimeProvider
+        )
+    }
+
+    @MainActor
+    init(
+        detector: AgentDetector,
+        terminalManager: TerminalManager?,
+        poller: AgentProcessSnapshotPoller
+    ) {
+        self.detector = detector
+        self.terminalManager = terminalManager
+        self.poller = poller
+        self.uptimeProvider = {
+            ProcessInfo.processInfo.systemUptime
+        }
     }
 
     @MainActor func start() {
         guard !isRunning else { return }
-        guard let generation = lifecycleGate.begin() else { return }
         isRunning = true
-        let run = AgentPollingRun(generation: generation)
-        let timer = DispatchSource.makeTimerSource(queue: pollQueue)
-        timer.schedule(deadline: .now() + pollInterval, repeating: pollInterval)
-        // Build the handler via the nonisolated makePollHandler(): a closure
-        // literal written here (inside the @MainActor start()) would inherit
-        // MainActor isolation and trap when the source invokes it on
-        // pollQueue — see the class doc and the release 1.31.1 crash fix.
-        timer.setEventHandler(handler: makePollHandler(run: run))
-        timer.resume()
-        self.timer = timer
-    }
-
-    /// Builds the timer's event handler in a `nonisolated` function so the
-    /// returned closure is nonisolated. The `DispatchSource` timer invokes
-    /// this handler directly on `pollQueue` (no actor hop); a MainActor-
-    /// isolated handler would trip Swift's executor-isolation assertion
-    /// (`swift_task_isCurrentExecutorWithFlagsImpl` → `dispatch_assert_queue`)
-    /// and trap the process (release 1.31.1 crash). `captureSnapshot` is
-    /// itself `nonisolated`, so a nonisolated handler can call it directly.
-    /// Returns `() -> Void` (not `@Sendable`) so the closure may capture the
-    /// non-Sendable `self` without a strict-concurrency violation.
-    nonisolated private func makePollHandler(
-        run: AgentPollingRun
-    ) -> () -> Void {
-        { [weak self] in self?.captureSnapshot(run: run) }
+        poller.subscribe(self)
     }
 
     @MainActor func stop() {
@@ -135,69 +320,19 @@ nonisolated final class AgentDetectionCoordinator {
     private func suspendPolling() -> Bool {
         guard isRunning else { return false }
         isRunning = false
-        lifecycleGate.end()
-        timer?.cancel()
-        timer = nil
+        poller.unsubscribe(self)
         return true
     }
 
-    deinit {
-        lifecycleGate.end()
-        timer?.cancel()
-    }
-
-    /// Runs on `pollQueue`: captures the process list, parses it, then hops
-    /// to main to apply the snapshot. `nonisolated` so the nonisolated timer
-    /// handler (`makePollHandler`) can call it directly off-main. A handler's
-    /// isolation is determined by where its closure literal is written, not
-    /// by this method's isolation — that is why the handler lives in
-    /// `makePollHandler`, not inline in `start()` (see the class doc and the
-    /// release 1.31.1 crash fix).
-    ///
-    /// Uses `DispatchWorkItem` + `MainActor.assumeIsolated` instead of
-    /// `Task { @MainActor in }` to match the `FileSystemWatcher` pattern:
-    /// `DispatchWorkItem` does not require `@Sendable` so non-Sendable
-    /// references (`detector`, `terminalManager`) can be captured. The
-    /// references are extracted to locals BEFORE the hop so the
-    /// `@MainActor` closure never captures `self`, avoiding the strict-
-    /// concurrency "sending 'self' risks causing data races" error.
-    nonisolated private func captureSnapshot(run: AgentPollingRun) {
-        guard let sequence = run.nextSequence() else {
-            lifecycleGate.end()
-            return
-        }
-        let result = processRunner(
-            "/bin/sh",
-            ["-c", Self.psSnapshotCommand],
-            "",
-            3.0
+    @MainActor fileprivate func receive(_ snapshot: AgentProcessSnapshot) {
+        #if DEBUG
+        receivedSnapshotCountForTesting += 1
+        #endif
+        Self.applySnapshot(
+            snapshot,
+            detector: detector,
+            terminalManager: terminalManager
         )
-        let observation = AgentObservationStamp(
-            wallTime: Date(),
-            uptime: uptimeProvider(),
-            generation: run.generation,
-            sequence: sequence
-        )
-        let snapshot = Self.enrichProcessStarts(Self.makeSnapshot(
-            from: result,
-            observation: observation
-        ))
-        // Extract references before the hop — the DispatchWorkItem closure
-        // must not capture `self` (nonisolated, non-Sendable).
-        let detector = self.detector
-        let termManager = self.terminalManager
-        let lifecycleGate = self.lifecycleGate
-        let work = DispatchWorkItem {
-            MainActor.assumeIsolated {
-                guard lifecycleGate.accepts(run.generation) else { return }
-                Self.applySnapshot(
-                    snapshot,
-                    detector: detector,
-                    terminalManager: termManager
-                )
-            }
-        }
-        DispatchQueue.main.async(execute: work)
     }
 
     /// Parses raw
@@ -246,7 +381,7 @@ nonisolated final class AgentDetectionCoordinator {
         return processes
     }
 
-    nonisolated private static func enrichProcessStarts(
+    nonisolated fileprivate static func enrichProcessStarts(
         _ snapshot: AgentProcessSnapshot
     ) -> AgentProcessSnapshot {
         guard case .success(let processes, let observation) = snapshot else {
@@ -519,7 +654,7 @@ nonisolated final class AgentDetectionCoordinator {
     /// Unlike any particular process row, this is guaranteed to be last.
     nonisolated static let psCompletionMarker = "__PINE_PS_SNAPSHOT_COMPLETE__"
 
-    nonisolated private static let psSnapshotCommand = [
+    nonisolated fileprivate static let psSnapshotCommand = [
         "TZ=UTC LC_ALL=C /bin/ps -eo pid=,ppid=,pgid=,lstart=,cputime=,command=;",
         "status=$?;",
         "printf '\\n\(psCompletionMarker)\\n';",
@@ -682,7 +817,7 @@ nonisolated final class AgentDetectionCoordinator {
     /// malformed exit-zero stdout with an authoritative full process list.
     /// A valid non-agent row still yields a non-empty parsed list and is
     /// therefore authoritative absence for tracked agents.
-    nonisolated private static func makeSnapshot(
+    nonisolated fileprivate static func makeSnapshot(
         from result: ProcessRunResult,
         observation: AgentObservationStamp
     ) -> AgentProcessSnapshot {
@@ -921,27 +1056,7 @@ nonisolated final class AgentDetectionCoordinator {
     /// returns. Uses the injected `processRunner` (mock in tests), parses via
     /// `parsePsOutput`, then calls `applySnapshot` directly on the main actor.
     @MainActor internal func runSnapshotForTesting() {
-        let result = processRunner(
-            "/bin/sh",
-            ["-c", Self.psSnapshotCommand],
-            "",
-            3.0
-        )
-        let observation = AgentObservationStamp(
-            wallTime: Date(),
-            uptime: uptimeProvider(),
-            generation: testingRun.generation,
-            sequence: testingRun.nextSequence() ?? UInt64.max
-        )
-        let snapshot = Self.makeSnapshot(
-            from: result,
-            observation: observation
-        )
-        Self.applySnapshot(
-            snapshot,
-            detector: detector,
-            terminalManager: terminalManager
-        )
+        receive(poller.captureSnapshotForTesting())
     }
 
     /// Applies a simulated complete process tree through the production
@@ -985,6 +1100,7 @@ nonisolated private final class AgentPollingRun: @unchecked Sendable {
     let generation: UInt64
     private let lock = NSLock()
     private var sequence: UInt64 = 0
+    private var snapshotInFlight = false
 
     init(generation: UInt64) {
         self.generation = generation
@@ -998,6 +1114,24 @@ nonisolated private final class AgentPollingRun: @unchecked Sendable {
         }
         sequence = next
         return sequence
+    }
+
+    func beginSnapshot() -> UInt64? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !snapshotInFlight,
+              let next = AgentMonotonicCounter.next(after: sequence) else {
+            return nil
+        }
+        snapshotInFlight = true
+        sequence = next
+        return sequence
+    }
+
+    func completeSnapshot() {
+        lock.lock()
+        snapshotInFlight = false
+        lock.unlock()
     }
 }
 

--- a/Pine/ContextFileWriter.swift
+++ b/Pine/ContextFileWriter.swift
@@ -7,6 +7,77 @@ import CryptoKit
 import Darwin
 import Foundation
 
+/// Registry-issued identity for one manager incarnation of a canonical root.
+/// The epoch orders different managers; the nonce rejects accidental epoch
+/// reuse, and each manager's command sequence orders its own show/hide events.
+nonisolated struct ContextPresentationIdentity: Sendable, Equatable {
+    let epoch: UInt64
+    let nonce: UUID
+
+    init(epoch: UInt64, nonce: UUID = UUID()) {
+        self.epoch = epoch
+        self.nonce = nonce
+    }
+}
+
+nonisolated struct ContextPresentationCommand: Sendable, Equatable {
+    let identity: ContextPresentationIdentity
+    let sequence: UInt64
+}
+
+/// One registry owns one gate shared by every writer it creates. File actions
+/// for the same canonical root run under this lock, so an old manager's actor
+/// cannot approve a cleanup and race a newer manager's publish to disk.
+nonisolated final class ContextPresentationCommandGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var latestByProject: [String: ContextPresentationCommand] = [:]
+
+    @discardableResult
+    func accept(
+        projectIdentity: String,
+        command: ContextPresentationCommand,
+        perform: () -> Void
+    ) -> Bool {
+        lock.withLock {
+            if let latest = latestByProject[projectIdentity],
+               !Self.isSameOrNewer(command, than: latest) {
+                return false
+            }
+            latestByProject[projectIdentity] = command
+            perform()
+            return true
+        }
+    }
+
+    @discardableResult
+    func performIfCurrent(
+        projectIdentity: String,
+        command: ContextPresentationCommand,
+        perform: () -> Void
+    ) -> Bool {
+        lock.withLock {
+            guard latestByProject[projectIdentity] == command else {
+                return false
+            }
+            perform()
+            return true
+        }
+    }
+
+    private static func isSameOrNewer(
+        _ candidate: ContextPresentationCommand,
+        than latest: ContextPresentationCommand
+    ) -> Bool {
+        if candidate.identity.epoch != latest.identity.epoch {
+            return candidate.identity.epoch > latest.identity.epoch
+        }
+        guard candidate.identity.nonce == latest.identity.nonce else {
+            return false
+        }
+        return candidate.sequence >= latest.sequence
+    }
+}
+
 /// Writes an explicitly enabled, read-only editor-context snapshot to
 /// `~/Library/Application Support/Pine/contexts/`.
 ///
@@ -51,6 +122,7 @@ actor ContextFileWriter {
     private(set) var hasPendingWrite = false
     /// Invalidates stale debounce tasks after updates, revocation, or re-scope.
     private var updateGeneration: UInt64 = 0
+    private let presentationGate: ContextPresentationCommandGate
 
     /// Override for the contexts directory. Used by tests.
     private var contextsDirOverride: URL?
@@ -69,7 +141,59 @@ actor ContextFileWriter {
         return encoder
     }()
 
+    init(
+        presentationGate: ContextPresentationCommandGate =
+            ContextPresentationCommandGate()
+    ) {
+        self.presentationGate = presentationGate
+    }
+
     // MARK: - Public API
+
+    /// Atomically applies one complete visible-window handoff state. The
+    /// caller captures `commandGeneration` on the main actor; stale commands
+    /// are discarded before they can re-scope, revoke, or write the file.
+    func publishPresentationSnapshot(
+        projectRoot: URL,
+        isReadOnlySharingEnabled: Bool,
+        payload: Payload,
+        command: ContextPresentationCommand
+    ) {
+        let projectIdentity = Self.projectIdentity(for: projectRoot)
+        presentationGate.accept(
+            projectIdentity: projectIdentity,
+            command: command
+        ) {
+            setProjectRoot(projectRoot)
+            setReadOnlySharingEnabled(isReadOnlySharingEnabled)
+            guard isReadOnlySharingEnabled else { return }
+            scheduleUpdate(
+                payload: Payload(
+                    projectIdentity: projectIdentity,
+                    openFiles: payload.openFiles,
+                    currentFile: payload.currentFile,
+                    cursorLine: payload.cursorLine,
+                    cursorColumn: payload.cursorColumn
+                ),
+                presentationCommand: command
+            )
+        }
+    }
+
+    /// Revokes a hidden window's snapshot only if no later visible-window
+    /// command has already reached the actor.
+    func cleanupPresentationSnapshot(
+        projectRoot: URL,
+        command: ContextPresentationCommand
+    ) {
+        presentationGate.accept(
+            projectIdentity: Self.projectIdentity(for: projectRoot),
+            command: command
+        ) {
+            setProjectRoot(projectRoot)
+            cleanup()
+        }
+    }
 
     /// Sets the project root directory. Must be called before `update(...)`.
     /// Also removes the legacy `.pine-context.json` from the project root if present.
@@ -134,6 +258,20 @@ actor ContextFileWriter {
             cursorColumn: Self.boundedCoordinate(cursorColumn)
         )
 
+        scheduleUpdate(payload: payload, presentationCommand: nil)
+    }
+
+    private func scheduleUpdate(
+        payload: Payload,
+        presentationCommand: ContextPresentationCommand?
+    ) {
+        let boundedPayload = Payload(
+            projectIdentity: payload.projectIdentity,
+            openFiles: Self.boundedRelativePaths(payload.openFiles),
+            currentFile: Self.boundedCurrentFile(payload.currentFile),
+            cursorLine: Self.boundedCoordinate(payload.cursorLine),
+            cursorColumn: Self.boundedCoordinate(payload.cursorColumn)
+        )
         debounceTask?.cancel()
         updateGeneration &+= 1
         hasPendingWrite = true
@@ -147,7 +285,11 @@ actor ContextFileWriter {
                 return // Cancelled
             }
             guard let self else { return }
-            await self.writeContext(payload, generation: generation)
+            await self.writeContext(
+                boundedPayload,
+                generation: generation,
+                presentationCommand: presentationCommand
+            )
         }
     }
 
@@ -199,7 +341,8 @@ actor ContextFileWriter {
 
     private func writeContext(
         _ payload: Payload,
-        generation: UInt64
+        generation: UInt64,
+        presentationCommand: ContextPresentationCommand?
     ) {
         guard generation == updateGeneration,
               isReadOnlySharingEnabled else {
@@ -211,6 +354,22 @@ actor ContextFileWriter {
             }
         }
         guard let fileURL = contextFileURL else { return }
+
+        if let presentationCommand {
+            let projectIdentity = payload.projectIdentity
+            presentationGate.performIfCurrent(
+                projectIdentity: projectIdentity,
+                command: presentationCommand
+            ) {
+                writeContextToDisk(payload, fileURL: fileURL)
+            }
+            return
+        }
+
+        writeContextToDisk(payload, fileURL: fileURL)
+    }
+
+    private func writeContextToDisk(_ payload: Payload, fileURL: URL) {
 
         // Skip redundant writes
         if payload == lastWrittenContext { return }

--- a/Pine/DialogPresentationContext.swift
+++ b/Pine/DialogPresentationContext.swift
@@ -502,6 +502,10 @@ enum DialogPresenter {
         window: NSWindow,
         projectManager: ProjectManager
     ) -> DialogPresentationContext {
+        guard projectManager.retiredDialogOwnerGeneration(for: window) == nil else {
+            ownerDidClose(window)
+            return .unscoped
+        }
         // A project owns one document window. SwiftUI can replace that
         // window during scene restoration, so retire every obsolete binding
         // (and abort its queued sheets) before installing the new anchor.
@@ -613,13 +617,22 @@ enum DialogPresenter {
 
     /// Captures the current project window. Welcome and Settings windows are
     /// intentionally excluded from document/project decisions.
-    static func forKeyProject() -> DialogPresentationContext {
-        guard let keyWindow = NSApp.keyWindow else { return .unscoped }
+    static func forKeyProject(
+        keyWindow: NSWindow? = NSApp.keyWindow
+    ) -> DialogPresentationContext {
+        guard let keyWindow else { return .unscoped }
         let window = keyWindow.sheetParent ?? keyWindow
         if projectManager(for: window) != nil {
             return context(for: window)
         }
         guard let delegate = window.delegate as? CloseDelegate else {
+            return .unscoped
+        }
+        guard delegate.authorizesOwnerRecovery(
+            for: window,
+            presentationGeneration:
+                delegate.projectManager.dialogOwnerWindowGeneration
+        ) else {
             return .unscoped
         }
         return register(window: window, projectManager: delegate.projectManager)
@@ -663,11 +676,15 @@ enum DialogPresenter {
 
         guard let match = candidates.first(where: { window in
             guard acceptsWindow(window),
-                  let delegate = window.delegate as? CloseDelegate,
-                  !delegate.didCompleteWindowLifecycle else {
+                  let delegate = window.delegate as? CloseDelegate else {
                 return false
             }
             return delegate.projectManager === projectManager
+                && delegate.authorizesOwnerRecovery(
+                    for: window,
+                    presentationGeneration:
+                        projectManager.dialogOwnerWindowGeneration
+                )
         }), let delegate = match.delegate as? CloseDelegate else {
             return nil
         }

--- a/Pine/LSP/LSPManager.swift
+++ b/Pine/LSP/LSPManager.swift
@@ -30,6 +30,12 @@ import os
 @Observable
 final class LSPManager {
 
+    enum PresentationLifecycle: Equatable {
+        case active
+        case backgroundSuspended
+        case invalidated
+    }
+
     private struct OpenDocument {
         let url: URL
         let version: Int
@@ -139,8 +145,14 @@ final class LSPManager {
     private var stoppingClients:
         [ObjectIdentifier: any LSPClientProtocol] = [:]
 
-    /// Permanently prevents work from relaunching after project destruction.
-    private var isInvalidated = false
+    /// Separates reversible project-window suspension from final destruction.
+    private(set) var presentationLifecycle: PresentationLifecycle = .active
+    private var isInvalidated: Bool {
+        presentationLifecycle == .invalidated
+    }
+    private var isBackgroundSuspended: Bool {
+        presentationLifecycle == .backgroundSuspended
+    }
     private var lifecycleEpoch = 0
 
     init(
@@ -162,10 +174,64 @@ final class LSPManager {
         rootURI = url.map { $0.absoluteString }
     }
 
+    /// Stops every language-server process while retaining the current editor
+    /// mirrors. A later window reopen can replay those buffers exactly once.
+    func suspendForBackground() {
+        guard presentationLifecycle == .active else { return }
+        presentationLifecycle = .backgroundSuspended
+        lifecycleEpoch &+= 1
+
+        let activeLanguages = Set(servers.keys).union(restartingLanguages)
+        for language in activeLanguages {
+            bumpGeneration(for: language)
+        }
+
+        var clients: [ObjectIdentifier: any LSPClientProtocol] =
+            stoppingClients
+        for entry in servers.values {
+            clients[ObjectIdentifier(entry.client)] = entry.client
+        }
+        for client in clients.values {
+            client.shutdown()
+        }
+
+        servers.removeAll()
+        stoppingClients.removeAll()
+        openedDocumentsByLanguage.removeAll()
+        restartingLanguages.removeAll()
+        diagnosticsByURI = [:]
+        rawDiagnosticsByURI = [:]
+        problemsDiagnosticsByURI = [:]
+        unavailableLanguages.removeAll()
+        bumpDiagnosticsGeneration()
+    }
+
+    /// Restarts only the language servers needed by currently open buffers.
+    /// The lifecycle epoch fences initialize tasks left behind by suspension.
+    func resumeFromBackground() {
+        guard presentationLifecycle == .backgroundSuspended else { return }
+        presentationLifecycle = .active
+        lifecycleEpoch &+= 1
+        guard enabled else { return }
+
+        let epoch = lifecycleEpoch
+        let languages = Set(openDocuments.values.compactMap {
+            LanguageServerRegistry.server(for: $0.url)?.language
+        })
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            for language in languages.sorted() {
+                await replayDocuments(for: language, epoch: epoch)
+                guard canContinue(epoch: epoch) else { return }
+            }
+        }
+    }
+
     /// Shuts down every running server. Called on project close and app
     /// termination so no orphan language-server processes survive.
     func shutdownAll() {
-        isInvalidated = true
+        guard presentationLifecycle != .invalidated else { return }
+        presentationLifecycle = .invalidated
         lifecycleEpoch &+= 1
 
         let activeLanguages = Set(servers.keys).union(restartingLanguages)
@@ -754,7 +820,10 @@ final class LSPManager {
     /// the `initialize` handshake) if it isn't. Returns `false` if the server
     /// binary is missing or the handshake failed.
     private func ensureServer(for config: LanguageServerConfig) async -> Bool {
-        guard enabled, !isInvalidated, !Task.isCancelled else {
+        guard enabled,
+              !isInvalidated,
+              !isBackgroundSuspended,
+              !Task.isCancelled else {
             return false
         }
         guard !restartingLanguages.contains(config.language) else {
@@ -823,6 +892,7 @@ final class LSPManager {
 
         guard enabled,
               !isInvalidated,
+              !isBackgroundSuspended,
               !Task.isCancelled,
               lifecycleEpoch == epoch,
               !restartingLanguages.contains(config.language),
@@ -923,6 +993,7 @@ final class LSPManager {
     /// are included with their latest text.
     private func sendPendingDidOpen(for language: String) {
         guard !isInvalidated,
+              !isBackgroundSuspended,
               servers[language]?.state == .initialized else {
             return
         }
@@ -1010,6 +1081,7 @@ final class LSPManager {
 
     private func canContinue(epoch: Int) -> Bool {
         !isInvalidated
+            && !isBackgroundSuspended
             && !Task.isCancelled
             && lifecycleEpoch == epoch
     }

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -441,6 +441,15 @@ struct PaneLeafView: View {
         )
         .id(tab.id)
         .accessibilityIdentifier(AccessibilityID.codeEditor)
+        .background {
+            LSPDocumentPresentationLifecycle(
+                manager: projectManager.lspManager,
+                url: tab.fileURL,
+                contentRevision: tab.contentVersion,
+                text: tab.content
+            )
+            .id(tab.id)
+        }
         .onAppear {
             goToLineOffset = nil
             projectManager.problemsController.refreshDocumentOwnership()
@@ -450,22 +459,12 @@ struct PaneLeafView: View {
                     content: tab.content,
                     revision: tab.contentVersion
                 )
-                projectManager.lspManager.didOpen(
-                    url: fileURL,
-                    ownerID: tab.id,
-                    contentRevision: tab.contentVersion,
-                    text: tab.content
-                )
             }
             installLSPUIEndpoint(tabManager: tabManager)
         }
         .onDisappear {
             configValidator.clear()
             if let fileURL = tab.fileURL {
-                projectManager.lspManager.didClose(
-                    url: fileURL,
-                    ownerID: tab.id
-                )
                 projectManager.problemsController.removeConfigDiagnostics(
                     owner: problemsOwner(
                         for: tab,
@@ -486,32 +485,14 @@ struct PaneLeafView: View {
                 content: newValue,
                 revision: tab.contentVersion
             )
-            projectManager.lspManager.didChange(
-                url: fileURL,
-                ownerID: tab.id,
-                contentRevision: tab.contentVersion,
-                text: newValue
-            )
         }
-        .onChange(of: tab.fileURL) { oldURL, newURL in
+        .onChange(of: tab.fileURL) { _, newURL in
             configValidator.clear()
-            if let oldURL {
-                projectManager.lspManager.didClose(
-                    url: oldURL,
-                    ownerID: tab.id
-                )
-            }
             if let newURL {
                 configValidator.validate(
                     url: newURL,
                     content: tab.content,
                     revision: tab.contentVersion
-                )
-                projectManager.lspManager.didOpen(
-                    url: newURL,
-                    ownerID: tab.id,
-                    contentRevision: tab.contentVersion,
-                    text: tab.content
                 )
             }
             projectManager.problemsController.refreshDocumentOwnership()
@@ -871,5 +852,55 @@ struct PaneLeafView: View {
                 paneManager.removePane(paneID)
             }
         }
+    }
+}
+
+/// Owns one LSP document lease for one mounted editor presentation. A durable
+/// tab ID can be reused across a window reopen, while these UUIDs cannot; an
+/// old view's delayed disappearance therefore removes only its own buffer.
+private struct LSPDocumentPresentationLifecycle: View {
+    let manager: LSPManager
+    let url: URL?
+    let contentRevision: UInt64
+    let text: String
+    @State private var ownerID = UUID()
+
+    var body: some View {
+        Color.clear
+            .onAppear {
+                guard let url else { return }
+                manager.didOpen(
+                    url: url,
+                    ownerID: ownerID,
+                    contentRevision: contentRevision,
+                    text: text
+                )
+            }
+            .onDisappear {
+                guard let url else { return }
+                manager.didClose(url: url, ownerID: ownerID)
+            }
+            .onChange(of: text) { _, newText in
+                guard let url else { return }
+                manager.didChange(
+                    url: url,
+                    ownerID: ownerID,
+                    contentRevision: contentRevision,
+                    text: newText
+                )
+            }
+            .onChange(of: url) { oldURL, newURL in
+                if let oldURL {
+                    manager.didClose(url: oldURL, ownerID: ownerID)
+                }
+                if let newURL {
+                    manager.didOpen(
+                        url: newURL,
+                        ownerID: ownerID,
+                        contentRevision: contentRevision,
+                        text: text
+                    )
+                }
+            }
     }
 }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -151,17 +151,7 @@ private struct ProjectWindowView: View {
             // Hidden windows from closed projects still get re-rendered by SwiftUI;
             // calling projectManager(for:) would silently re-add the closed project
             // to openProjects, breaking the "show Welcome when last project closes" logic.
-            if let pm = registry.openProjects[
-                registry.canonicalProjectURL(projectURL)
-            ] ?? {
-                // Fallback: the project may have been opened through a path
-                // that canonicalizes differently (e.g. before the AppDelegate
-                // bridge wired openProjectWindow). Try a direct registry lookup
-                // as a last resort so the window always shows content.
-                registry.projectManager(
-                    for: registry.canonicalProjectURL(projectURL)
-                )
-            }() {
+            if let pm = registry.projectManagerIfAdmitted(for: projectURL) {
                 ContentView()
                     .id(ObjectIdentifier(pm))
                     .environment(pm)
@@ -334,9 +324,11 @@ struct WindowCloseInterceptor: NSViewRepresentable {
                            registry.canonicalProjectURL(projectURL)
                        ] === projectManager {
                         existing.beginNewWindowLifecycle(on: window)
-                    } else if !existing.didCompleteWindowLifecycle {
-                        existing.observeWindowClose(window)
                     }
+                    // An unfinished delegate already observes this exact
+                    // window. Re-observing during coordinator transfer would
+                    // also renew dialog authorization and could resurrect a
+                    // retired A before B binds.
                     return
                 }
                 let existingOriginal = existing.original
@@ -495,6 +487,12 @@ class CloseDelegate: NSObject, NSWindowDelegate {
     /// CloseDelegate is always deallocated on the main thread.
     nonisolated(unsafe) private var closeObserver: Any?
     private weak var ownerWindow: NSWindow?
+    private var ownerWindowGeneration: UUID?
+    /// Recovery is intentionally narrower than close handling. A retained
+    /// delegate must still report A's eventual close with A's generation, but
+    /// once the registry starts presenting B it may no longer restore A as a
+    /// dialog owner merely because A remains visible for another run-loop turn.
+    private var ownerRecoveryIsAuthorized = false
     private(set) var dialogContext = DialogPresentationContext.unscoped
     private var closeDecisionTask: Task<Void, Never>?
     private weak var approvedCloseWindow: NSWindow?
@@ -539,10 +537,28 @@ class CloseDelegate: NSObject, NSWindowDelegate {
             DialogPresenter.ownerDidClose(previousWindow)
         }
         ownerWindow = window
+        if let retiredGeneration = projectManager
+            .retiredDialogOwnerGeneration(for: window) {
+            // Keep A's close callback armed with A's stale generation, but do
+            // not let a transferred or newly wrapped delegate turn A into the
+            // current dialog owner again.
+            ownerWindowGeneration = retiredGeneration
+            ownerRecoveryIsAuthorized = false
+            dialogContext = .unscoped
+            DialogPresenter.ownerDidClose(window)
+            installCloseObserver(for: window)
+            return
+        }
         dialogContext = DialogPresenter.register(
             window: window,
             projectManager: projectManager
         )
+        ownerWindowGeneration = projectManager.dialogOwnerWindowGeneration
+        ownerRecoveryIsAuthorized = true
+        installCloseObserver(for: window)
+    }
+
+    private func installCloseObserver(for window: NSWindow) {
         closeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,
             object: window,
@@ -552,6 +568,26 @@ class CloseDelegate: NSObject, NSWindowDelegate {
                 self?.handleWindowClose()
             }
         }
+    }
+
+    /// Revokes only presentation recovery for the current installation.
+    /// Close observation deliberately remains armed so a delayed close still
+    /// reaches the registry carrying the now-stale window generation.
+    func retirePresentationAuthorization(for window: NSWindow) {
+        guard ownerWindow === window else { return }
+        ownerRecoveryIsAuthorized = false
+        dialogContext = .unscoped
+        DialogPresenter.ownerDidClose(window)
+    }
+
+    func authorizesOwnerRecovery(
+        for window: NSWindow,
+        presentationGeneration: UUID
+    ) -> Bool {
+        ownerRecoveryIsAuthorized
+            && !didHandleClose
+            && ownerWindow === window
+            && ownerWindowGeneration == presentationGeneration
     }
 
     deinit {
@@ -754,14 +790,19 @@ class CloseDelegate: NSObject, NSWindowDelegate {
     private func handleWindowClose() {
         guard !didHandleClose else { return }
         didHandleClose = true
+        ownerRecoveryIsAuthorized = false
         closeDecisionTask?.cancel()
         closeDecisionTask = nil
         approvedCloseWindow = nil
+        let closingGeneration = ownerWindowGeneration
         if let ownerWindow {
             DialogPresenter.ownerDidClose(ownerWindow)
         }
         appDelegate?.handleProjectWindowDisappear(
-            projectURL: projectURL, registry: registry
+            projectURL: projectURL,
+            registry: registry,
+            expectedManager: projectManager,
+            expectedWindowGeneration: closingGeneration
         )
     }
 
@@ -789,6 +830,8 @@ class CloseDelegate: NSObject, NSWindowDelegate {
             DialogPresenter.ownerDidClose(ownerWindow)
         }
         ownerWindow = nil
+        ownerWindowGeneration = nil
+        ownerRecoveryIsAuthorized = false
         dialogContext = .unscoped
     }
 
@@ -983,14 +1026,30 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
 
     /// Handles cleanup when a project window disappears: saves session,
     /// removes from registry, and shows Welcome if no projects remain.
-    func handleProjectWindowDisappear(projectURL: URL, registry: ProjectRegistry) {
+    func handleProjectWindowDisappear(
+        projectURL: URL,
+        registry: ProjectRegistry,
+        expectedManager: ProjectManager? = nil,
+        expectedWindowGeneration: UUID? = nil
+    ) {
         guard !isTerminating else { return }
         // Save session before closing so it can be restored
         // when the user reopens this project from Welcome or Open Recent.
         let canonical = registry.canonicalProjectURL(projectURL)
-        registry.openProjects[canonical]?.saveSession()
-        registry.openProjects[canonical]?.cleanupEditorContext()
-        registry.closeProjectWindow(projectURL)
+        guard let manager = registry.openProjects[canonical],
+              expectedManager == nil || manager === expectedManager,
+              expectedWindowGeneration == nil
+                || manager.dialogOwnerWindowGeneration
+                    == expectedWindowGeneration else {
+            return
+        }
+        manager.saveSession()
+        manager.cleanupEditorContext()
+        registry.closeProjectWindow(
+            projectURL,
+            expectedManager: expectedManager,
+            expectedWindowGeneration: expectedWindowGeneration
+        )
         // Show Welcome if no windows are open (check non-background projects)
         let hasOpenWindows = registry.openProjects.keys.contains { url in
             !registry.backgroundProjects.contains(url)

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -796,6 +796,10 @@ class CloseDelegate: NSObject, NSWindowDelegate {
         approvedCloseWindow = nil
         let closingGeneration = ownerWindowGeneration
         if let ownerWindow {
+            projectManager.recordCompletedDialogOwnerLifecycle(
+                ownerWindow,
+                generation: closingGeneration
+            )
             DialogPresenter.ownerDidClose(ownerWindow)
         }
         appDelegate?.handleProjectWindowDisappear(
@@ -811,7 +815,11 @@ class CloseDelegate: NSObject, NSWindowDelegate {
     /// representable updates during one live window generation must never
     /// reset the once-only close guard.
     func beginNewWindowLifecycle(on window: NSWindow) {
-        guard didHandleClose else { return }
+        guard didHandleClose,
+              projectManager.authorizeCompletedDialogOwnerLifecycle(
+                window,
+                generation: ownerWindowGeneration
+              ) else { return }
         didHandleClose = false
         observeWindowClose(window)
     }

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -248,8 +248,25 @@ nonisolated private final class TerminationAwaitResolver<Result: Sendable>:
 /// Thin coordinator that owns the workspace, terminal, and tab managers.
 /// Passed via environment so views can access all sub-managers.
 @MainActor
+private final class RetiredDialogOwnerWindow {
+    weak var window: NSWindow?
+    let generation: UUID
+
+    init(window: NSWindow, generation: UUID) {
+        self.window = window
+        self.generation = generation
+    }
+}
+
+@MainActor
 @Observable
 final class ProjectManager {
+    enum PresentationLifecycle: Equatable {
+        case visible
+        case backgroundSuspended
+        case destroyed
+    }
+
     private static let terminationInstallDeadlineQueue = DispatchQueue(
         label: "com.pine.project.termination-install-deadline",
         qos: .userInteractive
@@ -349,7 +366,7 @@ final class ProjectManager {
     let searchProvider = ProjectSearchProvider()
     let quickOpenProvider = QuickOpenProvider()
     let progress = ProgressTracker()
-    let contextFileWriter = ContextFileWriter()
+    let contextFileWriter: ContextFileWriter
     /// Language Server Protocol manager — owns per-language server processes
     /// and aggregates diagnostics (#1010, parent #994). Spawned lazily on the
     /// first open of a matching file; shut down on project close / app quit.
@@ -365,6 +382,10 @@ final class ProjectManager {
     /// background) from extending the NSWindow lifetime.
     @ObservationIgnored
     private(set) weak var dialogOwnerWindow: NSWindow?
+    @ObservationIgnored
+    private(set) var dialogOwnerWindowGeneration = UUID()
+    @ObservationIgnored
+    private var retiredDialogOwnerWindows: [RetiredDialogOwnerWindow] = []
     @ObservationIgnored
     private var dialogOperationTail: Task<Void, Never>?
     @ObservationIgnored
@@ -1511,12 +1532,34 @@ final class ProjectManager {
     let taskRunStore = UserTaskRunStore()
     /// Recovery snapshots and their lifecycle are owned by the main actor.
     private(set) var recoveryManager: RecoveryManager?
+    private(set) var presentationLifecycle: PresentationLifecycle = .visible
+    #if DEBUG
+    private(set) var editorServiceSuspendCountForTesting = 0
+    private(set) var editorServiceResumeCountForTesting = 0
+    #endif
+    private var editorContextCommandGeneration: UInt64 = 0
+    private let contextPresentationIdentity: ContextPresentationIdentity
+
+    #if DEBUG
+    func removeRecoveryManagerForTesting() {
+        recoveryManager?.cancelScheduledSnapshot()
+        recoveryManager?.stopPeriodicSnapshots()
+        recoveryManager = nil
+    }
+    #endif
 
     init(
         lspSettings: LSPSettings = .shared,
-        agentTaskRegistry: AgentTaskRegistry? = nil
+        agentProcessSnapshotPoller: AgentProcessSnapshotPoller? = nil,
+        agentTaskRegistry: AgentTaskRegistry? = nil,
+        contextFileWriter: ContextFileWriter = ContextFileWriter(),
+        contextPresentationIdentity: ContextPresentationIdentity =
+            ContextPresentationIdentity(epoch: 1)
     ) {
+        self.contextFileWriter = contextFileWriter
+        self.contextPresentationIdentity = contextPresentationIdentity
         self.terminal = TerminalManager(
+            agentProcessSnapshotPoller: agentProcessSnapshotPoller,
             agentTaskRegistry: agentTaskRegistry
         )
         self.lspManager = LSPManager(settings: lspSettings)
@@ -1544,8 +1587,51 @@ final class ProjectManager {
         terminal.paneManager = paneManager
     }
 
-    func bindDialogOwnerWindow(_ window: NSWindow) {
+    @discardableResult
+    func bindDialogOwnerWindow(_ window: NSWindow) -> UUID {
+        guard retiredDialogOwnerGeneration(for: window) == nil else {
+            return dialogOwnerWindowGeneration
+        }
+        if dialogOwnerWindow !== window {
+            dialogOwnerWindowGeneration = UUID()
+        }
         dialogOwnerWindow = window
+        return dialogOwnerWindowGeneration
+    }
+
+    /// Starts a registry-authorized window presentation before SwiftUI can
+    /// bind its replacement NSWindow. Rotating now, rather than at the later
+    /// bind, fences a delayed close from the previous window during the gap
+    /// between retained-manager admission and replacement-window capture.
+    func prepareForWindowPresentation() {
+        let previousOwner = dialogOwnerWindow
+        let previousGeneration = dialogOwnerWindowGeneration
+        if let previousOwner {
+            retiredDialogOwnerWindows.removeAll {
+                $0.window == nil || $0.window === previousOwner
+            }
+            retiredDialogOwnerWindows.append(RetiredDialogOwnerWindow(
+                window: previousOwner,
+                generation: previousGeneration
+            ))
+        }
+        dialogOwnerWindowGeneration = UUID()
+        dialogOwnerWindow = nil
+        if let previousOwner {
+            if let delegate = previousOwner.delegate as? CloseDelegate,
+               delegate.projectManager === self {
+                delegate.retirePresentationAuthorization(for: previousOwner)
+            } else {
+                DialogPresenter.ownerDidClose(previousOwner)
+            }
+        }
+    }
+
+    func retiredDialogOwnerGeneration(for window: NSWindow) -> UUID? {
+        retiredDialogOwnerWindows.removeAll { $0.window == nil }
+        return retiredDialogOwnerWindows.first(where: {
+            $0.window === window
+        })?.generation
     }
 
     func unbindDialogOwnerWindow(_ window: NSWindow) {
@@ -1643,6 +1729,57 @@ final class ProjectManager {
         }
         manager.startPeriodicSnapshots()
         recoveryManager = manager
+    }
+
+    /// Stops services that exist only to keep a visible editor current while
+    /// retaining PTYs, terminal buffers, agent identity, and user-task owners.
+    func suspendEditorServices() {
+        guard presentationLifecycle == .visible else { return }
+        presentationLifecycle = .backgroundSuspended
+        #if DEBUG
+        editorServiceSuspendCountForTesting += 1
+        #endif
+        recoveryManager?.snapshotDirtyTabs(allTabs)
+        recoveryManager?.cancelScheduledSnapshot()
+        recoveryManager?.stopPeriodicSnapshots()
+        workspace.suspend()
+        searchProvider.cancel()
+        lspManager.suspendForBackground()
+        cleanupEditorContext()
+    }
+
+    /// Re-arms each visible-editor service once for one retained manager.
+    func resumeEditorServices() {
+        guard presentationLifecycle == .backgroundSuspended else { return }
+        presentationLifecycle = .visible
+        #if DEBUG
+        editorServiceResumeCountForTesting += 1
+        #endif
+        workspace.resume()
+        recoveryManager?.startPeriodicSnapshots()
+        lspManager.resumeFromBackground()
+        synchronizeAgentHandoff()
+        problemsController.refreshDocumentOwnership()
+    }
+
+    /// Final resource teardown used only after registry reclamation proves
+    /// there is no process/task ownership left to preserve.
+    func shutdownReclaimableProject() {
+        guard presentationLifecycle != .destroyed else { return }
+        presentationLifecycle = .destroyed
+        recoveryManager?.snapshotDirtyTabs(allTabs)
+        recoveryManager?.cancelScheduledSnapshot()
+        recoveryManager?.stopPeriodicSnapshots()
+        workspace.suspend()
+        searchProvider.cancel()
+        lspManager.shutdownAll()
+        terminal.shutdownPermanently()
+    }
+
+    var requiresBackgroundRetention: Bool {
+        allTabs.contains(where: \.isDirty)
+            || terminal.requiresBackgroundRetention
+            || hasOutstandingUserTaskExecution
     }
 
     /// Applies project-owned services to every editor group, including groups
@@ -2201,7 +2338,17 @@ final class ProjectManager {
     /// Pushes the current editor context (active file, cursor position) to the
     /// context file writer. Called when the active tab or cursor position changes.
     func updateEditorContext() {
-        guard let rootURL = workspace.rootURL else { return }
+        guard presentationLifecycle == .visible else { return }
+        publishEditorContext(projectRoot: workspace.rootURL)
+    }
+
+    /// Captures one complete desired handoff state on the main actor. Every
+    /// asynchronous actor command carries a monotonic presentation generation,
+    /// so a delayed hidden-window cleanup cannot delete a newer reopen publish
+    /// (and a delayed old publish cannot resurrect a cleaned-up snapshot).
+    private func publishEditorContext(projectRoot: URL?) {
+        guard presentationLifecycle == .visible,
+              let rootURL = projectRoot else { return }
         let tab = activeTabManager.activeTab
         let relativePath = ContextFileWriter.relativePath(
             fileURL: tab?.fileURL,
@@ -2213,20 +2360,43 @@ final class ProjectManager {
                 rootURL: rootURL
             )
         }
+        editorContextCommandGeneration &+= 1
+        let command = ContextPresentationCommand(
+            identity: contextPresentationIdentity,
+            sequence: editorContextCommandGeneration
+        )
+        let isEnabled = AgentHandoffSettings.shared.isReadOnlyContextEnabled
+        let cursorLine = tab?.cursorLine
+        let cursorColumn = tab?.cursorColumn
+        let payload = ContextFileWriter.Payload(
+            openFiles: openFiles,
+            currentFile: relativePath,
+            cursorLine: cursorLine,
+            cursorColumn: cursorColumn
+        )
         Task {
-            await contextFileWriter.update(
-                openFiles: openFiles,
-                currentFile: relativePath,
-                cursorLine: tab?.cursorLine,
-                cursorColumn: tab?.cursorColumn
+            await contextFileWriter.publishPresentationSnapshot(
+                projectRoot: rootURL,
+                isReadOnlySharingEnabled: isEnabled,
+                payload: payload,
+                command: command
             )
         }
     }
 
     /// Cleans up the context file. Called when the project window closes.
     func cleanupEditorContext() {
+        guard let rootURL = workspace.rootURL else { return }
+        editorContextCommandGeneration &+= 1
+        let command = ContextPresentationCommand(
+            identity: contextPresentationIdentity,
+            sequence: editorContextCommandGeneration
+        )
         Task {
-            await contextFileWriter.cleanup()
+            await contextFileWriter.cleanupPresentationSnapshot(
+                projectRoot: rootURL,
+                command: command
+            )
         }
     }
 
@@ -2234,15 +2404,10 @@ final class ProjectManager {
     /// revokes its bounded read-only snapshot.
     func synchronizeAgentHandoff(projectRoot: URL? = nil) {
         let rootURL = projectRoot ?? workspace.rootURL
-        let isEnabled = AgentHandoffSettings.shared.isReadOnlyContextEnabled
-        Task {
-            if let rootURL {
-                await contextFileWriter.setProjectRoot(rootURL)
-            }
-            await contextFileWriter.setReadOnlySharingEnabled(isEnabled)
-            if isEnabled {
-                self.updateEditorContext()
-            }
+        if presentationLifecycle == .visible, let rootURL {
+            publishEditorContext(projectRoot: rootURL)
+        } else {
+            cleanupEditorContext()
         }
     }
 

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -387,6 +387,8 @@ final class ProjectManager {
     @ObservationIgnored
     private var retiredDialogOwnerWindows: [RetiredDialogOwnerWindow] = []
     @ObservationIgnored
+    private var completedDialogOwnerWindow: RetiredDialogOwnerWindow?
+    @ObservationIgnored
     private var dialogOperationTail: Task<Void, Never>?
     @ObservationIgnored
     private var dialogOperationGeneration = 0
@@ -1592,6 +1594,7 @@ final class ProjectManager {
         guard retiredDialogOwnerGeneration(for: window) == nil else {
             return dialogOwnerWindowGeneration
         }
+        completedDialogOwnerWindow = nil
         if dialogOwnerWindow !== window {
             dialogOwnerWindowGeneration = UUID()
         }
@@ -1606,6 +1609,7 @@ final class ProjectManager {
     func prepareForWindowPresentation() {
         let previousOwner = dialogOwnerWindow
         let previousGeneration = dialogOwnerWindowGeneration
+        let completedOwner = completedDialogOwnerWindow?.window
         if let previousOwner {
             retiredDialogOwnerWindows.removeAll {
                 $0.window == nil || $0.window === previousOwner
@@ -1625,6 +1629,16 @@ final class ProjectManager {
                 DialogPresenter.ownerDidClose(previousOwner)
             }
         }
+        // SwiftUI can reopen a completed WindowGroup lifecycle by ordering the
+        // same NSWindow instance front without updating its representable.
+        // Re-arm only an owner whose old close callback already committed;
+        // unfinished retired owners remain fenced until a fresh window binds.
+        if let completedOwner,
+           let delegate = completedOwner.delegate as? CloseDelegate,
+           delegate.projectManager === self,
+           delegate.didCompleteWindowLifecycle {
+            delegate.beginNewWindowLifecycle(on: completedOwner)
+        }
     }
 
     func retiredDialogOwnerGeneration(for window: NSWindow) -> UUID? {
@@ -1632,6 +1646,37 @@ final class ProjectManager {
         return retiredDialogOwnerWindows.first(where: {
             $0.window === window
         })?.generation
+    }
+
+    func recordCompletedDialogOwnerLifecycle(
+        _ window: NSWindow,
+        generation: UUID?
+    ) {
+        guard let generation,
+              dialogOwnerWindow === window,
+              dialogOwnerWindowGeneration == generation else { return }
+        completedDialogOwnerWindow = RetiredDialogOwnerWindow(
+            window: window,
+            generation: generation
+        )
+    }
+
+    func authorizeCompletedDialogOwnerLifecycle(
+        _ window: NSWindow,
+        generation: UUID?
+    ) -> Bool {
+        guard let generation,
+              let completed = completedDialogOwnerWindow,
+              completed.window === window,
+              completed.generation == generation else {
+            return false
+        }
+        if let retiredGeneration = retiredDialogOwnerGeneration(for: window) {
+            guard retiredGeneration == generation else { return false }
+            retiredDialogOwnerWindows.removeAll { $0.window === window }
+        }
+        completedDialogOwnerWindow = nil
+        return true
     }
 
     func unbindDialogOwnerWindow(_ window: NSWindow) {

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -91,6 +91,16 @@ struct TerminationSaveInventoryAuthorization {
 @MainActor
 @Observable
 final class ProjectRegistry: LSPSettingsObserver {
+    private struct AgentInboxPresentationAuthorization {
+        let projectURL: URL
+        let projectIdentity: AgentTaskProjectIdentity
+        let manager: ProjectManager
+        let operationID: UUID
+        let leaseID: UUID
+        let ownerWindow: NSWindow
+        let ownerWindowGeneration: UUID
+    }
+
     /// Open projects keyed by their root directory URL.
     private(set) var openProjects: [URL: ProjectManager] = [:]
     /// Projects whose window was closed but whose ProjectManager (and terminal processes)
@@ -116,6 +126,27 @@ final class ProjectRegistry: LSPSettingsObserver {
     @ObservationIgnored private let defaults: UserDefaults
     @ObservationIgnored private let fileManager: FileManager
     @ObservationIgnored private let agentRecoveryInspector: AgentTaskRecoveryInspector
+    @ObservationIgnored private let agentProcessSnapshotPoller: AgentProcessSnapshotPoller
+    @ObservationIgnored private let agentInboxProjectCanonicalizer:
+        @Sendable (URL) async -> URL
+    @ObservationIgnored private let contextPresentationGate =
+        ContextPresentationCommandGate()
+    @ObservationIgnored private var contextPresentationEpochs: [URL: UInt64] = [:]
+    @ObservationIgnored private let backgroundReclamationInterval: Duration
+    @ObservationIgnored private let backgroundReclamationBatchSize: Int
+    @ObservationIgnored private var backgroundReclamationTask: Task<Void, Never>?
+    @ObservationIgnored private var backgroundReclamationQueue: [UInt64: URL] = [:]
+    @ObservationIgnored private var backgroundReclamationQueuedURLs: Set<URL> = []
+    @ObservationIgnored private var nextBackgroundReclamationQueueID: UInt64 = 0
+    @ObservationIgnored private var nextBackgroundReclamationDequeueID: UInt64 = 0
+    @ObservationIgnored private var backgroundReclamationCycleRemaining = 0
+    #if DEBUG
+    @ObservationIgnored private(set) var lastReclaimPassCountForTesting = 0
+    #endif
+    @ObservationIgnored
+    private var backgroundPresentationLeases: [URL: Set<UUID>] = [:]
+    @ObservationIgnored
+    private var agentInboxPresentationOperations: [URL: UUID] = [:]
     @ObservationIgnored
     private var agentTaskProjectsByRoot: [URL: AgentTaskProjectIdentity] = [:] {
         didSet {
@@ -156,6 +187,16 @@ final class ProjectRegistry: LSPSettingsObserver {
         fileManager: FileManager = .default,
         agentTasks: AgentTaskRegistry? = nil,
         agentRecoveryInspector: AgentTaskRecoveryInspector = AgentTaskRecoveryInspector(),
+        agentInboxProjectCanonicalizer: @escaping @Sendable (URL) async -> URL = { rawURL in
+            await Task.detached {
+                ProjectRegistry.canonicalProjectURL(rawURL)
+            }.value
+        },
+        agentDetectionProcessRunner: @escaping ProcessRunner = runRealProcess,
+        agentDetectionPollInterval: TimeInterval = 2.0,
+        agentDetectionInitialPollDelay: TimeInterval? = nil,
+        backgroundReclamationInterval: Duration = .seconds(30),
+        backgroundReclamationBatchSize: Int = 4,
         clearRecentProjects: Bool = CommandLine.arguments.contains(
             "--clear-recent-projects"
         )
@@ -165,6 +206,14 @@ final class ProjectRegistry: LSPSettingsObserver {
         self.defaults = defaults
         self.fileManager = fileManager
         self.agentRecoveryInspector = agentRecoveryInspector
+        self.agentInboxProjectCanonicalizer = agentInboxProjectCanonicalizer
+        self.agentProcessSnapshotPoller = AgentProcessSnapshotPoller(
+            processRunner: agentDetectionProcessRunner,
+            pollInterval: agentDetectionPollInterval,
+            initialPollDelay: agentDetectionInitialPollDelay
+        )
+        self.backgroundReclamationInterval = backgroundReclamationInterval
+        self.backgroundReclamationBatchSize = max(1, backgroundReclamationBatchSize)
         if clearRecentProjects {
             defaults.removeObject(forKey: Self.recentProjectsKey)
         }
@@ -212,6 +261,13 @@ final class ProjectRegistry: LSPSettingsObserver {
         )
     }
 
+    /// Non-admitting lookup for SwiftUI scene roots that may outlive their
+    /// native window. A stale hidden `ProjectWindowView` must never recreate a
+    /// manager after bounded reclamation.
+    func projectManagerIfAdmitted(for projectURL: URL) -> ProjectManager? {
+        openProjects[canonicalProjectURL(projectURL)]
+    }
+
     /// Opens a Pine-managed worktree while retaining the owning repository as
     /// the shared project scope. Sibling worktrees therefore remain comparable
     /// without sharing terminal, task, event, checkpoint, or notification IDs.
@@ -238,7 +294,8 @@ final class ProjectRegistry: LSPSettingsObserver {
     /// been canonicalized again. This is used by Inbox navigation and recovery.
     private func projectManager(
         for identity: AgentTaskProjectIdentity,
-        reopenBackgroundProject: Bool = true
+        reopenBackgroundProject: Bool = true,
+        admitMissingProjectInBackground: Bool = false
     ) -> ProjectManager? {
         let project = canonicalProjectURL(URL(
             fileURLWithPath: identity.canonicalProjectPath,
@@ -255,14 +312,16 @@ final class ProjectRegistry: LSPSettingsObserver {
         return projectManager(
             forCanonicalWorktree: worktree,
             identity: identity,
-            reopenBackgroundProject: reopenBackgroundProject
+            reopenBackgroundProject: reopenBackgroundProject,
+            admitMissingProjectInBackground: admitMissingProjectInBackground
         )
     }
 
     private func projectManager(
         forCanonicalWorktree canonical: URL,
         identity: AgentTaskProjectIdentity,
-        reopenBackgroundProject: Bool = true
+        reopenBackgroundProject: Bool = true,
+        admitMissingProjectInBackground: Bool = false
     ) -> ProjectManager? {
         if let existing = openProjects[canonical] {
             guard agentTaskProjectsByRoot[canonical] == identity else {
@@ -276,7 +335,7 @@ final class ProjectRegistry: LSPSettingsObserver {
                     // Directory was deleted while in background — clean up
                     existing.requestUserTaskShutdown()
                     existing.terminal.terminateAll()
-                    existing.shutdownLanguageServers()
+                    existing.shutdownReclaimableProject()
                     let ownerID = ObjectIdentifier(existing)
                     detachedTaskCleanupProjects[ownerID] = existing
                     Task { @MainActor [weak self] in
@@ -302,6 +361,7 @@ final class ProjectRegistry: LSPSettingsObserver {
                     return nil
                 }
                 if reopenBackgroundProject {
+                    existing.prepareForWindowPresentation()
                     _ = markProjectWindowOpen(
                         canonical,
                         identity: identity,
@@ -327,9 +387,18 @@ final class ProjectRegistry: LSPSettingsObserver {
         ), isProjectDir.boolValue else { return nil }
         guard !isProjectAdmissionFrozenForTermination else { return nil }
         agentTasks.registerProject(identity)
+        let contextEpoch = contextPresentationEpochs[canonical, default: 0] &+ 1
+        contextPresentationEpochs[canonical] = contextEpoch
         let pm = ProjectManager(
             lspSettings: lspSettings,
-            agentTaskRegistry: agentTasks
+            agentProcessSnapshotPoller: agentProcessSnapshotPoller,
+            agentTaskRegistry: agentTasks,
+            contextFileWriter: ContextFileWriter(
+                presentationGate: contextPresentationGate
+            ),
+            contextPresentationIdentity: ContextPresentationIdentity(
+                epoch: contextEpoch
+            )
         )
         if isAutoSaveFrozenForTermination {
             pm.freezeAutoSaveForTermination()
@@ -337,6 +406,17 @@ final class ProjectRegistry: LSPSettingsObserver {
         pm.loadDirectory(url: canonical, agentTaskProject: identity)
         openProjects[canonical] = pm
         agentTaskProjectsByRoot[canonical] = identity
+        if admitMissingProjectInBackground {
+            backgroundProjects.insert(canonical)
+            pm.suspendEditorServices()
+            agentTasks.setWindowOpen(false, project: identity)
+            pm.terminal.setAgentTaskWindowOpen(false)
+            enqueueBackgroundReclamationCandidate(canonical)
+            scheduleBackgroundReclamationIfNeeded()
+        } else {
+            agentTasks.setWindowOpen(true, project: identity)
+            pm.terminal.setAgentTaskWindowOpen(true)
+        }
         addToRecent(canonical)
         #if DEBUG
         seedAgentRecoveryUITestFixture(
@@ -360,6 +440,7 @@ final class ProjectRegistry: LSPSettingsObserver {
             return false
         }
         backgroundProjects.remove(canonical)
+        manager.resumeEditorServices()
         agentTasks.setWindowOpen(true, project: identity)
         manager.terminal.setAgentTaskWindowOpen(true)
         return true
@@ -569,13 +650,172 @@ final class ProjectRegistry: LSPSettingsObserver {
     /// sessions and user tasks continue in the background; reopening the
     /// project restores access to their current state and output history.
     func closeProjectWindow(_ url: URL) {
+        closeProjectWindow(
+            url,
+            expectedManager: nil,
+            expectedWindowGeneration: nil
+        )
+    }
+
+    /// Window-delegate close path. Both object identity and binding generation
+    /// must still match so a delayed close from window A cannot background a
+    /// replacement manager/window B registered for the same URL.
+    func closeProjectWindow(
+        _ url: URL,
+        expectedManager: ProjectManager?,
+        expectedWindowGeneration: UUID?
+    ) {
         let canonical = canonicalProjectURL(url)
-        guard openProjects[canonical] != nil else { return }
+        guard let manager = openProjects[canonical] else { return }
+        if let expectedManager, manager !== expectedManager { return }
+        if let expectedWindowGeneration,
+           manager.dialogOwnerWindowGeneration != expectedWindowGeneration {
+            return
+        }
+        manager.saveSession()
         backgroundProjects.insert(canonical)
+        manager.suspendEditorServices()
         if let identity = agentTaskProjectsByRoot[canonical] {
             agentTasks.setWindowOpen(false, project: identity)
         }
-        openProjects[canonical]?.terminal.setAgentTaskWindowOpen(false)
+        manager.terminal.setAgentTaskWindowOpen(false)
+        enqueueBackgroundReclamationCandidate(canonical)
+        scheduleBackgroundReclamationIfNeeded()
+    }
+
+    /// Reclaims one bounded set of editor-only background managers. Process,
+    /// launch, agent, and user-task evidence all fail closed and keep the exact
+    /// manager alive for the next pass.
+    func runBackgroundReclamationPassForTesting() {
+        let hasMoreInCycle = reclaimIdleBackgroundProjects()
+        scheduleBackgroundReclamationIfNeeded(
+            delayUntilNextCycle: !hasMoreInCycle
+        )
+    }
+
+    #if DEBUG
+    var agentSnapshotSubscriberCountForTesting: Int {
+        agentProcessSnapshotPoller.subscriberCountForTesting
+    }
+
+    func runAgentProcessSnapshotForTesting() {
+        agentProcessSnapshotPoller.runSnapshotForTesting()
+    }
+    #endif
+
+    /// Processes at most one fixed-size batch. Retained projects rotate to the
+    /// next delayed cycle; remaining candidates in the current cycle continue
+    /// on later MainActor turns without another 30-second delay.
+    @discardableResult
+    private func reclaimIdleBackgroundProjects() -> Bool {
+        guard !isProjectAdmissionFrozenForTermination,
+              !isAutoSaveFrozenForTermination else { return false }
+        if backgroundReclamationCycleRemaining == 0 {
+            backgroundReclamationCycleRemaining =
+                backgroundReclamationQueuedURLs.count
+        }
+        let candidateLimit = min(
+            backgroundReclamationBatchSize,
+            backgroundReclamationCycleRemaining
+        )
+        var processedCount = 0
+        for _ in 0..<candidateLimit {
+            guard let canonical = dequeueBackgroundReclamationCandidate() else {
+                backgroundReclamationCycleRemaining = 0
+                break
+            }
+            backgroundReclamationCycleRemaining -= 1
+            processedCount += 1
+            guard let manager = openProjects[canonical],
+                  backgroundProjects.contains(canonical) else {
+                continue
+            }
+            guard backgroundPresentationLeases[canonical]?.isEmpty != false,
+                  !manager.requiresBackgroundRetention else {
+                enqueueBackgroundReclamationCandidate(canonical)
+                continue
+            }
+            manager.saveSession()
+            manager.shutdownReclaimableProject()
+            openProjects.removeValue(forKey: canonical)
+            agentTaskProjectsByRoot.removeValue(forKey: canonical)
+            backgroundProjects.remove(canonical)
+        }
+        #if DEBUG
+        lastReclaimPassCountForTesting = processedCount
+        #endif
+        return backgroundReclamationCycleRemaining > 0
+    }
+
+    private func enqueueBackgroundReclamationCandidate(_ canonical: URL) {
+        guard backgroundReclamationQueuedURLs.insert(canonical).inserted else {
+            return
+        }
+        let queueID = nextBackgroundReclamationQueueID
+        nextBackgroundReclamationQueueID &+= 1
+        backgroundReclamationQueue[queueID] = canonical
+    }
+
+    private func dequeueBackgroundReclamationCandidate() -> URL? {
+        while nextBackgroundReclamationDequeueID
+                < nextBackgroundReclamationQueueID {
+            let queueID = nextBackgroundReclamationDequeueID
+            nextBackgroundReclamationDequeueID &+= 1
+            guard let canonical = backgroundReclamationQueue.removeValue(
+                forKey: queueID
+            ), backgroundReclamationQueuedURLs.remove(canonical) != nil else {
+                continue
+            }
+            return canonical
+        }
+        return nil
+    }
+
+    private func scheduleBackgroundReclamationIfNeeded(
+        delayUntilNextCycle: Bool = true
+    ) {
+        guard backgroundReclamationTask == nil,
+              !backgroundReclamationQueuedURLs.isEmpty,
+              !isProjectAdmissionFrozenForTermination,
+              !isAutoSaveFrozenForTermination else { return }
+        let interval = backgroundReclamationInterval
+        backgroundReclamationTask = Task { @MainActor [weak self] in
+            if delayUntilNextCycle {
+                try? await Task.sleep(for: interval)
+            } else {
+                await Task.yield()
+            }
+            guard let self, !Task.isCancelled else { return }
+            backgroundReclamationTask = nil
+            let hasMoreInCycle = reclaimIdleBackgroundProjects()
+            scheduleBackgroundReclamationIfNeeded(
+                delayUntilNextCycle: !hasMoreInCycle
+            )
+        }
+    }
+
+    @discardableResult
+    func retainBackgroundProjectForPresentation(
+        _ url: URL,
+        manager: ProjectManager
+    ) -> UUID? {
+        let canonical = canonicalProjectURL(url)
+        guard openProjects[canonical] === manager else { return nil }
+        let leaseID = UUID()
+        backgroundPresentationLeases[canonical, default: []].insert(leaseID)
+        return leaseID
+    }
+
+    func releaseBackgroundProjectPresentation(
+        _ leaseID: UUID,
+        for url: URL
+    ) {
+        let canonical = canonicalProjectURL(url)
+        backgroundPresentationLeases[canonical]?.remove(leaseID)
+        if backgroundPresentationLeases[canonical]?.isEmpty == true {
+            backgroundPresentationLeases[canonical] = nil
+        }
+        scheduleBackgroundReclamationIfNeeded()
     }
 
     /// Closes a project and removes it from open projects.
@@ -652,9 +892,7 @@ final class ProjectRegistry: LSPSettingsObserver {
             fileURLWithPath: task.project.canonicalWorktreePath,
             isDirectory: true
         )
-        let projectURL = await Task.detached {
-            Self.canonicalProjectURL(rawURL)
-        }.value
+        let projectURL = await agentInboxProjectCanonicalizer(rawURL)
         guard let currentTask = agentTasks.task(for: taskID),
               currentTask == task,
               currentTask.lifecycle == .active,
@@ -740,11 +978,9 @@ final class ProjectRegistry: LSPSettingsObserver {
             fileURLWithPath: initialTask.project.canonicalWorktreePath,
             isDirectory: true
         )
-        let projectURL = await Task.detached {
-            Self.canonicalProjectURL(rawURL)
-        }.value
+        let projectURL = await agentInboxProjectCanonicalizer(rawURL)
         guard projectURL.path == initialTask.project.canonicalWorktreePath,
-              let manager = await ensureAgentInboxProjectPresented(
+              let presentation = await ensureAgentInboxProjectPresented(
                 initialTask,
                 at: projectURL,
                 openProjectWindow: openProjectWindow,
@@ -752,6 +988,8 @@ final class ProjectRegistry: LSPSettingsObserver {
               ) else {
             return .projectUnavailable
         }
+        let manager = presentation.manager
+        defer { finishAgentInboxPresentation(presentation) }
 
         guard let route = await resolveAgentTaskRoute(taskID),
               let currentTask = agentTasks.task(for: taskID),
@@ -766,7 +1004,7 @@ final class ProjectRegistry: LSPSettingsObserver {
                   taskID: taskID,
                   terminalID: route.terminalID,
                   runID: run.id
-              ) else {
+              ), presentationIsCurrent(presentation) else {
             return .routeStale
         }
 
@@ -811,11 +1049,9 @@ final class ProjectRegistry: LSPSettingsObserver {
             fileURLWithPath: initialTask.project.canonicalWorktreePath,
             isDirectory: true
         )
-        let projectURL = await Task.detached {
-            Self.canonicalProjectURL(rawURL)
-        }.value
+        let projectURL = await agentInboxProjectCanonicalizer(rawURL)
         guard projectURL.path == initialTask.project.canonicalWorktreePath,
-              let manager = await ensureAgentInboxProjectPresented(
+              let presentation = await ensureAgentInboxProjectPresented(
                 initialTask,
                 at: projectURL,
                 openProjectWindow: openProjectWindow,
@@ -823,6 +1059,8 @@ final class ProjectRegistry: LSPSettingsObserver {
               ) else {
             return .projectUnavailable
         }
+        let manager = presentation.manager
+        defer { finishAgentInboxPresentation(presentation) }
         guard agentTasks.task(for: taskID) == initialTask else {
             return .changedWhilePreparing
         }
@@ -841,6 +1079,14 @@ final class ProjectRegistry: LSPSettingsObserver {
             return .launchRejected
         }
 
+        // No suspension occurs between this full ownership fence and launch.
+        // A concurrent presentation, stale close, reclaim, task mutation, or
+        // owner replacement therefore cannot launch into an obsolete manager.
+        guard !Task.isCancelled,
+              agentTasks.task(for: taskID) == initialTask,
+              presentationIsCurrent(presentation) else {
+            return .changedWhilePreparing
+        }
         let result = manager.terminal.launchAgentRecovery(plan)
         let terminalID: UUID
         switch result {
@@ -883,33 +1129,109 @@ final class ProjectRegistry: LSPSettingsObserver {
         at projectURL: URL,
         openProjectWindow: @escaping @MainActor (URL) -> Void,
         waitUntilPresented: (@MainActor (ProjectManager) async -> Bool)?
-    ) async -> ProjectManager? {
-        let requiresPresentation = task.route.availability == .background
-            || !isWindowOpen(projectURL)
-        guard let manager = projectManager(
-            for: task.project,
-            reopenBackgroundProject: false
-        ), manager.rootURL == projectURL else {
+    ) async -> AgentInboxPresentationAuthorization? {
+        // Canonicalization suspends the caller. Revalidate the value snapshot
+        // before retained lookup can admit/background a manager or disturb a
+        // window that another operation opened while that await was pending.
+        let canonicalProjectIdentityURL = canonicalProjectURL(URL(
+            fileURLWithPath: task.project.canonicalProjectPath,
+            isDirectory: true
+        ))
+        guard !Task.isCancelled,
+              agentTasks.task(for: task.id) == task,
+              projectURL.path == task.project.canonicalWorktreePath,
+              canonicalProjectIdentityURL.path
+                == task.project.canonicalProjectPath else {
             return nil
+        }
+        let manager: ProjectManager
+        if let existing = openProjects[projectURL] {
+            guard agentTaskProjectsByRoot[projectURL] == task.project,
+                  existing.rootURL == projectURL else {
+                return nil
+            }
+            manager = existing
+        } else {
+            guard let admitted = projectManager(
+                for: task.project,
+                reopenBackgroundProject: false,
+                admitMissingProjectInBackground: true
+            ), admitted.rootURL == projectURL,
+                agentTasks.task(for: task.id) == task,
+                agentTaskProjectsByRoot[projectURL] == task.project else {
+                return nil
+            }
+            manager = admitted
+        }
+        let hasEligibleCurrentOwner = manager.dialogOwnerWindow.map {
+            DialogPresenter.isEligibleApplicationOwner($0)
+        } == true
+        let requiresPresentation = backgroundProjects.contains(projectURL)
+            || !isWindowOpen(projectURL)
+            || !hasEligibleCurrentOwner
+        let operationID = UUID()
+        agentInboxPresentationOperations[projectURL] = operationID
+        guard let presentationLease = retainBackgroundProjectForPresentation(
+            projectURL,
+            manager: manager
+        ) else {
+            if agentInboxPresentationOperations[projectURL] == operationID {
+                agentInboxPresentationOperations[projectURL] = nil
+            }
+            return nil
+        }
+        var transfersAuthorization = false
+        defer {
+            if !transfersAuthorization {
+                releaseBackgroundProjectPresentation(
+                    presentationLease,
+                    for: projectURL
+                )
+                if agentInboxPresentationOperations[projectURL] == operationID {
+                    agentInboxPresentationOperations[projectURL] = nil
+                }
+            }
         }
 
         if requiresPresentation {
+            guard !Task.isCancelled,
+                  agentTasks.task(for: task.id) == task,
+                  openProjects[projectURL] === manager,
+                  agentTaskProjectsByRoot[projectURL] == task.project else {
+                return nil
+            }
             // A previously unknown durable project is admitted by lookup but
             // still has no window. Keep that new manager transactional too.
-            closeProjectWindow(projectURL)
+            manager.prepareForWindowPresentation()
+            closeProjectWindow(
+                projectURL,
+                expectedManager: manager,
+                expectedWindowGeneration: nil
+            )
             openProjectWindow(projectURL)
         }
-        let presented = if let waitUntilPresented {
-            await waitUntilPresented(manager)
+        let presentationReported: Bool
+        if let waitUntilPresented {
+            presentationReported = await waitUntilPresented(manager)
         } else {
-            await manager.awaitDialogOwnerWindow() != nil
+            presentationReported = await manager.awaitDialogOwnerWindow() != nil
         }
-        guard presented, !Task.isCancelled else {
-            if requiresPresentation
-                || manager.dialogOwnerWindow.map({
-                    !DialogPresenter.isEligibleApplicationOwner($0)
-                }) != false {
-                closeProjectWindow(projectURL)
+        guard presentationReported,
+              !Task.isCancelled,
+              agentInboxPresentationOperations[projectURL] == operationID,
+              openProjects[projectURL] === manager,
+              agentTaskProjectsByRoot[projectURL] == task.project,
+              let ownerWindow = manager.dialogOwnerWindow,
+              DialogPresenter.isEligibleApplicationOwner(ownerWindow) else {
+            if requiresPresentation,
+               backgroundProjects.contains(projectURL),
+               agentInboxPresentationOperations[projectURL] == operationID {
+                closeProjectWindow(
+                    projectURL,
+                    expectedManager: manager,
+                    expectedWindowGeneration:
+                        manager.dialogOwnerWindowGeneration
+                )
             }
             return nil
         }
@@ -920,7 +1242,51 @@ final class ProjectRegistry: LSPSettingsObserver {
         ) else {
             return nil
         }
-        return manager
+        let authorization = AgentInboxPresentationAuthorization(
+            projectURL: projectURL,
+            projectIdentity: task.project,
+            manager: manager,
+            operationID: operationID,
+            leaseID: presentationLease,
+            ownerWindow: ownerWindow,
+            ownerWindowGeneration: manager.dialogOwnerWindowGeneration
+        )
+        transfersAuthorization = true
+        return authorization
+    }
+
+    private func presentationIsCurrent(
+        _ authorization: AgentInboxPresentationAuthorization
+    ) -> Bool {
+        !Task.isCancelled
+            && agentInboxPresentationOperations[authorization.projectURL]
+                == authorization.operationID
+            && openProjects[authorization.projectURL]
+                === authorization.manager
+            && agentTaskProjectsByRoot[authorization.projectURL]
+                == authorization.projectIdentity
+            && !backgroundProjects.contains(authorization.projectURL)
+            && authorization.manager.presentationLifecycle == .visible
+            && authorization.manager.dialogOwnerWindow
+                === authorization.ownerWindow
+            && authorization.manager.dialogOwnerWindowGeneration
+                == authorization.ownerWindowGeneration
+            && DialogPresenter.isEligibleApplicationOwner(
+                authorization.ownerWindow
+            )
+    }
+
+    private func finishAgentInboxPresentation(
+        _ authorization: AgentInboxPresentationAuthorization
+    ) {
+        releaseBackgroundProjectPresentation(
+            authorization.leaseID,
+            for: authorization.projectURL
+        )
+        if agentInboxPresentationOperations[authorization.projectURL]
+                == authorization.operationID {
+            agentInboxPresentationOperations[authorization.projectURL] = nil
+        }
     }
 
     private func resolveAgentRecoveryTerminal(
@@ -961,9 +1327,7 @@ final class ProjectRegistry: LSPSettingsObserver {
             fileURLWithPath: task.project.canonicalWorktreePath,
             isDirectory: true
         )
-        let projectURL = await Task.detached {
-            Self.canonicalProjectURL(rawURL)
-        }.value
+        let projectURL = await agentInboxProjectCanonicalizer(rawURL)
         guard let currentTask = agentTasks.task(for: task.id),
               currentTask == task,
               agentTasks.canResumeTask(task.id),
@@ -997,6 +1361,8 @@ final class ProjectRegistry: LSPSettingsObserver {
 
     func freezeAgentTasksForTermination() {
         isProjectAdmissionFrozenForTermination = true
+        backgroundReclamationTask?.cancel()
+        backgroundReclamationTask = nil
         for manager in openProjects.values {
             manager.terminal.freezeAgentTasksForTermination()
         }
@@ -1008,6 +1374,11 @@ final class ProjectRegistry: LSPSettingsObserver {
     func freezeAutoSaveForTermination() {
         guard !isAutoSaveFrozenForTermination else { return }
         isAutoSaveFrozenForTermination = true
+        // This is the first mutation in the Quit transaction, before human
+        // decisions and inventory capture. Freeze reclamation here so that
+        // captured project/tab ownership cannot disappear mid-handshake.
+        backgroundReclamationTask?.cancel()
+        backgroundReclamationTask = nil
         openProjects.values.forEach { $0.freezeAutoSaveForTermination() }
         detachedTaskCleanupProjects.values.forEach {
             $0.freezeAutoSaveForTermination()
@@ -1060,6 +1431,7 @@ final class ProjectRegistry: LSPSettingsObserver {
         detachedTaskCleanupProjects.values.forEach {
             $0.cancelAutoSaveTerminationFreeze()
         }
+        scheduleBackgroundReclamationIfNeeded()
     }
 
     func finishAutoSaveTerminationFreeze() {
@@ -1097,6 +1469,7 @@ final class ProjectRegistry: LSPSettingsObserver {
             manager.terminal.cancelAgentTaskTermination()
         }
         isProjectAdmissionFrozenForTermination = false
+        scheduleBackgroundReclamationIfNeeded()
         return rollbackWasSaved
     }
 
@@ -1285,9 +1658,16 @@ final class ProjectRegistry: LSPSettingsObserver {
 
         lspSettingsChangeTask?.cancel()
         lspSettingsChangeTask = nil
+        backgroundReclamationTask?.cancel()
+        backgroundReclamationTask = nil
+        backgroundReclamationQueue.removeAll()
+        backgroundReclamationQueuedURLs.removeAll()
+        backgroundReclamationCycleRemaining = 0
+        backgroundPresentationLeases.removeAll()
+        agentInboxPresentationOperations.removeAll()
         for (_, pm) in openProjects {
             pm.terminal.terminateAll()
-            pm.shutdownLanguageServers()
+            pm.shutdownReclaimableProject()
         }
         openProjects.removeAll()
         agentTaskProjectsByRoot.removeAll()

--- a/Pine/RecoveryManager.swift
+++ b/Pine/RecoveryManager.swift
@@ -391,6 +391,9 @@ final class RecoveryManager {
         periodicTimer = nil
     }
 
+    /// Internal lifecycle observability for project suspend/resume tests.
+    var isPeriodicSnapshotting: Bool { periodicTimer != nil }
+
     /// Schedules a debounced snapshot (5 seconds after last edit).
     func scheduleSnapshot() {
         // Lazily create the debouncer (captures self weakly).

--- a/Pine/SidebarFileTree.swift
+++ b/Pine/SidebarFileTree.swift
@@ -327,9 +327,6 @@ private struct SidebarFileTreeNode: View {
         requestKeyboardFocus: Bool
     ) {
         selection = node
-        if requestKeyboardFocus {
-            onKeyboardFocusRequested()
-        }
         navigation.resetTypeAhead()
         if !expansion.isExpanded(node.url) {
             loadDeferredChildrenIfNeeded()
@@ -339,6 +336,12 @@ private struct SidebarFileTreeNode: View {
             expansion: expansion,
             debounced: debounced
         )
+        if requestKeyboardFocus {
+            // Queue the responder retry only after disclosure has invalidated
+            // the SwiftUI tree. That makes the retry follow reconciliation
+            // instead of being displaced by it on accessibility presses.
+            onKeyboardFocusRequested()
+        }
     }
 
     private func setFolderExpanded(_ expanded: Bool) {

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -146,6 +146,10 @@ final class TerminalManager {
     /// the macos-26 fork/spawn hang, #1060). Read once at boot; stored
     /// privately so it cannot be mutated after construction.
     private let agentDetectionProcessRunner: ProcessRunner
+    /// Shared in production so every project consumes one machine-wide `ps`
+    /// snapshot. Nil for standalone managers, which retain their private-poller
+    /// test seam through `agentDetectionProcessRunner`.
+    private let agentProcessSnapshotPoller: AgentProcessSnapshotPoller?
 
     /// Application-lifetime registry and canonical project scope. The
     /// registry itself retains value metadata only; terminal objects retain no
@@ -155,6 +159,10 @@ final class TerminalManager {
     private var agentTaskProject: AgentTaskProjectIdentity?
     @ObservationIgnored
     private var agentTaskCallbacksFrozen = false
+    /// Final project teardown is irreversible. Stale view/layout callbacks may
+    /// still reference this coordinator, but they cannot create, activate, or
+    /// start terminal work after invalidation.
+    private(set) var isPermanentlyInvalidated = false
     @ObservationIgnored
     private var agentTaskWindowOpen = true
     @ObservationIgnored
@@ -198,6 +206,11 @@ final class TerminalManager {
     /// test hook. Delegates to the coordinator's `isRunning` so it correctly
     /// reports `false` after a future `stop()`.
     var isAgentDetectionPolling: Bool { agentCoordinator?.isRunning ?? false }
+    #if DEBUG
+    var receivedAgentSnapshotCountForTesting: Int {
+        agentCoordinator?.receivedSnapshotCountForTesting ?? 0
+    }
+    #endif
 
     /// Coordinator that polls `ps` off the main thread and reconciles agent
     /// sessions with terminal tabs. Started lazily by
@@ -213,9 +226,11 @@ final class TerminalManager {
     /// injection pattern used by `ExternalFileFormatter` / `FileFormatter`.
     init(
         agentDetectionProcessRunner: @escaping ProcessRunner = runRealProcess,
+        agentProcessSnapshotPoller: AgentProcessSnapshotPoller? = nil,
         agentTaskRegistry: AgentTaskRegistry? = nil
     ) {
         self.agentDetectionProcessRunner = agentDetectionProcessRunner
+        self.agentProcessSnapshotPoller = agentProcessSnapshotPoller
         self.agentTaskRegistry = agentTaskRegistry
     }
 
@@ -237,6 +252,7 @@ final class TerminalManager {
     /// Receives an already validated identity from `ProjectRegistry`; this
     /// method performs no filesystem work on MainActor.
     func configureAgentTaskProject(_ project: AgentTaskProjectIdentity) {
+        guard !isPermanentlyInvalidated else { return }
         if let agentTaskProject, agentTaskProject != project {
             ownedAgentHistoryLedger.removeAll()
             ownedAgentHistoryOrder.removeAll()
@@ -253,10 +269,15 @@ final class TerminalManager {
     }
 
     func setAgentTaskWindowOpen(_ isOpen: Bool) {
+        guard !isPermanentlyInvalidated else { return }
         agentTaskWindowOpen = isOpen
     }
 
     func configureAgentLifecycle(for tab: TerminalTab) {
+        guard !isPermanentlyInvalidated else {
+            tab.stop()
+            return
+        }
         guard let agentTaskRegistry, let project = agentTaskProject else { return }
         tab.onLifecycleEnded = { [weak self, weak agentTaskRegistry] terminalID in
             if let reservation = self?.launchReservations.removeValue(
@@ -274,6 +295,7 @@ final class TerminalManager {
     }
 
     func agentTerminalDidMove(_ tab: TerminalTab, to paneID: PaneID) {
+        guard !isPermanentlyInvalidated else { return }
         if let project = agentTaskProject {
             agentTaskRegistry?.updateRoute(
                 terminalID: tab.id,
@@ -341,7 +363,8 @@ final class TerminalManager {
     /// PaneManager atomically selects the requested pane-local tab.
     @discardableResult
     func activateTerminal(paneID: PaneID, tabID: UUID) -> Bool {
-        guard let paneManager,
+        guard !isPermanentlyInvalidated,
+              let paneManager,
               paneManager.terminalPaneIDs.contains(paneID),
               let state = paneManager.terminalState(for: paneID),
               state.terminalTabs.contains(where: { $0.id == tabID }),
@@ -390,7 +413,8 @@ final class TerminalManager {
     /// tab remains owned by the same terminal pane.
     @discardableResult
     func sendText(_ text: String, to destination: Destination) -> Bool {
-        guard let paneManager,
+        guard !isPermanentlyInvalidated,
+              let paneManager,
               paneManager.terminalPaneIDs.contains(destination.paneID),
               let state = paneManager.terminalState(for: destination.paneID),
               state.activeTerminalID == destination.tab.id,
@@ -411,6 +435,7 @@ final class TerminalManager {
     /// Invalid persisted preferences fall back to the first valid terminal in
     /// stable tree order and an empty terminal inventory restores `nil`.
     func restoreTerminalDestination(preferredPaneID: PaneID?) {
+        guard !isPermanentlyInvalidated else { return }
         guard let paneManager else {
             lastActiveTerminalPaneID = nil
             return
@@ -430,7 +455,8 @@ final class TerminalManager {
     }
 
     func agentTaskContext(for tab: TerminalTab) -> AgentTaskBridgeContext? {
-        guard let paneManager,
+        guard !isPermanentlyInvalidated,
+              let paneManager,
               let project = agentTaskProject,
               let paneID = paneManager.terminalPaneIDs.first(where: { paneID in
                   paneManager.terminalState(for: paneID)?
@@ -459,7 +485,8 @@ final class TerminalManager {
         in tab: TerminalTab,
         reservation: AgentTaskLaunchReservation? = nil
     ) {
-        guard !agentTaskCallbacksFrozen,
+        guard !isPermanentlyInvalidated,
+              !agentTaskCallbacksFrozen,
               let base = agentTaskContext(for: tab),
               let agentTaskRegistry else { return }
         let ownedReservation = reservation ?? launchReservations[tab.id]
@@ -612,7 +639,8 @@ final class TerminalManager {
         title: String? = nil,
         objective: String? = nil
     ) -> AgentTaskLaunchResult {
-        guard !agentTaskCallbacksFrozen,
+        guard !isPermanentlyInvalidated,
+              !agentTaskCallbacksFrozen,
               let base = agentTaskContext(for: tab),
               let agentTaskRegistry else { return .rejected }
         if let reservation = launchReservations[tab.id] {
@@ -780,7 +808,8 @@ final class TerminalManager {
         command: String,
         in tab: TerminalTab
     ) async -> AgentTaskLaunchResult {
-        guard let agentTaskRegistry,
+        guard !isPermanentlyInvalidated,
+              let agentTaskRegistry,
               let task = agentTaskRegistry.task(for: taskID),
               task.descriptor.launchExecutable == command,
               Self.exactAgentLaunchDescriptor(for: command) == task.descriptor,
@@ -818,7 +847,8 @@ final class TerminalManager {
         taskID: UUID,
         in tab: TerminalTab
     ) -> AgentTaskLaunchResult {
-        guard !agentTaskCallbacksFrozen,
+        guard !isPermanentlyInvalidated,
+              !agentTaskCallbacksFrozen,
               let base = agentTaskContext(for: tab),
               let agentTaskRegistry else { return .rejected }
         if let reservation = launchReservations[tab.id] {
@@ -870,7 +900,8 @@ final class TerminalManager {
     }
 
     func cancelAgentTaskTermination() {
-        guard agentTaskCallbacksFrozen else { return }
+        guard !isPermanentlyInvalidated,
+              agentTaskCallbacksFrozen else { return }
         agentTaskCallbacksFrozen = false
         acknowledgedAgentLaunches.removeAll()
         if paneManager?.allTerminalTabs.isEmpty == false {
@@ -891,7 +922,8 @@ final class TerminalManager {
     func launchAgentRecovery(
         _ plan: AgentTaskRecoveryPlan
     ) -> AgentTaskRecoveryLaunchResult {
-        guard let pm = paneManager,
+        guard !isPermanentlyInvalidated,
+              let pm = paneManager,
               let project = agentTaskProject,
               project == plan.project,
               project.canonicalWorktreePath
@@ -965,7 +997,8 @@ final class TerminalManager {
         in paneID: PaneID,
         workingDirectory: URL?
     ) -> TerminalTab? {
-        guard let pm = paneManager,
+        guard !isPermanentlyInvalidated,
+              let pm = paneManager,
               pm.terminalPaneIDs.contains(paneID) else { return nil }
         ensureAgentDetectionStarted()
         guard let tab = pm.addTerminalTab(
@@ -982,7 +1015,7 @@ final class TerminalManager {
     /// Creates a terminal tab in the last-used terminal pane.
     /// If no terminal pane exists, creates one below the given editor pane.
     func createTerminalTab(relativeTo editorPaneID: PaneID, workingDirectory: URL?) {
-        guard let pm = paneManager else { return }
+        guard !isPermanentlyInvalidated, let pm = paneManager else { return }
         // Boot agent detection on the first terminal creation. Idempotent —
         // the guard inside makes repeated calls a no-op. The coordinator
         // lives for the lifetime of this `TerminalManager` and reconciles
@@ -1014,7 +1047,7 @@ final class TerminalManager {
 
     /// Focuses the nearest terminal pane, or creates one.
     func focusOrCreateTerminal(relativeTo editorPaneID: PaneID, workingDirectory: URL?) {
-        guard paneManager != nil else { return }
+        guard !isPermanentlyInvalidated, paneManager != nil else { return }
 
         if let destination = resolvedDestination() {
             _ = activateTerminal(
@@ -1192,6 +1225,21 @@ final class TerminalManager {
         allTerminalTabs.contains { $0.hasForegroundProcess }
     }
 
+    /// Exact process/launch evidence that requires a background project to
+    /// retain its terminal objects. Stale agent evidence is uncertainty and
+    /// therefore fails closed until a later successful shared snapshot.
+    var requiresBackgroundRetention: Bool {
+        !launchReservations.isEmpty
+            || !launchWritesInFlight.isEmpty
+            || !acknowledgedAgentLaunches.isEmpty
+            || allTerminalTabs.contains { tab in
+                tab.isProcessRunning
+                    || tab.agentSession.map {
+                        $0.liveness != .terminated
+                    } == true
+            }
+    }
+
     var tabsWithForegroundProcesses: [TerminalTab] {
         allTerminalTabs.filter { $0.hasForegroundProcess }
     }
@@ -1203,7 +1251,7 @@ final class TerminalManager {
     }
 
     func startTerminals(workingDirectory: URL?) {
-        guard let pm = paneManager else { return }
+        guard !isPermanentlyInvalidated, let pm = paneManager else { return }
         for state in pm.terminalStates.values {
             state.startTabs(workingDirectory: workingDirectory)
         }
@@ -1228,20 +1276,49 @@ final class TerminalManager {
     /// creates tabs via `state.addTab` directly, bypassing `createTerminalTab`).
     /// Internal rather than private so the restore path can reach it.
     func ensureAgentDetectionStarted() {
-        guard agentCoordinator == nil else { return }
+        guard !isPermanentlyInvalidated,
+              !agentTaskCallbacksFrozen,
+              agentCoordinator == nil else { return }
         // Allow UI tests (and users hitting the macos-26 fork/spawn hang,
         // #1060) to disable the coordinator entirely. Without this gate the
         // repeated 2s `ps` fork hangs the terminal UI-test shards on macos-26
         // runners — unit tests inject a no-op runner instead, so they do not
         // set this flag and still exercise the boot path.
         if Self.isAgentDetectionDisabled { return }
-        let coord = AgentDetectionCoordinator(
-            detector: agentDetector,
-            terminalManager: self,
-            processRunner: agentDetectionProcessRunner
-        )
+        let coord: AgentDetectionCoordinator
+        if let agentProcessSnapshotPoller {
+            coord = AgentDetectionCoordinator(
+                detector: agentDetector,
+                terminalManager: self,
+                poller: agentProcessSnapshotPoller
+            )
+        } else {
+            coord = AgentDetectionCoordinator(
+                detector: agentDetector,
+                terminalManager: self,
+                processRunner: agentDetectionProcessRunner
+            )
+        }
         agentCoordinator = coord
         coord.start()
+    }
+
+    /// Removes this project from application-wide process observation. Final
+    /// reclamation calls this only after proving no live/stale process owner
+    /// remains, so clearing tab-local detector state cannot lose live work.
+    func shutdownAgentDetection() {
+        agentCoordinator?.stop()
+        agentCoordinator = nil
+    }
+
+    /// Permanently tears down every PTY and rejects all later terminal work.
+    /// This is distinct from reversible project-window suspension.
+    func shutdownPermanently() {
+        guard !isPermanentlyInvalidated else { return }
+        isPermanentlyInvalidated = true
+        terminateAll()
+        agentTaskCallbacksFrozen = true
+        shutdownAgentDetection()
     }
 
     /// `true` when agent detection is explicitly disabled via the

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -2163,7 +2163,9 @@ final class TerminalTab: Identifiable, Hashable {
     /// the correct column/row count for the PTY. Starting with a zero frame
     /// causes a blank terminal (issue #661).
     func startIfNeeded() {
-        guard !processStarted else { return }
+        // Final project reclamation may race a delayed NSViewRepresentable
+        // update. A terminated tab is a tombstone and must never fork again.
+        guard !isTerminated, !processStarted else { return }
         guard terminalView.frame.size.width > 0,
               terminalView.frame.size.height > 0 else { return }
         processStarted = true

--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -8,6 +8,14 @@
 import os
 import SwiftUI
 
+@MainActor
+protocol WorkspaceFileWatching: AnyObject {
+    func watch(directory: URL)
+    func stop()
+}
+
+extension FileSystemWatcher: WorkspaceFileWatching {}
+
 /// Thread-safe result storage for parallel top-level `FileNode` construction.
 ///
 /// The specialized API keeps mutable storage behind a lock, so callers cannot
@@ -56,7 +64,11 @@ final class WorkspaceManager {
     weak var progressTracker: ProgressTracker?
     /// File-watcher lifecycle is driven on the main actor.
     /// `FileSystemWatcher.stop()` is itself thread-safe (uses queue.sync).
-    private var fileWatcher: FileSystemWatcher?
+    private var fileWatcher: (any WorkspaceFileWatching)?
+    private let fileWatcherFactory: (
+        @escaping @MainActor () -> Void
+    ) -> any WorkspaceFileWatching
+    private(set) var isSuspended = false
 
     /// Incremented on every file-watcher event so ContentView can trigger
     /// external change detection on open tabs.
@@ -78,6 +90,19 @@ final class WorkspaceManager {
 
     /// Continuations waiting for `isLoading` to become `false`.
     private var loadingContinuations: [CheckedContinuation<Void, Never>] = []
+
+    init(
+        fileWatcherFactory: @escaping (
+            @escaping @MainActor () -> Void
+        ) -> any WorkspaceFileWatching = { callback in
+            FileSystemWatcher(
+                debounceInterval: WorkspaceManager.watcherDebounce,
+                callback: callback
+            )
+        }
+    ) {
+        self.fileWatcherFactory = fileWatcherFactory
+    }
 
     /// Debounce interval for `onRootNodesChanged` notifications.
     private static let rootNodesChangedDebounce: TimeInterval = 0.2
@@ -129,6 +154,7 @@ final class WorkspaceManager {
     /// Schedules a debounced `onRootNodesChanged` notification.
     /// Cancels any pending notification so rapid updates coalesce into one.
     private func notifyRootNodesChanged() {
+        guard !isSuspended else { return }
         // Lazily create the debouncer (captures self weakly).
         if rootNodesChangedDebouncer == nil {
             rootNodesChangedDebouncer = Debouncer(
@@ -185,6 +211,7 @@ final class WorkspaceManager {
     }
 
     func loadDirectory(url: URL) {
+        isSuspended = false
         // Stop old watcher immediately so it cannot fire events
         // that would bump loadGeneration and race with the new load.
         fileWatcher?.stop()
@@ -228,10 +255,11 @@ final class WorkspaceManager {
         // (or any external process) appear in the sidebar almost immediately.
         // The previous default (500ms) combined with the watcher's own event
         // coalescing made the sidebar feel unresponsive to shell commands.
-        let watcher = FileSystemWatcher(debounceInterval: Self.watcherDebounce) { [weak self] in
+        let watcher = fileWatcherFactory { [weak self] in
             // This closure runs on main (guaranteed by FileSystemWatcher).
-            self?.externalChangeToken += 1
-            self?.refreshFileTreeAsync()
+            guard let self, !self.isSuspended else { return }
+            self.externalChangeToken += 1
+            self.refreshFileTreeAsync()
         }
         watcher.watch(directory: url)
         fileWatcher = watcher
@@ -374,6 +402,12 @@ final class WorkspaceManager {
                     if let progressID { self?.progressTracker?.endOperation(progressID) }
                     return
                 }
+                guard !self.isSuspended else {
+                    if let progressID {
+                        self.progressTracker?.endOperation(progressID)
+                    }
+                    return
+                }
                 let publishesShallowResult = presentation.publishesShallowResult(
                     shallowChildren,
                     replacing: self.rootNodes,
@@ -423,6 +457,12 @@ final class WorkspaceManager {
             await MainActor.run { [weak self] in
                 guard let self, self.loadGeneration == generation else {
                     if let progressID { self?.progressTracker?.endOperation(progressID) }
+                    return
+                }
+                guard !self.isSuspended else {
+                    if let progressID {
+                        self.progressTracker?.endOperation(progressID)
+                    }
                     return
                 }
                 self.setRootNodes(fullChildren)
@@ -546,7 +586,7 @@ final class WorkspaceManager {
     /// shallow cost is paid only for direct user mutations, which are
     /// infrequent, and not for every external FSEvents burst.
     func refreshFileTree() {
-        guard let url = rootURL else { return }
+        guard !isSuspended, let url = rootURL else { return }
         loadGeneration += 1
         let generation = loadGeneration
         let ignoredPaths = gitProvider.ignoredPaths
@@ -589,7 +629,7 @@ final class WorkspaceManager {
     /// removed; `loadGeneration` is enough to keep concurrent refreshes
     /// consistent and the duplicate cost of an echoed event is invisible.
     func refreshFileTreeAsync() {
-        guard let url = rootURL else { return }
+        guard !isSuspended, let url = rootURL else { return }
         loadGeneration += 1
         let generation = loadGeneration
         loadDirectoryContentsAsync(
@@ -599,4 +639,30 @@ final class WorkspaceManager {
             presentation: .refresh
         )
     }
+
+    /// Cancels invisible workspace work while preserving the last tree/git
+    /// snapshot for an instant retained-project reopen.
+    func suspend() {
+        guard !isSuspended else { return }
+        isSuspended = true
+        loadGeneration &+= 1
+        loadingTask?.cancel()
+        loadingTask = nil
+        fileWatcher?.stop()
+        fileWatcher = nil
+        rootNodesChangedDebouncer?.cancel()
+        isLoading = false
+        resumeLoadingContinuations()
+    }
+
+    /// Reinstalls one watcher and refreshes the preserved tree after reopen.
+    func resume() {
+        guard isSuspended else { return }
+        isSuspended = false
+        guard let url = rootURL else { return }
+        startWatching(url: url)
+        refreshFileTreeAsync()
+    }
+
+    var hasActiveFileWatcherForTesting: Bool { fileWatcher != nil }
 }

--- a/PineTests/AgentInboxTests.swift
+++ b/PineTests/AgentInboxTests.swift
@@ -3,9 +3,68 @@
 //  PineTests
 //
 
+import AppKit
 import Foundation
 import Testing
 @testable import Pine
+
+nonisolated private final class BlockingInboxProcessRunner: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var didEnter = false
+    private var isReleased = false
+
+    var hasEntered: Bool {
+        condition.withLock { didEnter }
+    }
+
+    func run() -> ProcessRunResult {
+        condition.lock()
+        didEnter = true
+        condition.broadcast()
+        while !isReleased {
+            condition.wait()
+        }
+        condition.unlock()
+        return ProcessRunResult(
+            stdout: "1.2.3\n",
+            stderr: "",
+            exitCode: 0,
+            timedOut: false
+        )
+    }
+
+    func release() {
+        condition.withLock {
+            isReleased = true
+            condition.broadcast()
+        }
+    }
+}
+
+private actor BlockingInboxProjectCanonicalizer {
+    private var entered = false
+    private var released = false
+
+    func canonicalize(_ url: URL) async -> URL {
+        entered = true
+        while !released {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        return ProjectRegistry.canonicalProjectURL(url)
+    }
+
+    func waitUntilEntered() async -> Bool {
+        for _ in 0..<200 {
+            if entered { return true }
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        return entered
+    }
+
+    func release() {
+        released = true
+    }
+}
 
 @MainActor
 struct AgentInboxTests {
@@ -319,6 +378,12 @@ struct AgentInboxTests {
         let taskID = try #require(taskRegistry.taskID(forSessionID: session.id))
         #expect(taskRegistry.task(for: taskID)?.isUnread == true)
         manager.terminal.lastActiveTerminalPaneID = firstPane
+        let presentationWindow = makeEligibleProjectWindow()
+        manager.bindDialogOwnerWindow(presentationWindow)
+        defer {
+            manager.unbindDialogOwnerWindow(presentationWindow)
+            presentationWindow.orderOut(nil)
+        }
 
         let focused = await projectRegistry.navigateToAgentTaskFromInbox(
             taskID,
@@ -335,6 +400,16 @@ struct AgentInboxTests {
         #expect(state.pendingFocusTabID == tab.id)
         #expect(manager.terminal.lastActiveTerminalPaneID == pane)
         #expect(taskRegistry.task(for: taskID)?.isUnread == false)
+
+        #expect(await projectRegistry.navigateToAgentTaskFromInbox(
+            taskID,
+            openProjectWindow: { _ in },
+            waitUntilPresented: { _ in false },
+            activateApplication: { _ in }
+        ) == .projectUnavailable)
+        let canonical = projectRegistry.canonicalProjectURL(fixture.project)
+        #expect(projectRegistry.openProjects[canonical] === manager)
+        #expect(!projectRegistry.backgroundProjects.contains(canonical))
 
         session.applyLiveness(.terminated)
         let replacement = makeSession(seed: 41, state: .executing)
@@ -384,6 +459,12 @@ struct AgentInboxTests {
             runID: original.id,
             processGeneration: 45
         )
+        let presentationWindow = makeEligibleProjectWindow()
+        manager.bindDialogOwnerWindow(presentationWindow)
+        defer {
+            manager.unbindDialogOwnerWindow(presentationWindow)
+            presentationWindow.orderOut(nil)
+        }
 
         let result = await projectRegistry.navigateToAgentTaskFromInbox(
             taskID,
@@ -431,11 +512,32 @@ struct AgentInboxTests {
         let taskID = try #require(taskRegistry.taskID(forSessionID: session.id))
         projectRegistry.closeProjectWindow(fixture.project)
         var openedURL: URL?
+        var presentationWindow: NSWindow?
+        defer {
+            if let presentationWindow {
+                manager.unbindDialogOwnerWindow(presentationWindow)
+                presentationWindow.orderOut(nil)
+            }
+        }
 
         let result = await projectRegistry.navigateToAgentTaskFromInbox(
             taskID,
             openProjectWindow: { openedURL = $0 },
-            waitUntilPresented: { _ in true },
+            waitUntilPresented: { recoveredManager in
+                #expect(recoveredManager === manager)
+                let window = self.makeEligibleProjectWindow()
+                presentationWindow = window
+                recoveredManager.bindDialogOwnerWindow(window)
+                projectRegistry.runBackgroundReclamationPassForTesting()
+                await Task.yield()
+                #expect(projectRegistry.openProjects[
+                    projectRegistry.canonicalProjectURL(fixture.project)
+                ] === manager)
+                #expect(projectRegistry.backgroundProjects.contains(
+                    projectRegistry.canonicalProjectURL(fixture.project)
+                ))
+                return true
+            },
             activateApplication: { _ in }
         )
 
@@ -510,6 +612,12 @@ struct AgentInboxTests {
         )
         let historicalTask = try #require(taskRegistry.task(for: taskID))
         #expect(historicalTask.lifecycle == .paused)
+        let presentationWindow = makeEligibleProjectWindow()
+        manager.bindDialogOwnerWindow(presentationWindow)
+        defer {
+            manager.unbindDialogOwnerWindow(presentationWindow)
+            presentationWindow.orderOut(nil)
+        }
 
         let result = await projectRegistry.recoverAgentTaskFromInbox(
             taskID,
@@ -545,48 +653,55 @@ struct AgentInboxTests {
         )
         manager.terminal.lastActiveTerminalPaneID = pane
         let state = try #require(manager.paneManager.terminalState(for: pane))
-        let retainedTab = try #require(state.activeTab)
+        _ = try #require(state.activeTab)
         try await requireLoadedTask(pausedTask.id, in: taskRegistry)
 
-        let liveSession = makeSession(seed: 60, state: .executing)
-        manager.terminal.bridgeAgentSession(
-            liveSession,
-            replacing: nil,
-            in: retainedTab
-        )
-        retainedTab.agentSession = liveSession
-        let liveTaskID = try #require(
-            taskRegistry.taskID(forSessionID: liveSession.id)
-        )
         let retainedTerminalIDs = state.terminalTabs.map(\.id)
         let canonical = projectRegistry.canonicalProjectURL(fixture.project)
         projectRegistry.closeProjectWindow(fixture.project)
         let expectRetainedBackgroundState = {
             self.assertBackgroundRecoveryState(
                 projectRegistry: projectRegistry,
-                taskRegistry: taskRegistry,
                 projectURL: canonical,
-                liveTaskID: liveTaskID,
                 retained: (manager, state, retainedTerminalIDs)
             )
         }
         expectRetainedBackgroundState()
 
         var requestedURLs: [URL] = []
+        var presentationWindow: NSWindow?
+        defer {
+            if let presentationWindow {
+                manager.unbindDialogOwnerWindow(presentationWindow)
+                presentationWindow.orderOut(nil)
+            }
+        }
+        var cancellationWaitEntered = false
         let cancelledRecovery = Task { @MainActor in
             await projectRegistry.recoverAgentTaskFromInbox(
                 pausedTask.id,
                 action: .startNewSession,
                 openProjectWindow: { requestedURLs.append($0) },
                 waitUntilPresented: { recoveredManager in
+                    cancellationWaitEntered = true
                     #expect(recoveredManager === manager)
                     #expect(requestedURLs == [canonical])
                     expectRetainedBackgroundState()
-                    return true
+                    projectRegistry.runBackgroundReclamationPassForTesting()
+                    while !Task.isCancelled {
+                        try? await Task.sleep(for: .milliseconds(5))
+                    }
+                    return false
                 },
                 activateApplication: { _ in }
             )
         }
+        for _ in 0..<100 where !cancellationWaitEntered {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        try #require(cancellationWaitEntered)
+        projectRegistry.runBackgroundReclamationPassForTesting()
+        expectRetainedBackgroundState()
         cancelledRecovery.cancel()
         #expect(await cancelledRecovery.value == .projectUnavailable)
         expectRetainedBackgroundState()
@@ -614,6 +729,9 @@ struct AgentInboxTests {
                 #expect(recoveredManager === manager)
                 #expect(requestedURLs == [canonical, canonical, canonical])
                 expectRetainedBackgroundState()
+                let window = self.makeEligibleProjectWindow()
+                presentationWindow = window
+                recoveredManager.bindDialogOwnerWindow(window)
                 return true
             },
             activateApplication: { _ in }
@@ -625,8 +743,6 @@ struct AgentInboxTests {
         #expect(projectRegistry.openProjects[canonical] === manager)
         #expect(projectRegistry.isWindowOpen(canonical))
         #expect(!projectRegistry.backgroundProjects.contains(canonical))
-        #expect(taskRegistry.task(for: liveTaskID)?.route.availability
-                == .available)
         #expect(state.terminalTabs.map(\.id)
                 == retainedTerminalIDs + [recoveredTerminalID])
     }
@@ -692,6 +808,13 @@ struct AgentInboxTests {
         projectRegistry.closeProjectWindow(fixture.project)
 
         var requestedURL: URL?
+        var presentationWindow: NSWindow?
+        defer {
+            if let presentationWindow {
+                manager.unbindDialogOwnerWindow(presentationWindow)
+                presentationWindow.orderOut(nil)
+            }
+        }
         let result = await projectRegistry.recoverAgentTaskFromInbox(
             pausedTask.id,
             action: .resumeVendorSession,
@@ -703,6 +826,9 @@ struct AgentInboxTests {
                 #expect(projectRegistry.backgroundProjects.contains(canonical))
                 #expect(!projectRegistry.isWindowOpen(canonical))
                 #expect(state.terminalTabs.map(\.id) == retainedTerminalIDs)
+                let window = self.makeEligibleProjectWindow()
+                presentationWindow = window
+                recoveredManager.bindDialogOwnerWindow(window)
                 return true
             },
             activateApplication: { _ in }
@@ -721,6 +847,261 @@ struct AgentInboxTests {
             executablePath: executable.path,
             arguments: ["resume", "--session", "opaque-session-1423"]
         ))
+    }
+
+    @Test("failed presentation cannot roll back a newer successful operation")
+    func concurrentPresentationRollbackIsTokenQualified() async throws {
+        let fixture = try InboxProjectFixture()
+        defer { fixture.cleanup() }
+        let pausedTask = makePersistedRecoveryTask(projectURL: fixture.project)
+        let taskRegistry = AgentTaskRegistry(
+            persistence: InboxLoadedAgentTaskStore(tasks: [pausedTask])
+        )
+        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        manager.terminal.lastActiveTerminalPaneID = pane
+        let state = try #require(manager.paneManager.terminalState(for: pane))
+        let originalIDs = state.terminalTabs.map(\.id)
+        try await requireLoadedTask(pausedTask.id, in: taskRegistry)
+        let canonical = projectRegistry.canonicalProjectURL(fixture.project)
+        projectRegistry.closeProjectWindow(fixture.project)
+
+        var firstWaitEntered = false
+        var releaseFirstWait = false
+        let first = Task { @MainActor in
+            await projectRegistry.recoverAgentTaskFromInbox(
+                pausedTask.id,
+                action: .startNewSession,
+                openProjectWindow: { _ in },
+                waitUntilPresented: { _ in
+                    firstWaitEntered = true
+                    while !releaseFirstWait {
+                        try? await Task.sleep(for: .milliseconds(2))
+                    }
+                    return false
+                },
+                activateApplication: { _ in }
+            )
+        }
+        for _ in 0..<200 where !firstWaitEntered {
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        try #require(firstWaitEntered)
+
+        let window = makeEligibleProjectWindow()
+        defer {
+            manager.unbindDialogOwnerWindow(window)
+            window.orderOut(nil)
+        }
+        let second = await projectRegistry.recoverAgentTaskFromInbox(
+            pausedTask.id,
+            action: .startNewSession,
+            openProjectWindow: { _ in },
+            waitUntilPresented: { recoveredManager in
+                #expect(recoveredManager === manager)
+                recoveredManager.bindDialogOwnerWindow(window)
+                return true
+            },
+            activateApplication: { _ in }
+        )
+        guard case .openedNewSession(let terminalID) = second else {
+            Issue.record("Expected newer presentation to succeed")
+            releaseFirstWait = true
+            _ = await first.value
+            return
+        }
+        releaseFirstWait = true
+        #expect(await first.value == .projectUnavailable)
+
+        #expect(projectRegistry.openProjects[canonical] === manager)
+        #expect(!projectRegistry.backgroundProjects.contains(canonical))
+        #expect(projectRegistry.isWindowOpen(canonical))
+        #expect(state.terminalTabs.map(\.id) == originalIDs + [terminalID])
+    }
+
+    @Test("cancelled Inbox canonicalization cannot background a reopened window")
+    func cancelledCanonicalizationPreservesConcurrentOpen() async throws {
+        try await assertStaleCanonicalizationPreservesConcurrentOpen(
+            mutateTask: false
+        )
+    }
+
+    @Test("mutated Inbox task cannot background a concurrently reopened window")
+    func mutatedTaskDuringCanonicalizationPreservesConcurrentOpen() async throws {
+        try await assertStaleCanonicalizationPreservesConcurrentOpen(
+            mutateTask: true
+        )
+    }
+
+    @Test("recovery lease survives inspector await and fences stale launch")
+    func recoveryRevalidatesAfterInspectorAwait() async throws {
+        let fixture = try InboxProjectFixture()
+        defer { fixture.cleanup() }
+        let executable = fixture.project.appendingPathComponent("codex")
+        try Data().write(to: executable)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: executable.path
+        )
+        let pausedTask = makePersistedRecoveryTask(
+            projectURL: fixture.project,
+            vendorIdentity: AgentVendorSessionIdentity(
+                provider: "example",
+                opaqueIdentifier: "blocked-session-1421",
+                executableVersion: "1.2.3"
+            )
+        )
+        let taskRegistry = AgentTaskRegistry(
+            persistence: InboxLoadedAgentTaskStore(tasks: [pausedTask])
+        )
+        let blocker = BlockingInboxProcessRunner()
+        let inspector = AgentTaskRecoveryInspector(
+            resolver: ExternalToolResolver(
+                searchDirectories: [fixture.project.path]
+            ),
+            processRunner: { _, _, _, _ in blocker.run() },
+            recipes: [AgentTaskResumeRecipe(
+                provider: "example",
+                agentTypeIdentifier: pausedTask.descriptor.typeIdentifier,
+                executableAliases: ["codex"],
+                supportedVersions: ["1.2.3"],
+                identifierArgumentPrefix: ["resume", "--session"],
+                identifierArgumentSuffix: []
+            )]
+        )
+        let projectRegistry = ProjectRegistry(
+            agentTasks: taskRegistry,
+            agentRecoveryInspector: inspector
+        )
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        manager.terminal.lastActiveTerminalPaneID = pane
+        let state = try #require(manager.paneManager.terminalState(for: pane))
+        let originalIDs = state.terminalTabs.map(\.id)
+        try await requireLoadedTask(pausedTask.id, in: taskRegistry)
+        let canonical = projectRegistry.canonicalProjectURL(fixture.project)
+        projectRegistry.closeProjectWindow(fixture.project)
+        let window = makeEligibleProjectWindow()
+        defer {
+            blocker.release()
+            manager.unbindDialogOwnerWindow(window)
+            window.orderOut(nil)
+        }
+
+        let recovery = Task { @MainActor in
+            await projectRegistry.recoverAgentTaskFromInbox(
+                pausedTask.id,
+                action: .resumeVendorSession,
+                openProjectWindow: { _ in },
+                waitUntilPresented: { recoveredManager in
+                    recoveredManager.bindDialogOwnerWindow(window)
+                    return true
+                },
+                activateApplication: { _ in }
+            )
+        }
+        for _ in 0..<200 where !blocker.hasEntered {
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        try #require(blocker.hasEntered)
+
+        projectRegistry.closeProjectWindow(
+            canonical,
+            expectedManager: manager,
+            expectedWindowGeneration: manager.dialogOwnerWindowGeneration
+        )
+        projectRegistry.runBackgroundReclamationPassForTesting()
+        #expect(projectRegistry.openProjects[canonical] === manager)
+        #expect(projectRegistry.backgroundProjects.contains(canonical))
+        blocker.release()
+
+        #expect(await recovery.value == .changedWhilePreparing)
+        #expect(state.terminalTabs.map(\.id) == originalIDs)
+    }
+
+    private func makeEligibleProjectWindow() -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.orderFront(nil)
+        return window
+    }
+
+    private func assertStaleCanonicalizationPreservesConcurrentOpen(
+        mutateTask: Bool
+    ) async throws {
+        let fixture = try InboxProjectFixture()
+        defer { fixture.cleanup() }
+        let pausedTask = makePersistedRecoveryTask(projectURL: fixture.project)
+        let taskRegistry = AgentTaskRegistry(
+            persistence: InboxLoadedAgentTaskStore(tasks: [pausedTask])
+        )
+        let canonicalizer = BlockingInboxProjectCanonicalizer()
+        let projectRegistry = ProjectRegistry(
+            agentTasks: taskRegistry,
+            agentInboxProjectCanonicalizer: { url in
+                await canonicalizer.canonicalize(url)
+            }
+        )
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        try await requireLoadedTask(pausedTask.id, in: taskRegistry)
+        let canonical = projectRegistry.canonicalProjectURL(fixture.project)
+        projectRegistry.closeProjectWindow(canonical)
+
+        let recovery = Task { @MainActor in
+            await projectRegistry.recoverAgentTaskFromInbox(
+                pausedTask.id,
+                action: .startNewSession,
+                openProjectWindow: { _ in },
+                activateApplication: { _ in }
+            )
+        }
+        let entered = await canonicalizer.waitUntilEntered()
+        try #require(entered)
+
+        // Another UI action wins while Inbox is suspended canonicalizing the
+        // old snapshot. Its valid owner must not be cleared transactionally.
+        let reopened = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        #expect(reopened === manager)
+        let window = makeEligibleProjectWindow()
+        manager.bindDialogOwnerWindow(window)
+        defer {
+            manager.unbindDialogOwnerWindow(window)
+            window.orderOut(nil)
+        }
+
+        if mutateTask {
+            var replacement = pausedTask
+            replacement.title = (replacement.title ?? "Recovery fixture")
+                + " changed"
+            taskRegistry.setTasksForTesting([replacement])
+        } else {
+            recovery.cancel()
+        }
+        await canonicalizer.release()
+
+        #expect(await recovery.value == .projectUnavailable)
+        #expect(projectRegistry.openProjects[canonical] === manager)
+        #expect(!projectRegistry.backgroundProjects.contains(canonical))
+        #expect(projectRegistry.isWindowOpen(canonical))
+        #expect(manager.dialogOwnerWindow === window)
+        #expect(manager.presentationLifecycle == .visible)
     }
 
     private func makePersistedRecoveryTask(
@@ -789,9 +1170,7 @@ struct AgentInboxTests {
 
     private func assertBackgroundRecoveryState(
         projectRegistry: ProjectRegistry,
-        taskRegistry: AgentTaskRegistry,
         projectURL: URL,
-        liveTaskID: UUID,
         retained: (
             manager: ProjectManager,
             state: TerminalPaneState,
@@ -801,8 +1180,6 @@ struct AgentInboxTests {
         #expect(projectRegistry.openProjects[projectURL] === retained.manager)
         #expect(projectRegistry.backgroundProjects.contains(projectURL))
         #expect(!projectRegistry.isWindowOpen(projectURL))
-        #expect(taskRegistry.task(for: liveTaskID)?.route.availability
-                == .background)
         #expect(retained.state.terminalTabs.map(\.id) == retained.terminalIDs)
     }
 

--- a/PineTests/BackgroundProjectLifecycleTests.swift
+++ b/PineTests/BackgroundProjectLifecycleTests.swift
@@ -1,0 +1,789 @@
+//
+//  BackgroundProjectLifecycleTests.swift
+//  PineTests
+//
+
+import AppKit
+import Foundation
+import Testing
+
+@testable import Pine
+
+nonisolated private final class ProcessSnapshotRunCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedCount = 0
+
+    var count: Int {
+        lock.withLock { storedCount }
+    }
+
+    func recordRun() -> ProcessRunResult {
+        lock.withLock { storedCount += 1 }
+        return ProcessRunResult(
+            stdout: "",
+            stderr: "",
+            exitCode: 0,
+            timedOut: false
+        )
+    }
+}
+
+@MainActor
+private final class ControlledWorkspaceWatcher: WorkspaceFileWatching {
+    private let callback: @MainActor () -> Void
+    private(set) var isStopped = false
+
+    init(callback: @escaping @MainActor () -> Void) {
+        self.callback = callback
+    }
+
+    func watch(directory _: URL) {
+        isStopped = false
+    }
+
+    func stop() {
+        isStopped = true
+    }
+
+    func emit() {
+        guard !isStopped else { return }
+        callback()
+    }
+
+    func emitIgnoringStop() {
+        callback()
+    }
+}
+
+@MainActor
+private final class ControlledWorkspaceWatcherFactory {
+    private(set) var watchers: [ControlledWorkspaceWatcher] = []
+
+    func make(
+        callback: @escaping @MainActor () -> Void
+    ) -> any WorkspaceFileWatching {
+        let watcher = ControlledWorkspaceWatcher(callback: callback)
+        watchers.append(watcher)
+        return watcher
+    }
+}
+
+@Suite("Background Project Lifecycle", .serialized)
+@MainActor
+struct BackgroundProjectLifecycleTests {
+    private static let noOpProcessRunner: ProcessRunner = { _, _, _, _ in
+        ProcessRunResult(
+            stdout: "",
+            stderr: "",
+            exitCode: 0,
+            timedOut: false
+        )
+    }
+
+    @Test("close and reopen suspend and resume editor services once")
+    func suspendAndResumeAreIdempotent() throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let registry = makeRegistry()
+        let manager = try #require(registry.projectManager(for: directory))
+
+        #expect(manager.presentationLifecycle == .visible)
+        #expect(!manager.workspace.isSuspended)
+        #expect(manager.workspace.hasActiveFileWatcherForTesting)
+        #expect(manager.recoveryManager?.isPeriodicSnapshotting == true)
+
+        registry.closeProjectWindow(directory)
+        registry.closeProjectWindow(directory)
+
+        #expect(manager.presentationLifecycle == .backgroundSuspended)
+        #expect(manager.workspace.isSuspended)
+        #expect(!manager.workspace.hasActiveFileWatcherForTesting)
+        #expect(manager.recoveryManager?.isPeriodicSnapshotting == false)
+        #expect(manager.lspManager.presentationLifecycle == .backgroundSuspended)
+        #expect(manager.editorServiceSuspendCountForTesting == 1)
+
+        let reopened = try #require(registry.projectManager(for: directory))
+        let reopenedAgain = try #require(registry.projectManager(for: directory))
+
+        #expect(reopened === manager)
+        #expect(reopenedAgain === manager)
+        #expect(manager.presentationLifecycle == .visible)
+        #expect(!manager.workspace.isSuspended)
+        #expect(manager.workspace.hasActiveFileWatcherForTesting)
+        #expect(manager.recoveryManager?.isPeriodicSnapshotting == true)
+        #expect(manager.lspManager.presentationLifecycle == .active)
+        #expect(manager.editorServiceResumeCountForTesting == 1)
+    }
+
+    @Test("workspace watcher events are fenced while suspended and rearmed")
+    func workspaceWatcherEventsFollowLifecycle() throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let factory = ControlledWorkspaceWatcherFactory()
+        let workspace = WorkspaceManager(fileWatcherFactory: { callback in
+            factory.make(callback: callback)
+        })
+        workspace.loadDirectory(url: directory)
+        let firstWatcher = try #require(factory.watchers.first)
+        let initialToken = workspace.externalChangeToken
+
+        firstWatcher.emit()
+        #expect(workspace.externalChangeToken == initialToken + 1)
+
+        workspace.suspend()
+        #expect(firstWatcher.isStopped)
+        firstWatcher.emitIgnoringStop()
+        #expect(workspace.externalChangeToken == initialToken + 1)
+
+        workspace.resume()
+        let resumedWatcher = try #require(factory.watchers.last)
+        #expect(resumedWatcher !== firstWatcher)
+        resumedWatcher.emit()
+        #expect(workspace.externalChangeToken == initialToken + 2)
+    }
+
+    @Test("application timer delivers one shared snapshot to two detectors")
+    func processSnapshotIsSharedAcrossProjects() async throws {
+        let firstDirectory = try makeTempDirectory()
+        let secondDirectory = try makeTempDirectory()
+        defer {
+            cleanup(firstDirectory)
+            cleanup(secondDirectory)
+        }
+        let counter = ProcessSnapshotRunCounter()
+        let registry = makeRegistry(
+            processRunner: { _, _, _, _ in counter.recordRun() },
+            pollInterval: 3_600,
+            initialPollDelay: 0.2
+        )
+        let first = try #require(
+            registry.projectManager(for: firstDirectory)
+        )
+        let second = try #require(
+            registry.projectManager(for: secondDirectory)
+        )
+
+        first.terminal.ensureAgentDetectionStarted()
+        second.terminal.ensureAgentDetectionStarted()
+
+        #expect(registry.agentSnapshotSubscriberCountForTesting == 2)
+        await waitUntil {
+            first.terminal.receivedAgentSnapshotCountForTesting >= 1
+                && second.terminal.receivedAgentSnapshotCountForTesting >= 1
+        }
+        let firstReceiptCount =
+            first.terminal.receivedAgentSnapshotCountForTesting
+        let secondReceiptCount =
+            second.terminal.receivedAgentSnapshotCountForTesting
+        #expect(registry.destroyAllProjects())
+        #expect(counter.count == 1)
+        #expect(firstReceiptCount == 1)
+        #expect(secondReceiptCount == 1)
+        #expect(registry.agentSnapshotSubscriberCountForTesting == 0)
+    }
+
+    @Test("live terminal keeps its exact manager, pane, tab, and PTY")
+    func liveTerminalIdentitySurvivesBackgroundReclamation() async throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let registry = makeRegistry()
+        let manager = try #require(registry.projectManager(for: directory))
+        let paneID = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: directory,
+            initialProcess: TerminalInitialProcess(
+                executablePath: "/bin/cat",
+                arguments: []
+            )
+        )
+        let state = try #require(
+            manager.paneManager.terminalState(for: paneID)
+        )
+        let tab = try #require(state.activeTab)
+        defer {
+            tab.stop()
+            _ = registry.destroyAllProjects()
+        }
+        tab.terminalView.frame = NSRect(
+            x: 0,
+            y: 0,
+            width: 800,
+            height: 300
+        )
+        tab.startIfNeeded()
+        try #require(tab.isProcessRunning)
+        let sentinel = "pine-scrollback-\(UUID().uuidString)"
+        try #require(tab.sendText("\(sentinel)\n"))
+        for _ in 0..<100 {
+            await tab.search(for: sentinel)
+            if !tab.searchMatches.isEmpty { break }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        try #require(!tab.searchMatches.isEmpty)
+        let matchCount = tab.searchMatches.count
+
+        registry.closeProjectWindow(directory)
+        registry.runBackgroundReclamationPassForTesting()
+
+        let canonical = registry.canonicalProjectURL(directory)
+        #expect(registry.openProjects[canonical] === manager)
+        #expect(manager.paneManager.terminalState(for: paneID) === state)
+        #expect(state.activeTab === tab)
+        #expect(tab.isProcessRunning)
+        await tab.search(for: sentinel)
+        #expect(tab.searchMatches.count == matchCount)
+
+        let reopened = try #require(registry.projectManager(for: directory))
+        #expect(reopened === manager)
+        #expect(reopened.paneManager.terminalState(for: paneID) === state)
+        #expect(state.activeTab === tab)
+        #expect(tab.isProcessRunning)
+        await tab.search(for: sentinel)
+        #expect(tab.searchMatches.count == matchCount)
+    }
+
+    @Test("dirty project is retained when recovery is unavailable")
+    func dirtyProjectFailsClosedWithoutRecovery() throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let file = directory.appendingPathComponent("Dirty.swift")
+        try "let value = 1\n".write(to: file, atomically: true, encoding: .utf8)
+        let registry = makeRegistry()
+        let manager = try #require(registry.projectManager(for: directory))
+        manager.primaryTabManager.openTab(url: file)
+        manager.primaryTabManager.updateContent("let value = 2\n")
+        try #require(manager.allTabs.contains { $0.isDirty })
+        manager.removeRecoveryManagerForTesting()
+
+        registry.closeProjectWindow(directory)
+        registry.runBackgroundReclamationPassForTesting()
+
+        let canonical = registry.canonicalProjectURL(directory)
+        #expect(registry.openProjects[canonical] === manager)
+        #expect(manager.presentationLifecycle == .backgroundSuspended)
+        #expect(manager.recoveryManager == nil)
+        #expect(manager.allTabs.contains { $0.isDirty })
+    }
+
+    @Test("idle background projects are reclaimed by the bounded sweep")
+    func idleProjectIsReclaimedAndCanBeReadmitted() async throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let registry = makeRegistry(
+            backgroundReclamationInterval: .milliseconds(10)
+        )
+        let original = try #require(registry.projectManager(for: directory))
+        let canonical = registry.canonicalProjectURL(directory)
+
+        registry.closeProjectWindow(directory)
+        await waitUntil { registry.openProjects[canonical] == nil }
+
+        #expect(original.presentationLifecycle == .destroyed)
+        #expect(!registry.backgroundProjects.contains(canonical))
+        let replacement = try #require(registry.projectManager(for: directory))
+        #expect(replacement !== original)
+        #expect(replacement.presentationLifecycle == .visible)
+    }
+
+    @Test("reclamation is capped per turn and eventually preserves sessions")
+    func reclamationIsBatchedAndEventual() async throws {
+        let directories = try (0..<7).map { _ in try makeTempDirectory() }
+        defer {
+            for directory in directories {
+                SessionState.clear(for: directory)
+                cleanup(directory)
+            }
+        }
+        let registry = makeRegistry(
+            backgroundReclamationInterval: .milliseconds(10),
+            backgroundReclamationBatchSize: 2
+        )
+        let expectedFiles = try directories.enumerated().map { index, directory in
+            let file = directory.appendingPathComponent("Project-\(index).swift")
+            try "let project = \(index)\n".write(
+                to: file,
+                atomically: true,
+                encoding: .utf8
+            )
+            return file
+        }
+        let managers = try zip(directories, expectedFiles).map { directory, file in
+            let manager = try #require(registry.projectManager(for: directory))
+            manager.primaryTabManager.openTab(url: file)
+            return manager
+        }
+        for directory in directories {
+            registry.closeProjectWindow(directory)
+        }
+
+        registry.runBackgroundReclamationPassForTesting()
+        #expect(registry.lastReclaimPassCountForTesting == 2)
+        #expect(registry.openProjects.count == 5)
+        await waitUntil { registry.openProjects.isEmpty }
+
+        #expect(managers.allSatisfy {
+            $0.presentationLifecycle == .destroyed
+        })
+        for (directory, expectedFile) in zip(directories, expectedFiles) {
+            let canonical = registry.canonicalProjectURL(directory)
+            let session = try #require(SessionState.load(for: canonical))
+            #expect(session.existingFileURLs == [expectedFile])
+        }
+    }
+
+    @Test("reclaim tombstones delayed terminal layout starts")
+    func reclaimPermanentlyInvalidatesDelayedTerminalStart() throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let registry = makeRegistry()
+        let manager = try #require(registry.projectManager(for: directory))
+        let paneID = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: directory,
+            initialProcess: TerminalInitialProcess(
+                executablePath: "/bin/cat",
+                arguments: []
+            )
+        )
+        let state = try #require(manager.paneManager.terminalState(for: paneID))
+        let tab = try #require(state.activeTab)
+        #expect(!tab.isProcessRunning)
+
+        registry.closeProjectWindow(directory)
+        registry.runBackgroundReclamationPassForTesting()
+
+        #expect(manager.presentationLifecycle == .destroyed)
+        #expect(manager.terminal.isPermanentlyInvalidated)
+        #expect(tab.isTerminated)
+        tab.terminalView.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
+        tab.startIfNeeded()
+        #expect(!tab.isProcessRunning)
+    }
+
+    @Test("stale scene lookup cannot admit a reclaimed manager")
+    func staleSceneLookupDoesNotResurrectProject() throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let registry = makeRegistry()
+        let original = try #require(registry.projectManager(for: directory))
+        let canonical = registry.canonicalProjectURL(directory)
+
+        registry.closeProjectWindow(directory)
+        registry.runBackgroundReclamationPassForTesting()
+        #expect(original.presentationLifecycle == .destroyed)
+        #expect(registry.projectManagerIfAdmitted(for: directory) == nil)
+        #expect(registry.openProjects[canonical] == nil)
+
+        let explicitlyAdmitted = try #require(
+            registry.projectManager(for: directory)
+        )
+        #expect(explicitlyAdmitted !== original)
+    }
+
+    @Test("delayed old-manager close cannot background its replacement")
+    func staleCloseCannotBackgroundReplacementManager() throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let registry = makeRegistry()
+        let appDelegate = AppDelegate()
+        appDelegate.registry = registry
+        let original = try #require(registry.projectManager(for: directory))
+        let oldWindow = makeWindow()
+        let closeDelegate = CloseDelegate(
+            projectManager: original,
+            registry: registry,
+            projectURL: directory,
+            appDelegate: appDelegate,
+            original: nil
+        )
+        closeDelegate.observeWindowClose(oldWindow)
+        defer { closeDelegate.detachFromWindow() }
+
+        registry.closeProjectWindow(directory)
+        registry.runBackgroundReclamationPassForTesting()
+        let replacement = try #require(registry.projectManager(for: directory))
+        #expect(replacement !== original)
+
+        closeDelegate.windowWillClose(Notification(
+            name: NSWindow.willCloseNotification,
+            object: oldWindow
+        ))
+
+        let canonical = registry.canonicalProjectURL(directory)
+        #expect(registry.openProjects[canonical] === replacement)
+        #expect(!registry.backgroundProjects.contains(canonical))
+        #expect(replacement.presentationLifecycle == .visible)
+    }
+
+    @Test("delayed old-window close cannot background a newer generation")
+    func staleCloseCannotBackgroundNewWindowGeneration() throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let registry = makeRegistry()
+        let appDelegate = AppDelegate()
+        appDelegate.registry = registry
+        let manager = try #require(registry.projectManager(for: directory))
+        let oldWindow = makeWindow()
+        let newWindow = makeWindow()
+        let oldDelegate = CloseDelegate(
+            projectManager: manager,
+            registry: registry,
+            projectURL: directory,
+            appDelegate: appDelegate,
+            original: nil
+        )
+        let newDelegate = CloseDelegate(
+            projectManager: manager,
+            registry: registry,
+            projectURL: directory,
+            appDelegate: appDelegate,
+            original: nil
+        )
+        oldDelegate.observeWindowClose(oldWindow)
+        newDelegate.observeWindowClose(newWindow)
+        defer {
+            oldDelegate.detachFromWindow()
+            newDelegate.detachFromWindow()
+        }
+
+        oldDelegate.windowWillClose(Notification(
+            name: NSWindow.willCloseNotification,
+            object: oldWindow
+        ))
+
+        let canonical = registry.canonicalProjectURL(directory)
+        #expect(registry.openProjects[canonical] === manager)
+        #expect(!registry.backgroundProjects.contains(canonical))
+        #expect(manager.dialogOwnerWindow === newWindow)
+        #expect(manager.presentationLifecycle == .visible)
+    }
+
+    @Test("retained reopen fences old close before replacement window binds")
+    func retainedReopenRotatesGenerationBeforeWindowBinding() throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let registry = makeRegistry()
+        let appDelegate = AppDelegate()
+        appDelegate.registry = registry
+        let manager = try #require(registry.projectManager(for: directory))
+        let oldWindow = makeWindow()
+        let oldDelegate = CloseDelegate(
+            projectManager: manager,
+            registry: registry,
+            projectURL: directory,
+            appDelegate: appDelegate,
+            original: nil
+        )
+        oldDelegate.observeWindowClose(oldWindow)
+        let oldGeneration = manager.dialogOwnerWindowGeneration
+        defer { oldDelegate.detachFromWindow() }
+
+        registry.closeProjectWindow(directory)
+        let reopened = try #require(registry.projectManager(for: directory))
+        #expect(reopened === manager)
+        #expect(manager.dialogOwnerWindowGeneration != oldGeneration)
+        #expect(manager.dialogOwnerWindow == nil)
+
+        // Window B has not bound yet. A's delayed close must already be stale.
+        oldDelegate.windowWillClose(Notification(
+            name: NSWindow.willCloseNotification,
+            object: oldWindow
+        ))
+
+        let canonical = registry.canonicalProjectURL(directory)
+        #expect(registry.openProjects[canonical] === manager)
+        #expect(!registry.backgroundProjects.contains(canonical))
+        #expect(manager.presentationLifecycle == .visible)
+    }
+
+    @Test("retained reopen cannot recover the old visible window before binding")
+    func retainedReopenRetiresOldWindowRecoveryAuthorization() async throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let registry = makeRegistry()
+        let appDelegate = AppDelegate()
+        appDelegate.registry = registry
+        let manager = try #require(registry.projectManager(for: directory))
+        let oldWindow = makeWindow()
+        let oldDelegate = CloseDelegate(
+            projectManager: manager,
+            registry: registry,
+            projectURL: directory,
+            appDelegate: appDelegate,
+            original: nil
+        )
+        oldWindow.delegate = oldDelegate
+        oldDelegate.observeWindowClose(oldWindow)
+        oldWindow.orderFront(nil)
+        defer {
+            oldDelegate.detachFromWindow()
+            oldWindow.delegate = nil
+            oldWindow.orderOut(nil)
+        }
+
+        registry.closeProjectWindow(directory)
+        let reopened = try #require(registry.projectManager(for: directory))
+        #expect(reopened === manager)
+        #expect(manager.dialogOwnerWindow == nil)
+
+        // A is still visible and still carries the exact manager delegate,
+        // but its pre-transition authorization must not be repaired as B's.
+        let recovered = await manager.awaitDialogOwnerWindow(
+            maximumAttempts: 0
+        )
+        #expect(recovered == nil)
+        #expect(manager.dialogOwnerWindow == nil)
+
+        oldDelegate.windowWillClose(Notification(
+            name: NSWindow.willCloseNotification,
+            object: oldWindow
+        ))
+
+        let canonical = registry.canonicalProjectURL(directory)
+        #expect(registry.openProjects[canonical] === manager)
+        #expect(!registry.backgroundProjects.contains(canonical))
+        #expect(manager.presentationLifecycle == .visible)
+    }
+
+    @Test("coordinator transfer cannot reauthorize a retired old window")
+    func coordinatorTransferPreservesRetiredWindowFence() async throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let registry = makeRegistry()
+        let appDelegate = AppDelegate()
+        appDelegate.registry = registry
+        let manager = try #require(registry.projectManager(for: directory))
+        let oldWindow = makeWindow()
+        let firstCoordinator = WindowCloseInterceptor.Coordinator()
+        firstCoordinator.installDelegate(
+            on: oldWindow,
+            projectManager: manager,
+            registry: registry,
+            projectURL: directory,
+            appDelegate: appDelegate
+        )
+        let oldDelegate = try #require(oldWindow.delegate as? CloseDelegate)
+        oldWindow.makeKeyAndOrderFront(nil)
+        let secondCoordinator = WindowCloseInterceptor.Coordinator()
+        defer {
+            secondCoordinator.detach()
+            oldWindow.orderOut(nil)
+        }
+
+        registry.closeProjectWindow(directory)
+        #expect(registry.projectManager(for: directory) === manager)
+        #expect(manager.dialogOwnerWindow == nil)
+
+        // SwiftUI installs another coordinator on A before B binds. Transfer
+        // must preserve both the revoked presentation authority and A's old
+        // close generation.
+        secondCoordinator.installDelegate(
+            on: oldWindow,
+            projectManager: manager,
+            registry: registry,
+            projectURL: directory,
+            appDelegate: appDelegate
+        )
+        #expect(oldWindow.delegate === oldDelegate)
+        #expect(await manager.awaitDialogOwnerWindow(maximumAttempts: 0) == nil)
+        #expect(DialogPresenter.forKeyProject(
+            keyWindow: oldWindow
+        ).nsWindow == nil)
+        #expect(manager.dialogOwnerWindow == nil)
+
+        oldDelegate.windowWillClose(Notification(
+            name: NSWindow.willCloseNotification,
+            object: oldWindow
+        ))
+
+        let canonical = registry.canonicalProjectURL(directory)
+        #expect(registry.openProjects[canonical] === manager)
+        #expect(!registry.backgroundProjects.contains(canonical))
+        #expect(manager.presentationLifecycle == .visible)
+    }
+
+    @Test("auto-save termination freeze fences reclamation until rollback")
+    func earlyTerminationFreezeFencesReclamation() async throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let registry = makeRegistry(
+            backgroundReclamationInterval: .milliseconds(10)
+        )
+        let manager = try #require(registry.projectManager(for: directory))
+        let canonical = registry.canonicalProjectURL(directory)
+        registry.closeProjectWindow(directory)
+
+        registry.freezeAutoSaveForTermination()
+        _ = registry.captureApplicationTerminationSaveInventory(
+            allowingSaveAs: [:]
+        )
+        try? await Task.sleep(for: .milliseconds(40))
+        registry.runBackgroundReclamationPassForTesting()
+        #expect(registry.openProjects[canonical] === manager)
+
+        registry.cancelAutoSaveTerminationFreeze()
+        await waitUntil { registry.openProjects[canonical] == nil }
+        #expect(manager.presentationLifecycle == .destroyed)
+    }
+
+    @Test("Inbox presentation lease prevents mid-presentation reclamation")
+    func presentationLeaseRetainsBackgroundManager() throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let registry = makeRegistry()
+        let manager = try #require(registry.projectManager(for: directory))
+        let canonical = registry.canonicalProjectURL(directory)
+
+        registry.closeProjectWindow(directory)
+        let leaseID = try #require(
+            registry.retainBackgroundProjectForPresentation(
+                directory,
+                manager: manager
+            )
+        )
+        registry.runBackgroundReclamationPassForTesting()
+        #expect(registry.openProjects[canonical] === manager)
+
+        registry.releaseBackgroundProjectPresentation(
+            leaseID,
+            for: directory
+        )
+        registry.runBackgroundReclamationPassForTesting()
+        #expect(registry.openProjects[canonical] == nil)
+        #expect(manager.presentationLifecycle == .destroyed)
+    }
+
+    @Test("quit freeze fences reclaim while exact retained reopen survives")
+    func quitAndReopenRaceIsFenced() async throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let registry = makeRegistry()
+        let manager = try #require(registry.projectManager(for: directory))
+        let canonical = registry.canonicalProjectURL(directory)
+        registry.closeProjectWindow(directory)
+
+        registry.freezeAgentTasksForTermination()
+        registry.runBackgroundReclamationPassForTesting()
+
+        #expect(registry.openProjects[canonical] === manager)
+        let reopenedDuringFreeze = try #require(
+            registry.projectManager(for: directory)
+        )
+        #expect(reopenedDuringFreeze === manager)
+        #expect(manager.presentationLifecycle == .visible)
+
+        #expect(await registry.cancelAgentTaskTermination())
+        let reopened = try #require(registry.projectManager(for: directory))
+        #expect(reopened === manager)
+        #expect(manager.presentationLifecycle == .visible)
+    }
+
+    @Test("committed teardown invalidates services and poll subscriptions")
+    func committedTeardownIsFinal() throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let registry = makeRegistry()
+        let appDelegate = AppDelegate()
+        appDelegate.registry = registry
+        let manager = try #require(registry.projectManager(for: directory))
+        let paneID = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: directory,
+            initialProcess: TerminalInitialProcess(
+                executablePath: "/bin/cat",
+                arguments: []
+            )
+        )
+        let state = try #require(manager.paneManager.terminalState(for: paneID))
+        let tab = try #require(state.activeTab)
+        let originalTabIDs = state.terminalTabs.map(\.id)
+        manager.terminal.ensureAgentDetectionStarted()
+        try #require(registry.agentSnapshotSubscriberCountForTesting == 1)
+
+        appDelegate.applicationWillTerminate(Notification(
+            name: NSApplication.willTerminateNotification
+        ))
+
+        #expect(manager.presentationLifecycle == .destroyed)
+        #expect(manager.workspace.isSuspended)
+        #expect(manager.lspManager.presentationLifecycle == .invalidated)
+        #expect(manager.terminal.isPermanentlyInvalidated)
+        #expect(!manager.terminal.isAgentDetectionPolling)
+        #expect(registry.agentSnapshotSubscriberCountForTesting == 0)
+        #expect(registry.openProjects.isEmpty)
+        tab.terminalView.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
+        tab.startIfNeeded()
+        #expect(tab.isTerminated)
+        #expect(!tab.isProcessRunning)
+        _ = manager.terminal.createTerminalTab(
+            in: paneID,
+            workingDirectory: directory
+        )
+        #expect(state.terminalTabs.map(\.id) == originalTabIDs)
+    }
+
+    @Test("frozen task callbacks cannot restart agent detection")
+    func callbackFreezeRejectsDetectionRestart() throws {
+        let terminal = TerminalManager(
+            agentDetectionProcessRunner: Self.noOpProcessRunner
+        )
+        terminal.ensureAgentDetectionStarted()
+        try #require(terminal.isAgentDetectionPolling)
+        terminal.freezeAgentTasksForTermination()
+        terminal.shutdownAgentDetection()
+
+        terminal.ensureAgentDetectionStarted()
+
+        #expect(!terminal.isAgentDetectionPolling)
+        terminal.cancelAgentTaskTermination()
+        terminal.ensureAgentDetectionStarted()
+        #expect(terminal.isAgentDetectionPolling)
+        terminal.shutdownAgentDetection()
+    }
+
+    private func makeRegistry(
+        processRunner: @escaping ProcessRunner = Self.noOpProcessRunner,
+        pollInterval: TimeInterval = 3_600,
+        initialPollDelay: TimeInterval? = nil,
+        backgroundReclamationInterval: Duration = .seconds(30),
+        backgroundReclamationBatchSize: Int = 4
+    ) -> ProjectRegistry {
+        ProjectRegistry(
+            agentDetectionProcessRunner: processRunner,
+            agentDetectionPollInterval: pollInterval,
+            agentDetectionInitialPollDelay: initialPollDelay,
+            backgroundReclamationInterval: backgroundReclamationInterval,
+            backgroundReclamationBatchSize: backgroundReclamationBatchSize
+        )
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Pine-1421-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        return directory
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+    }
+
+    private func waitUntil(
+        _ condition: @escaping @MainActor () -> Bool
+    ) async {
+        for _ in 0..<100 {
+            if condition() { return }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        Issue.record("Timed out waiting for background reclamation")
+    }
+}

--- a/PineTests/CloseDelegateTests.swift
+++ b/PineTests/CloseDelegateTests.swift
@@ -727,7 +727,7 @@ struct CloseDelegateTests {
         #expect(targetProject.dialogOwnerWindow == nil)
     }
 
-    @Test func interceptorRearmsRetainedDelegateForReopenedWindowGeneration() async throws {
+    @Test func retainedReopenRearmsCompletedDelegateWithoutCoordinatorUpdate() async throws {
         let dir = try makeTempDir()
         let otherDir = try makeTempDir()
         defer {
@@ -763,14 +763,10 @@ struct CloseDelegateTests {
 
         #expect(registry.projectManager(for: dir) === project)
         #expect(registry.isWindowOpen(dir))
-        coordinator.installDelegate(
-            on: window,
-            projectManager: project,
-            registry: registry,
-            projectURL: dir,
-            appDelegate: appDelegate
-        )
 
+        // macOS 26 can order the same WindowGroup NSWindow front without an
+        // update/move callback for its NSViewRepresentable. Admission must
+        // therefore re-arm the delegate from the completed close record.
         #expect(window.delegate === interceptor)
         #expect(!interceptor.didCompleteWindowLifecycle)
         #expect(project.dialogOwnerWindow === window)
@@ -786,6 +782,61 @@ struct CloseDelegateTests {
         #expect(project.dialogOwnerWindow == nil)
         coordinator.detach()
         #expect(window.delegate === original)
+    }
+
+    @Test func staleCloseCannotReplaceCompletedOwnerChosenForReopen() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let appDelegate = AppDelegate()
+        let oldWindow = NSWindow()
+        let currentWindow = NSWindow()
+        let oldDelegate = CloseDelegate(
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: appDelegate,
+            original: nil
+        )
+        let currentDelegate = CloseDelegate(
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: appDelegate,
+            original: nil
+        )
+        oldWindow.delegate = oldDelegate
+        currentWindow.delegate = currentDelegate
+        oldDelegate.observeWindowClose(oldWindow)
+        currentDelegate.observeWindowClose(currentWindow)
+        defer {
+            oldDelegate.detachFromWindow()
+            currentDelegate.detachFromWindow()
+            oldWindow.delegate = nil
+            currentWindow.delegate = nil
+        }
+
+        // B is the exact current owner and completes the close that moves the
+        // project to the background. A's older callback arrives afterwards.
+        currentDelegate.windowWillClose(Notification(
+            name: NSWindow.willCloseNotification,
+            object: currentWindow
+        ))
+        oldDelegate.windowWillClose(Notification(
+            name: NSWindow.willCloseNotification,
+            object: oldWindow
+        ))
+        #expect(currentDelegate.didCompleteWindowLifecycle)
+        #expect(oldDelegate.didCompleteWindowLifecycle)
+        #expect(!registry.isWindowOpen(dir))
+
+        // Admission may reuse B without a representable update. The stale A
+        // callback must not have replaced B's completed-lifecycle record.
+        #expect(registry.projectManager(for: dir) === project)
+        #expect(!currentDelegate.didCompleteWindowLifecycle)
+        #expect(oldDelegate.didCompleteWindowLifecycle)
+        #expect(project.dialogOwnerWindow === currentWindow)
     }
 }
 

--- a/PineTests/ContextFileWriterTests.swift
+++ b/PineTests/ContextFileWriterTests.swift
@@ -960,6 +960,100 @@ struct ContextFileWriterTests {
         #expect(decoded.cursorColumn == 0)
     }
 
+    @Test func presentationGenerationOrdersCleanupAndRepublish() async throws {
+        let tmpDir = try makeTmpDir()
+        let contextsDir = tmpDir.appendingPathComponent("contexts")
+        let projectRoot = tmpDir.appendingPathComponent("project")
+        try FileManager.default.createDirectory(
+            at: projectRoot,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let gate = ContextPresentationCommandGate()
+        let oldWriter = ContextFileWriter(presentationGate: gate)
+        let newWriter = ContextFileWriter(presentationGate: gate)
+        for writer in [oldWriter, newWriter] {
+            await writer.setContextsDirectory(contextsDir)
+            await writer.setDebounceInterval(0.01)
+        }
+        let oldIdentity = ContextPresentationIdentity(epoch: 1)
+        let newIdentity = ContextPresentationIdentity(epoch: 2)
+        let visible = ContextFileWriter.Payload(
+            openFiles: ["Visible.swift"],
+            currentFile: "Visible.swift",
+            cursorLine: 7,
+            cursorColumn: 3
+        )
+
+        await newWriter.publishPresentationSnapshot(
+            projectRoot: projectRoot,
+            isReadOnlySharingEnabled: true,
+            payload: visible,
+            command: ContextPresentationCommand(
+                identity: newIdentity,
+                sequence: 1
+            )
+        )
+        await oldWriter.cleanupPresentationSnapshot(
+            projectRoot: projectRoot,
+            command: ContextPresentationCommand(
+                identity: oldIdentity,
+                sequence: 2
+            )
+        )
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(try readPayload(
+            projectRoot: projectRoot,
+            contextsDir: contextsDir
+        ).currentFile == "Visible.swift")
+
+        await newWriter.cleanupPresentationSnapshot(
+            projectRoot: projectRoot,
+            command: ContextPresentationCommand(
+                identity: newIdentity,
+                sequence: 2
+            )
+        )
+        await oldWriter.publishPresentationSnapshot(
+            projectRoot: projectRoot,
+            isReadOnlySharingEnabled: true,
+            payload: visible,
+            command: ContextPresentationCommand(
+                identity: oldIdentity,
+                sequence: 3
+            )
+        )
+        try await Task.sleep(for: .milliseconds(30))
+        #expect(!FileManager.default.fileExists(atPath: contextFileURL(
+            projectRoot: projectRoot,
+            contextsDir: contextsDir
+        ).path))
+    }
+
+    @Test func hiddenProjectManagerDoesNotPublishEditorContext() async throws {
+        let tmpDir = try makeTmpDir()
+        let contextsDir = tmpDir.appendingPathComponent("contexts")
+        let projectRoot = tmpDir.appendingPathComponent("project")
+        try FileManager.default.createDirectory(
+            at: projectRoot,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let writer = ContextFileWriter()
+        await writer.setContextsDirectory(contextsDir)
+        await writer.setDebounceInterval(0.01)
+        let manager = ProjectManager(contextFileWriter: writer)
+        manager.loadDirectory(url: projectRoot)
+        manager.suspendEditorServices()
+        try await Task.sleep(for: .milliseconds(20))
+        await writer.setProjectRoot(nil)
+
+        manager.updateEditorContext()
+        try await Task.sleep(for: .milliseconds(20))
+
+        #expect(await writer.projectRoot == nil)
+    }
+
     // MARK: - TabManager.onEditorContextChanged callback
 
     @Test func tabManagerCallsContextChangedOnActiveTabSwitch() {

--- a/PineTests/LSPSettingsTests.swift
+++ b/PineTests/LSPSettingsTests.swift
@@ -596,6 +596,135 @@ struct LSPSettingsLifecycleTests {
         #expect(clients.last?.opens.first?.text == "let value = 2")
     }
 
+    @Test("Background suspend is idempotent and resume replays latest buffers once")
+    func backgroundSuspendAndResume() async throws {
+        let settings = makeSettings()
+        var clients: [RecordingLSPClient] = []
+        let manager = LSPManager(
+            settings: settings,
+            resolver: TestLSPResolver(executablePath: "/bin/echo")
+        ) { _ in
+            let client = RecordingLSPClient()
+            clients.append(client)
+            return client
+        }
+        let url = URL(fileURLWithPath: "/project/App.swift")
+
+        manager.didOpen(
+            url: url,
+            contentRevision: 1,
+            text: "let value = 1"
+        )
+        await waitUntil { manager.servers["swift"]?.state == .initialized }
+        let original = try #require(clients.first)
+
+        manager.suspendForBackground()
+        manager.suspendForBackground()
+        #expect(manager.presentationLifecycle == .backgroundSuspended)
+        #expect(manager.servers.isEmpty)
+        #expect(original.shutdownCount == 1)
+
+        manager.didChange(
+            url: url,
+            contentRevision: 2,
+            text: "let value = 2"
+        )
+        manager.resumeFromBackground()
+        manager.resumeFromBackground()
+        await waitUntil {
+            clients.count == 2
+                && manager.servers["swift"]?.state == .initialized
+        }
+
+        let replacement = try #require(clients.last)
+        #expect(manager.presentationLifecycle == .active)
+        #expect(replacement.starts.count == 1)
+        #expect(replacement.opens.count == 1)
+        #expect(replacement.opens.first?.text == "let value = 2")
+    }
+
+    @Test("Delayed old presentation close preserves the reopened owner")
+    func delayedOldClosePreservesReopenedPresentation() async throws {
+        let settings = makeSettings()
+        let client = RecordingLSPClient()
+        let manager = LSPManager(
+            settings: settings,
+            resolver: TestLSPResolver(executablePath: "/bin/echo")
+        ) { _ in client }
+        let url = URL(fileURLWithPath: "/project/App.swift")
+        let oldPresentation = UUID()
+        let reopenedPresentation = UUID()
+
+        manager.didOpen(
+            url: url,
+            ownerID: oldPresentation,
+            contentRevision: 1,
+            text: "old"
+        )
+        await waitUntil { client.opens.count == 1 }
+        manager.didOpen(
+            url: url,
+            ownerID: reopenedPresentation,
+            contentRevision: 2,
+            text: "reopened"
+        )
+
+        // SwiftUI can deliver this disappearance after the replacement view's
+        // onAppear. Its unique presentation token must not close the reopen.
+        manager.didClose(url: url, ownerID: oldPresentation)
+        manager.didChange(
+            url: url,
+            ownerID: reopenedPresentation,
+            contentRevision: 3,
+            text: "reopened latest"
+        )
+
+        #expect(client.closes.isEmpty)
+        #expect(Array(client.changes.map(\.text).suffix(2)) == [
+            "reopened",
+            "reopened latest"
+        ])
+        manager.didClose(url: url, ownerID: reopenedPresentation)
+        #expect(client.closes == [url.absoluteString])
+    }
+
+    @Test("Suspend during initialize fences stale completion after resume")
+    func suspendDuringInitializeAndResume() async throws {
+        let settings = makeSettings()
+        let suspended = SuspendedStartLSPClient()
+        var replacements: [RecordingLSPClient] = []
+        var creationCount = 0
+        let manager = LSPManager(
+            settings: settings,
+            resolver: TestLSPResolver(executablePath: "/bin/echo")
+        ) { _ in
+            creationCount += 1
+            if creationCount == 1 { return suspended }
+            let replacement = RecordingLSPClient()
+            replacements.append(replacement)
+            return replacement
+        }
+        let url = URL(fileURLWithPath: "/project/App.swift")
+
+        manager.didOpen(url: url, text: "before")
+        await waitUntil { suspended.isWaitingToStart }
+        manager.suspendForBackground()
+        manager.didChange(url: url, text: "after")
+        manager.resumeFromBackground()
+        await waitUntil {
+            manager.servers["swift"]?.state == .initialized
+        }
+
+        suspended.resumeStart(true)
+        await Task.yield()
+
+        let replacement = try #require(replacements.first)
+        #expect(suspended.shutdownCount == 2)
+        #expect(suspended.opens.isEmpty)
+        #expect(replacement.opens.map(\.text) == ["after"])
+        #expect(manager.servers["swift"]?.state == .initialized)
+    }
+
     @Test("A stale initialize cannot replace a reconfigured client")
     func reconfigureDuringInitialize() async throws {
         let settings = makeSettings()


### PR DESCRIPTION
## Summary

- suspend reversible editor-only services when project windows move to the background while preserving exact PTY, agent, task, and scrollback ownership
- share one application-level process snapshot poller and reclaim idle background projects in bounded, fail-closed batches
- fence close/reopen, Inbox recovery, LSP, context publication, and final teardown against stale windows and asynchronous lifecycle callbacks
- add deterministic regression coverage for dirty buffers, delayed terminal starts, concurrent Inbox presentation, stale window closes, shared polling, watcher suspension, session restoration, and quit teardown

## Related issue

Fixes #1421

## Independent review gate

Reviewed from fresh context with correctness/architecture, concurrency/security/lifecycle, and tests/UX/macOS compatibility lenses. Confirmed P1/P2 findings were fixed on the same branch, including dirty-buffer loss, invisible manager resurrection, reclaim-vs-Quit mutation, stale LSP/context/window callbacks, delayed PTY launch after destruction, concurrent Inbox rollback/recovery races, and retired-window coordinator reauthorization. Final targeted re-review: no unresolved P0-P2.

## Verification

- selected 12-suite matrix: 420/420 passed
- final affected lifecycle/Inbox suites: 114/114 passed
- final owner/delegate matrix: 69/69 passed
- production `xcodebuild build`: succeeded
- SwiftLint: 743 files, 0 violations
- `git diff --check`: clean
- macOS 26 deployment-target compile: passed

Environment: macOS 27.0 (26A5406e), Xcode 27.0 beta (27A5218g), SDK 27.0 (26A5378i). A macOS 26 runtime was not available locally; CI must provide compatibility confirmation.

## Merge readiness

Implementation and local review are complete. Ready to merge only after every required CI check is green.