### PR TITLE
fix(terminal): wire Quick Terminal agents into detection and Agent Inbox

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -43,6 +43,8 @@ nonisolated enum AccessibilityID {
     static let quickTerminalHideOnFocusLossToggle =
         "quickTerminalHideOnFocusLossToggle"
     static let quickTerminalResetButton = "quickTerminalResetButton"
+    static let quickTerminalContent = "quickTerminalContent"
+    static let quickTerminalAgentIdentity = "quickTerminalAgentIdentity"
 
     // MARK: - Welcome window
     static let welcomeOpenFolderButton = "welcomeOpenFolderButton"

--- a/Pine/Agent/AgentDetectionCoordinator.swift
+++ b/Pine/Agent/AgentDetectionCoordinator.swift
@@ -24,8 +24,23 @@ nonisolated enum AgentMonotonicCounter {
     }
 }
 
+/// Main-actor consumer boundary for one application-owned process snapshot.
+/// Consumers receive the already captured, parsed, and generation-fenced
+/// result; none of them owns another timer or invokes `ps`.
+@MainActor
+protocol AgentProcessSnapshotConsuming: AnyObject {
+    func consumeAgentProcessSnapshot(
+        _ processes: [DetectedProcess],
+        observation: AgentObservationStamp
+    )
+
+    func consumeAgentProcessSnapshotFailure(
+        observation: AgentObservationStamp
+    )
+}
+
 /// Captures one machine-wide process snapshot and fans it out to every
-/// project-local detector. Production owns one instance in `ProjectRegistry`;
+/// subscribed detector. Production owns one instance in `ProjectRegistry`;
 /// standalone terminal-manager tests keep using a private instance.
 nonisolated final class AgentProcessSnapshotPoller {
     private let processRunner: ProcessRunner
@@ -60,14 +75,14 @@ nonisolated final class AgentProcessSnapshotPoller {
     }
 
     @MainActor
-    func subscribe(_ coordinator: AgentDetectionCoordinator) {
-        sink.insert(coordinator)
+    func subscribe(_ consumer: any AgentProcessSnapshotConsuming) {
+        sink.insert(consumer)
         startIfNeeded()
     }
 
     @MainActor
-    func unsubscribe(_ coordinator: AgentDetectionCoordinator) {
-        sink.remove(coordinator)
+    func unsubscribe(_ consumer: any AgentProcessSnapshotConsuming) {
+        sink.remove(consumer)
         if sink.isEmpty {
             stopPolling()
         }
@@ -174,46 +189,56 @@ nonisolated final class AgentProcessSnapshotPoller {
 
 @MainActor
 private final class AgentProcessSnapshotSink {
-    private final class WeakCoordinator {
-        weak var value: AgentDetectionCoordinator?
+    private final class WeakConsumer {
+        weak var value: (any AgentProcessSnapshotConsuming)?
 
-        init(_ value: AgentDetectionCoordinator) {
+        init(_ value: any AgentProcessSnapshotConsuming) {
             self.value = value
         }
     }
 
-    private var coordinators: [ObjectIdentifier: WeakCoordinator] = [:]
+    private var consumers: [ObjectIdentifier: WeakConsumer] = [:]
 
     var count: Int {
-        pruneReleasedCoordinators()
-        return coordinators.count
+        pruneReleasedConsumers()
+        return consumers.count
     }
 
     var isEmpty: Bool {
-        pruneReleasedCoordinators()
-        return coordinators.isEmpty
+        pruneReleasedConsumers()
+        return consumers.isEmpty
     }
 
-    func insert(_ coordinator: AgentDetectionCoordinator) {
-        pruneReleasedCoordinators()
-        coordinators[ObjectIdentifier(coordinator)] = WeakCoordinator(
-            coordinator
+    func insert(_ consumer: any AgentProcessSnapshotConsuming) {
+        pruneReleasedConsumers()
+        consumers[ObjectIdentifier(consumer)] = WeakConsumer(
+            consumer
         )
     }
 
-    func remove(_ coordinator: AgentDetectionCoordinator) {
-        coordinators.removeValue(forKey: ObjectIdentifier(coordinator))
+    func remove(_ consumer: any AgentProcessSnapshotConsuming) {
+        consumers.removeValue(forKey: ObjectIdentifier(consumer))
     }
 
     func apply(_ snapshot: AgentProcessSnapshot) {
-        pruneReleasedCoordinators()
-        for coordinator in coordinators.values.compactMap(\.value) {
-            coordinator.receive(snapshot)
+        pruneReleasedConsumers()
+        for consumer in consumers.values.compactMap(\.value) {
+            switch snapshot {
+            case .success(let processes, let observation):
+                consumer.consumeAgentProcessSnapshot(
+                    processes,
+                    observation: observation
+                )
+            case .failed(let observation):
+                consumer.consumeAgentProcessSnapshotFailure(
+                    observation: observation
+                )
+            }
         }
     }
 
-    private func pruneReleasedCoordinators() {
-        coordinators = coordinators.filter { $0.value.value != nil }
+    private func pruneReleasedConsumers() {
+        consumers = consumers.filter { $0.value.value != nil }
     }
 }
 
@@ -247,7 +272,8 @@ private final class AgentProcessSnapshotSink {
 /// `nonisolated` `makePollHandler()` so the closure is nonisolated. Note that
 /// `captureSnapshot` being `nonisolated` is NOT sufficient on its own — only
 /// the closure literal's own isolation matters at the dispatch boundary.
-nonisolated final class AgentDetectionCoordinator {
+nonisolated final class AgentDetectionCoordinator:
+    AgentProcessSnapshotConsuming {
     let detector: AgentDetector
     weak var terminalManager: TerminalManager?
     private let poller: AgentProcessSnapshotPoller
@@ -324,7 +350,22 @@ nonisolated final class AgentDetectionCoordinator {
         return true
     }
 
-    @MainActor fileprivate func receive(_ snapshot: AgentProcessSnapshot) {
+    @MainActor
+    func consumeAgentProcessSnapshot(
+        _ processes: [DetectedProcess],
+        observation: AgentObservationStamp
+    ) {
+        receive(.success(processes: processes, observation: observation))
+    }
+
+    @MainActor
+    func consumeAgentProcessSnapshotFailure(
+        observation: AgentObservationStamp
+    ) {
+        receive(.failed(observation: observation))
+    }
+
+    @MainActor private func receive(_ snapshot: AgentProcessSnapshot) {
         #if DEBUG
         receivedSnapshotCountForTesting += 1
         #endif

--- a/Pine/Agent/AgentHandoffSettingsView.swift
+++ b/Pine/Agent/AgentHandoffSettingsView.swift
@@ -8,6 +8,31 @@
 import SwiftUI
 import AppKit
 
+nonisolated enum AgentNotificationSettingsProjection {
+    static func projectOptions(
+        tasks: [AgentTask]
+    ) -> [(path: String, label: String)] {
+        let values = tasks
+            .filter { $0.route.surface.isProjectBacked }
+            .map {
+                let path = $0.project.canonicalProjectPath
+                return (
+                    path,
+                    URL(fileURLWithPath: path).lastPathComponent
+                )
+            }
+        return Dictionary(
+            values,
+            uniquingKeysWith: { current, _ in current }
+        )
+        .map { (path: $0.key, label: $0.value) }
+        .sorted {
+            $0.label.localizedStandardCompare($1.label)
+                == .orderedAscending
+        }
+    }
+}
+
 @MainActor
 struct PineSettingsView: View {
     let lspSettings: LSPSettings
@@ -149,11 +174,9 @@ private struct AgentNotificationSettingsView: View {
     }
 
     private var projectOptions: [(String, String)] {
-        let values = agentTasks.tasks.map {
-            ($0.project.canonicalProjectPath, URL(fileURLWithPath: $0.project.canonicalProjectPath).lastPathComponent)
-        }
-        return Dictionary(values, uniquingKeysWith: { current, _ in current })
-            .sorted { $0.value.localizedStandardCompare($1.value) == .orderedAscending }
+        AgentNotificationSettingsProjection.projectOptions(
+            tasks: agentTasks.tasks
+        )
     }
 
     private var taskOptions: [(UUID, String)] {

--- a/Pine/Agent/AgentInboxModels.swift
+++ b/Pine/Agent/AgentInboxModels.swift
@@ -18,6 +18,7 @@ nonisolated enum AgentInboxSectionID: String, CaseIterable, Sendable {
 nonisolated struct AgentInboxRow: Identifiable, Equatable, Sendable {
     let id: UUID
     let section: AgentInboxSectionID
+    let surface: AgentTaskTerminalSurface
     let projectPath: String
     let worktreePath: String
     let projectName: String
@@ -40,7 +41,8 @@ nonisolated struct AgentInboxRow: Identifiable, Equatable, Sendable {
     }
 
     var canRecover: Bool {
-        !canNavigateToLiveRun
+        surface == .projectWindow
+            && !canNavigateToLiveRun
             && (lifecycle == .paused || lifecycle == .completed)
             && liveness != .live
     }
@@ -69,13 +71,16 @@ nonisolated struct AgentInboxSnapshot: Equatable, Sendable {
         accuracyPolicy: AgentLifecycleAccuracyPolicy = .production
     ) {
         let visibleTasks = tasks.filter { $0.lifecycle != .dismissed }
+        let projectBackedTasks = visibleTasks.filter {
+            $0.route.surface.isProjectBacked
+        }
         let projectNames = Self.shortestUniquePathLabels(
-            visibleTasks.map(\.project.canonicalProjectPath)
+            projectBackedTasks.map(\.project.canonicalProjectPath)
         )
         // Worktrees form their own label namespace. A worktree basename must
         // neither widen a project label nor be widened by one.
         let worktreeNames = Self.shortestUniquePathLabels(
-            visibleTasks.compactMap { task in
+            projectBackedTasks.compactMap { task in
                 task.project.canonicalWorktreePath
                     == task.project.canonicalProjectPath
                     ? nil
@@ -104,14 +109,20 @@ nonisolated struct AgentInboxSnapshot: Equatable, Sendable {
             grouped[section, default: []].append(AgentInboxRow(
                 id: task.id,
                 section: section,
-                projectPath: task.project.canonicalProjectPath,
-                worktreePath: task.project.canonicalWorktreePath,
-                projectName: projectNames[
-                    task.project.canonicalProjectPath
-                ] ?? task.project.canonicalProjectPath,
-                worktreeName: worktreeNames[
-                    task.project.canonicalWorktreePath
-                ],
+                surface: task.route.surface,
+                projectPath: task.route.surface.isProjectBacked
+                    ? task.project.canonicalProjectPath
+                    : "",
+                worktreePath: task.route.surface.isProjectBacked
+                    ? task.project.canonicalWorktreePath
+                    : "",
+                projectName: Self.projectName(
+                    for: task,
+                    projectNames: projectNames
+                ),
+                worktreeName: task.route.surface.isProjectBacked
+                    ? worktreeNames[task.project.canonicalWorktreePath]
+                    : nil,
                 terminalLabel: Self.terminalLabel(
                     for: task,
                     terminalIDsByScope: terminalIDsByScope,
@@ -143,6 +154,7 @@ nonisolated struct AgentInboxSnapshot: Equatable, Sendable {
 
     private struct TerminalLabelScope: Hashable {
         let project: AgentTaskProjectIdentity
+        let surface: AgentTaskTerminalSurface
         let source: TerminalLabelSource
     }
 
@@ -156,6 +168,7 @@ nonisolated struct AgentInboxSnapshot: Equatable, Sendable {
     ) -> TerminalLabelScope {
         TerminalLabelScope(
             project: task.project,
+            surface: task.route.surface,
             source: task.presentationContext.map {
                 .stable($0.terminalLabel)
             } ?? .legacyFallback
@@ -168,6 +181,10 @@ nonisolated struct AgentInboxSnapshot: Equatable, Sendable {
         terminalIDsByScope: [TerminalLabelScope: Set<UUID>],
         tokensByScope: [TerminalLabelScope: [UUID: String]]
     ) -> String {
+        if task.route.surface == .quickTerminalStandalone {
+            return task.presentationContext?.terminalLabel
+                ?? Strings.quickTerminalText()
+        }
         let scope = terminalLabelScope(for: task)
         let token = tokensByScope[scope]?[task.route.terminalID]
             ?? task.route.terminalID.uuidString
@@ -178,6 +195,19 @@ nonisolated struct AgentInboxSnapshot: Equatable, Sendable {
             return stableLabel
         }
         return "\(stableLabel) · #\(token)"
+    }
+
+    @MainActor
+    private static func projectName(
+        for task: AgentTask,
+        projectNames: [String: String]
+    ) -> String {
+        guard task.route.surface.isProjectBacked else {
+            return task.presentationContext?.terminalLabel
+                ?? Strings.quickTerminalText()
+        }
+        return projectNames[task.project.canonicalProjectPath]
+            ?? task.project.canonicalProjectPath
     }
 
     /// Returns deterministic shortest trailing path suffixes. Equal canonical

--- a/Pine/Agent/AgentInboxView.swift
+++ b/Pine/Agent/AgentInboxView.swift
@@ -253,11 +253,13 @@ struct AgentInboxView: View {
             HStack(spacing: 5) {
                 Image(systemName: "terminal")
                 Text(verbatim: row.terminalLabel)
-                Image(systemName: "folder")
-                Text(verbatim: row.projectName)
-                if let worktreeName = row.worktreeName {
-                    Image(systemName: "arrow.triangle.branch")
-                    Text(verbatim: worktreeName)
+                if row.surface.isProjectBacked {
+                    Image(systemName: "folder")
+                    Text(verbatim: row.projectName)
+                    if let worktreeName = row.worktreeName {
+                        Image(systemName: "arrow.triangle.branch")
+                        Text(verbatim: worktreeName)
+                    }
                 }
             }
             .font(.caption)
@@ -408,9 +410,11 @@ struct AgentInboxView: View {
         fields.append(row.agentName)
         fields.append(statusText(for: row, locale: locale))
         fields.append(row.terminalLabel)
-        fields.append(row.projectName)
-        if let worktreeName = row.worktreeName {
-            fields.append(worktreeName)
+        if row.surface.isProjectBacked {
+            fields.append(row.projectName)
+            if let worktreeName = row.worktreeName {
+                fields.append(worktreeName)
+            }
         }
         return fields.joined(separator: ", ")
     }

--- a/Pine/Agent/AgentNotificationModels.swift
+++ b/Pine/Agent/AgentNotificationModels.swift
@@ -68,7 +68,10 @@ enum AgentNotificationTransitionResolver {
                 kind: kind,
                 observedAt: newRun.lastObservedAt,
                 agentName: safeDisplayName(for: task),
-                projectName: sanitizedProjectName(task.project.canonicalProjectPath),
+                projectName: task.route.surface.isProjectBacked
+                    ? sanitizedProjectName(task.project.canonicalProjectPath)
+                    : task.presentationContext?.terminalLabel
+                        ?? Strings.quickTerminalText(),
                 taskTitle: sanitizedTitle(task.title),
                 startedAt: newRun.startedAt
             )

--- a/Pine/Agent/AgentPresenceController.swift
+++ b/Pine/Agent/AgentPresenceController.swift
@@ -145,9 +145,11 @@ final class AgentPresenceController {
     /// compatibility catalog on the main actor.
     static func dockMenuAgentTitle(for task: AgentTask) -> String {
         let agent = task.descriptor.agentType.displayName
-        let projectName = URL(
-            fileURLWithPath: task.project.canonicalProjectPath
-        ).lastPathComponent
+        let projectName = task.route.surface == .quickTerminalStandalone
+            ? Strings.quickTerminalText()
+            : URL(
+                fileURLWithPath: task.project.canonicalProjectPath
+            ).lastPathComponent
         let trimmedTitle = task.title?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if let trimmedTitle, !trimmedTitle.isEmpty {

--- a/Pine/Agent/AgentTaskModels.swift
+++ b/Pine/Agent/AgentTaskModels.swift
@@ -41,17 +41,38 @@ nonisolated enum AgentTaskRouteAvailability: String, Codable, Sendable {
     case missing
 }
 
+/// The runtime surface that owns a terminal route.
+///
+/// Surface identity is navigation and lifecycle authority. A project pane and
+/// the application-wide Quick Terminal must never become interchangeable only
+/// because their runtime UUIDs happen to match.
+nonisolated enum AgentTaskTerminalSurface: String, Codable, Hashable, Sendable {
+    case projectWindow
+    case quickTerminalProject
+    case quickTerminalStandalone
+
+    var isQuickTerminal: Bool {
+        self != .projectWindow
+    }
+
+    var isProjectBacked: Bool {
+        self != .quickTerminalStandalone
+    }
+}
+
 /// Stable value route back to the terminal surface that owns a run.
 ///
 /// `terminalID` identifies the terminal lifetime; `tabID` and `paneID` locate
 /// it in the current layout. Moving a tab changes only `paneID`.
 nonisolated struct AgentTaskRoute: Codable, Equatable, Sendable {
+    let surface: AgentTaskTerminalSurface
     let paneID: UUID
     let tabID: UUID
     let terminalID: UUID
     var availability: AgentTaskRouteAvailability
 
     private enum CodingKeys: String, CodingKey {
+        case surface
         case paneID
         case tabID
         case terminalID
@@ -59,15 +80,43 @@ nonisolated struct AgentTaskRoute: Codable, Equatable, Sendable {
     }
 
     init(
+        surface: AgentTaskTerminalSurface = .projectWindow,
         paneID: UUID,
         tabID: UUID,
         terminalID: UUID,
         availability: AgentTaskRouteAvailability = .available
     ) {
+        self.surface = surface
         self.paneID = paneID
         self.tabID = tabID
         self.terminalID = terminalID
         self.availability = availability
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        // Routes persisted before Quick Terminal integration are all project
+        // pane routes. Decode them additively without a metadata schema bump.
+        surface = try values.decodeIfPresent(
+            AgentTaskTerminalSurface.self,
+            forKey: .surface
+        ) ?? .projectWindow
+        paneID = try values.decode(UUID.self, forKey: .paneID)
+        tabID = try values.decode(UUID.self, forKey: .tabID)
+        terminalID = try values.decode(UUID.self, forKey: .terminalID)
+        availability = try values.decode(
+            AgentTaskRouteAvailability.self,
+            forKey: .availability
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        try values.encode(surface, forKey: .surface)
+        try values.encode(paneID, forKey: .paneID)
+        try values.encode(tabID, forKey: .tabID)
+        try values.encode(terminalID, forKey: .terminalID)
+        try values.encode(availability, forKey: .availability)
     }
 }
 

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -10,6 +10,7 @@ import Observation
 
 nonisolated private struct AgentTaskTerminalKey: Hashable, Sendable {
     let project: AgentTaskProjectIdentity
+    let surface: AgentTaskTerminalSurface
     let terminalID: UUID
 }
 
@@ -458,6 +459,7 @@ final class AgentTaskRegistry {
         guard let task = task(for: taskID) else { return false }
         let key = AgentTaskTerminalKey(
             project: task.project,
+            surface: task.route.surface,
             terminalID: terminalID
         )
         return taskIDByTerminal[key] == taskID
@@ -511,6 +513,7 @@ final class AgentTaskRegistry {
                     taskID: existingTaskID,
                     key: AgentTaskTerminalKey(
                         project: task.project,
+                        surface: task.route.surface,
                         terminalID: task.route.terminalID
                     )
                 )
@@ -602,8 +605,9 @@ final class AgentTaskRegistry {
                 removeLiveOwnership(
                     taskID: taskID,
                     key: AgentTaskTerminalKey(
-                    project: task.project,
-                    terminalID: task.route.terminalID
+                        project: task.project,
+                        surface: task.route.surface,
+                        terminalID: task.route.terminalID
                     )
                 )
             }
@@ -927,7 +931,7 @@ final class AgentTaskRegistry {
     ) {
         var projects = Set<AgentTaskProjectIdentity>()
         for key in Array(pendingClaims.keys)
-        where matchesProject(key.project) {
+        where key.surface == .projectWindow && matchesProject(key.project) {
             guard var claim = pendingClaims[key] else { continue }
             if isOpen, claim.route.availability == .background {
                 claim.route.availability = .available
@@ -939,7 +943,10 @@ final class AgentTaskRegistry {
             pendingClaims[key] = claim
         }
         for (_, taskID) in taskIDByTerminal
-        where task(for: taskID).map({ matchesProject($0.project) }) == true {
+        where task(for: taskID).map({
+            $0.route.surface == .projectWindow
+                && matchesProject($0.project)
+        }) == true {
             guard let index = taskIndex(for: taskID) else { continue }
             let availability = tasks[index].route.availability
             if isOpen, availability == .background {
@@ -968,6 +975,7 @@ final class AgentTaskRegistry {
         expireClaims()
         let key = AgentTaskTerminalKey(
             project: project,
+            surface: route.surface,
             terminalID: terminalID
         )
         guard !isTerminating,
@@ -978,9 +986,11 @@ final class AgentTaskRegistry {
             pendingClaims[key] = claim
         }
         guard let taskID = taskIDByTerminal[key],
-              let index = taskIndex(for: taskID) else { return }
+              let index = taskIndex(for: taskID),
+              tasks[index].route.surface == route.surface else { return }
         let availability = tasks[index].route.availability
         tasks[index].route = AgentTaskRoute(
+            surface: route.surface,
             paneID: route.paneID,
             tabID: route.tabID,
             terminalID: route.terminalID,
@@ -992,6 +1002,7 @@ final class AgentTaskRegistry {
         )
         taskIDByTerminal[AgentTaskTerminalKey(
             project: project,
+            surface: route.surface,
             terminalID: terminalID
         )] = tasks[index].id
         markDirty(project)
@@ -1002,11 +1013,16 @@ final class AgentTaskRegistry {
     func markTerminalClosed(
         terminalID: UUID,
         project: AgentTaskProjectIdentity,
+        surface: AgentTaskTerminalSurface = .projectWindow,
         at timestamp: Date = Date()
     ) {
         expireClaims()
         guard !isTerminating else { return }
-        let key = AgentTaskTerminalKey(project: project, terminalID: terminalID)
+        let key = AgentTaskTerminalKey(
+            project: project,
+            surface: surface,
+            terminalID: terminalID
+        )
         cancelClaim(for: key)
         guard let taskID = taskIDByTerminal[key],
               let index = taskIndex(for: taskID) else { return }
@@ -1522,9 +1538,11 @@ final class AgentTaskRegistry {
         tasks[taskIndex].runs[runIndex] = run
         if let route,
            route.terminalID == run.terminalID,
-           route.tabID == run.terminalID {
+           route.tabID == run.terminalID,
+           route.surface == tasks[taskIndex].route.surface {
             let availability = tasks[taskIndex].route.availability
             tasks[taskIndex].route = AgentTaskRoute(
+                surface: route.surface,
                 paneID: route.paneID,
                 tabID: route.tabID,
                 terminalID: route.terminalID,
@@ -1674,6 +1692,7 @@ final class AgentTaskRegistry {
         taskIDByRunID[run.id] = task.id
         taskIDByTerminal[AgentTaskTerminalKey(
             project: task.project,
+            surface: task.route.surface,
             terminalID: task.route.terminalID
         )] = task.id
     }
@@ -1759,6 +1778,7 @@ final class AgentTaskRegistry {
     ) -> AgentTaskTerminalKey {
         AgentTaskTerminalKey(
             project: context.project,
+            surface: context.route.surface,
             terminalID: context.route.terminalID
         )
     }
@@ -1930,6 +1950,7 @@ final class AgentTaskRegistry {
     ) -> Bool {
         guard let task = task(for: taskID),
               task.project == context.project,
+              task.route.surface == context.route.surface,
               task.route.terminalID == context.route.terminalID,
               task.descriptor.agentType == session.agentType,
               let run = task.runs.last,
@@ -1953,6 +1974,7 @@ final class AgentTaskRegistry {
         guard let index = taskIndex(forRunID: sessionID) else { return }
         let key = AgentTaskTerminalKey(
             project: tasks[index].project,
+            surface: tasks[index].route.surface,
             terminalID: tasks[index].route.terminalID
         )
         endRun(sessionID: sessionID, at: timestamp)

--- a/Pine/Agent/AgentWorktreeService.swift
+++ b/Pine/Agent/AgentWorktreeService.swift
@@ -24,6 +24,10 @@ nonisolated struct AgentManagedWorktree: Sendable, Equatable {
     let worktreeRoot: URL
     let branchName: String
     let baseCommit: String
+    /// Filesystem-instance proof captured by the worktree service before the
+    /// managed identity leaves its serialized creation boundary. Consumers
+    /// must revalidate it off the main actor before admitting the worktree.
+    let repositoryProof: RecentAgentTaskRepositoryProof
 }
 
 nonisolated enum AgentWorktreeCreateFailure: Error, Sendable, Equatable {
@@ -165,6 +169,12 @@ actor AgentWorktreeService {
         ) else {
             return .failed(.invalidRepository)
         }
+        guard let initialRepositoryProof =
+                RecentAgentTaskFilesystemValidator.repositoryProof(
+                    forRepository: repository
+                ) else {
+            return .failed(.invalidRepository)
+        }
         guard let managedRoot = secureExistingDirectory(request.managedRoot)
         else {
             return .failed(.unsafeManagedRoot)
@@ -221,13 +231,26 @@ actor AgentWorktreeService {
             return .failed(.primaryCheckoutChanged(destination))
         }
 
+        let identity = AgentTaskProjectIdentity(
+            canonicalProjectPath: repository.path,
+            canonicalWorktreePath: destination.path
+        )
+        guard let finalRepositoryProof =
+                RecentAgentTaskFilesystemValidator.repositoryProof(
+                    for: identity
+                ), finalRepositoryProof.identifiesSameRepository(
+                    as: initialRepositoryProof
+                ) else {
+            return .failed(.createdWorktreeInvalid(destination))
+        }
         return .created(AgentManagedWorktree(
             taskID: request.taskID,
             repositoryRoot: repository,
             managedRoot: managedRoot,
             worktreeRoot: destination,
             branchName: request.branchName,
-            baseCommit: baseCommit
+            baseCommit: baseCommit,
+            repositoryProof: finalRepositoryProof
         ))
     }
 

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -925,7 +925,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
     )
 
     /// Central project registry — created early so it's available for AppKit fallback.
-    var registry = ProjectRegistry()
+    var registry = ProjectRegistry() {
+        didSet {
+            if oldValue !== registry {
+                oldValue.quickTerminalAgentRouter = nil
+            }
+            bindQuickTerminalAgentRouting()
+        }
+    }
 
     /// Application-wide, permission-gated agent notification coordinator.
     lazy var agentNotifications = AgentNotificationController(
@@ -955,6 +962,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
     let quickTerminalCoordinator = QuickTerminalController()
     private let hotkeyManager = GlobalHotkeyManager()
     private var hotkeySettingsBinding: QuickTerminalSettingsRuntimeBinding?
+
+    private func bindQuickTerminalAgentRouting() {
+        quickTerminalCoordinator.registry = registry
+        registry.quickTerminalAgentRouter = quickTerminalCoordinator
+    }
 
     /// `true` when the quick-terminal hotkey is explicitly disabled via the
     /// `--disable-quick-terminal` launch argument or `PINE_DISABLE_QUICK_TERMINAL`
@@ -1316,6 +1328,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSWindow.allowsAutomaticWindowTabbing = false
+        bindQuickTerminalAgentRouting()
         agentNotifications.start()
         agentPresence.start()
 
@@ -1331,7 +1344,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         // in the App Sandbox without Accessibility permission; disabled by
         // launch flag for UI tests / opt-out.
         if !Self.isQuickTerminalDisabled {
-            quickTerminalCoordinator.registry = registry
             hotkeyManager.onTrigger = { @Sendable [weak self] in
                 // Hop to MainActor: toggle touches @MainActor coordinator state.
                 Task { @MainActor in self?.quickTerminalCoordinator.toggle() }
@@ -1772,10 +1784,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         fallbackOpenProjectWindow: ((URL) -> Void)? = nil
     ) {
         NativeCommandDelivery.deferToNextMainRunLoop { [weak self] in
-            _ = self?.openRecentProject(
-                url,
-                fallbackOpenProjectWindow: fallbackOpenProjectWindow
-            )
+            Task { @MainActor [weak self] in
+                _ = await self?.openRecentProject(
+                    url,
+                    fallbackOpenProjectWindow: fallbackOpenProjectWindow
+                )
+            }
         }
     }
 
@@ -1785,20 +1799,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
     func openRecentProject(
         _ url: URL,
         fallbackOpenProjectWindow: ((URL) -> Void)? = nil
-    ) -> Bool {
-        let canonical = registry.canonicalProjectURL(url)
-        if registry.isWindowOpen(canonical),
-           let project = registry.openProjects[canonical],
+    ) async -> Bool {
+        let targetRegistry = registry
+        guard let project = await targetRegistry
+                .projectManagerForRecentProject(url),
+              !Task.isCancelled,
+              registry === targetRegistry,
+              let canonical = project.rootURL?.standardizedFileURL,
+              targetRegistry.openProjects[canonical] === project else {
+            return false
+        }
+        if targetRegistry.isWindowOpen(canonical),
            let window = liveProjectWindow(
                for: project,
                canonicalURL: canonical
            ) {
             window.makeKeyAndOrderFront(nil)
             NSApp.activate()
-            // Touch the registered project manager (no-op side effect; result
-            // intentionally unused) so the Open Recent path mirrors the normal
-            // open path that resolves the manager for the canonical URL.
-            _ = registry.projectManager(for: canonical)
             hideWelcome()
             return true
         }
@@ -1806,15 +1823,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         // A registry entry can briefly claim an open window after AppKit has
         // already hidden or retired its delegate. Move that model back to the
         // retained-background state before asking SwiftUI for a replacement.
-        if registry.isWindowOpen(canonical) {
-            registry.closeProjectWindow(canonical)
-        }
-        guard registry.projectManager(for: canonical) != nil else {
-            return false
+        if targetRegistry.isWindowOpen(canonical) {
+            targetRegistry.closeProjectWindow(canonical)
         }
         guard let openProjectWindow =
                 self.openProjectWindow ?? fallbackOpenProjectWindow else {
-            registry.closeProjectWindow(canonical)
+            targetRegistry.closeProjectWindow(canonical)
+            return false
+        }
+        guard !Task.isCancelled,
+              registry === targetRegistry,
+              targetRegistry.openProjects[canonical] === project else {
             return false
         }
         openProjectWindow(canonical)
@@ -2968,11 +2987,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             return false
         }
         registry.freezeAgentTasksForTermination()
+        quickTerminalCoordinator.freezeAgentTasksForTermination()
         registry.agentTasks.prepareForApplicationTermination()
         func rollbackAgentTasks() async {
-            guard await registry.cancelAgentTaskTermination(
+            let rollbackWasSaved = await registry.cancelAgentTaskTermination(
                 until: terminationDeadline
-            ) else {
+            )
+            quickTerminalCoordinator.cancelAgentTaskTermination()
+            guard rollbackWasSaved else {
                 Logger.app.error(
                     "Agent task rollback did not reach a clean persistence barrier"
                 )

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -341,7 +341,7 @@ final class ProjectManager {
         case invalidated
     }
 
-    let workspace = WorkspaceManager()
+    let workspace: WorkspaceManager
     let terminal: TerminalManager
     /// Structured agent-action feed for the Activity Panel (vision #933,
     /// Phase 2 — Visibility, issue #1072).
@@ -1541,6 +1541,13 @@ final class ProjectManager {
     #endif
     private var editorContextCommandGeneration: UInt64 = 0
     private let contextPresentationIdentity: ContextPresentationIdentity
+    @ObservationIgnored
+    private var agentTaskFilesystemAdmission:
+        RecentAgentTaskFilesystemValidationLease?
+    @ObservationIgnored
+    private var agentTaskFilesystemAdmissionGeneration = UUID()
+    @ObservationIgnored
+    private var agentTaskFilesystemIdentity: AgentTaskProjectIdentity?
 
     #if DEBUG
     func removeRecoveryManagerForTesting() {
@@ -1554,10 +1561,15 @@ final class ProjectManager {
         lspSettings: LSPSettings = .shared,
         agentProcessSnapshotPoller: AgentProcessSnapshotPoller? = nil,
         agentTaskRegistry: AgentTaskRegistry? = nil,
+        workspaceFilesystemValidationSeam:
+            @escaping @Sendable () async -> Void = {},
         contextFileWriter: ContextFileWriter = ContextFileWriter(),
         contextPresentationIdentity: ContextPresentationIdentity =
             ContextPresentationIdentity(epoch: 1)
     ) {
+        self.workspace = WorkspaceManager(
+            filesystemValidationSeam: workspaceFilesystemValidationSeam
+        )
         self.contextFileWriter = contextFileWriter
         self.contextPresentationIdentity = contextPresentationIdentity
         self.terminal = TerminalManager(
@@ -1581,6 +1593,7 @@ final class ProjectManager {
         }
         paneManager.configureTerminalTab = { [weak self] tab in
             self?.terminal.configureAgentLifecycle(for: tab)
+            self?.configureFilesystemAdmission(for: tab)
         }
         problemsController.configureDocumentStatesProvider { [weak self] in
             self?.problemsDocumentStates ?? []
@@ -1819,6 +1832,8 @@ final class ProjectManager {
         searchProvider.cancel()
         lspManager.shutdownAll()
         terminal.shutdownPermanently()
+        agentTaskFilesystemAdmission = nil
+        agentTaskFilesystemAdmissionGeneration = UUID()
     }
 
     var requiresBackgroundRetention: Bool {
@@ -2090,15 +2105,36 @@ final class ProjectManager {
     }
     func loadDirectory(
         url: URL,
-        agentTaskProject: AgentTaskProjectIdentity? = nil
+        agentTaskProject: AgentTaskProjectIdentity? = nil,
+        filesystemAdmission:
+            RecentAgentTaskFilesystemValidationLease? = nil
     ) {
-        workspace.loadDirectory(url: url)
-        terminal.configureAgentTaskProject(
-            agentTaskProject ?? AgentTaskProjectIdentity(
+        let projectIdentity = agentTaskProject ?? AgentTaskProjectIdentity(
                 canonicalProjectPath: url.path,
                 canonicalWorktreePath: url.path
-            )
         )
+        replaceAgentTaskFilesystemAdmission(
+            filesystemAdmission,
+            identity: projectIdentity
+        )
+        let admissionGeneration = agentTaskFilesystemAdmissionGeneration
+        let workspaceValidator: (@Sendable () async -> Bool)?
+        if filesystemAdmission != nil {
+            workspaceValidator = { [weak self] in
+                guard let self else { return false }
+                return await self.revalidateAgentTaskFilesystemAdmission(
+                    expectedGeneration: admissionGeneration,
+                    workingDirectory: url
+                )
+            }
+        } else {
+            workspaceValidator = nil
+        }
+        workspace.loadDirectory(
+            url: url,
+            filesystemValidator: workspaceValidator
+        )
+        terminal.configureAgentTaskProject(projectIdentity)
         setupRecovery(projectURL: url)
         agentHistory.updateProjectRoot(url)
         synchronizeAgentHandoff(projectRoot: url)
@@ -2107,6 +2143,60 @@ final class ProjectManager {
         seedAgentActivityUITestFixture(projectURL: url)
         seedAgentAttentionUITestFixture(projectURL: url)
         #endif
+    }
+
+    /// Replaces only an already-proved descriptor lease. No filesystem work
+    /// occurs on MainActor; a new generation fences every load/PTY validation
+    /// still in flight for the prior admitted instance.
+    func replaceAgentTaskFilesystemAdmission(
+        _ admission: RecentAgentTaskFilesystemValidationLease?,
+        identity: AgentTaskProjectIdentity
+    ) {
+        agentTaskFilesystemAdmission = admission
+        agentTaskFilesystemIdentity = identity
+        agentTaskFilesystemAdmissionGeneration = UUID()
+        paneManager.allTerminalTabs.forEach(configureFilesystemAdmission)
+    }
+
+    private func configureFilesystemAdmission(for tab: TerminalTab) {
+        guard agentTaskFilesystemAdmission != nil else {
+            tab.configureWorkingDirectoryValidation(nil)
+            return
+        }
+        tab.configureWorkingDirectoryValidation { [weak self] directory in
+            guard let self else { return false }
+            return await self.revalidateAgentTaskFilesystemAdmission(
+                workingDirectory: directory
+            )
+        }
+    }
+
+    func revalidateAgentTaskFilesystemAdmission(
+        expectedIdentity: AgentTaskProjectIdentity? = nil,
+        expectedGeneration: UUID? = nil,
+        workingDirectory: URL? = nil
+    ) async -> Bool {
+        guard let identity = agentTaskFilesystemIdentity else { return false }
+        if let expectedIdentity, expectedIdentity != identity { return false }
+        if let workingDirectory,
+           workingDirectory.standardizedFileURL.path
+            != identity.canonicalWorktreePath { return false }
+        if identity.canonicalProjectPath == identity.canonicalWorktreePath {
+            return true
+        }
+        guard let admission = agentTaskFilesystemAdmission else { return false }
+        let generation = agentTaskFilesystemAdmissionGeneration
+        if let expectedGeneration, expectedGeneration != generation {
+            return false
+        }
+        let valid = await Task.detached(priority: .utility) {
+            admission.revalidate()
+        }.value
+        return !Task.isCancelled
+            && valid
+            && agentTaskFilesystemAdmission === admission
+            && agentTaskFilesystemAdmissionGeneration == generation
+            && agentTaskFilesystemIdentity == identity
     }
 
     // MARK: - Agent activity file-system correlation (#1072)

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -5,8 +5,993 @@
 //  Created by Claude on 13.03.2026.
 //
 
+import Darwin
 import os
 import SwiftUI
+
+nonisolated struct RecentAgentTaskFilesystemObjectProof:
+    Codable, Equatable, Sendable {
+    let device: UInt64
+    let inode: UInt64
+    let generation: UInt64
+    let birthSeconds: Int64
+    let birthNanoseconds: Int64
+    let kind: UInt16
+}
+
+nonisolated struct RecentAgentTaskRepositoryProof:
+    Codable, Equatable, Sendable {
+    let commonDirectoryDevice: UInt64
+    let commonDirectoryInode: UInt64
+    let commonDirectoryGeneration: UInt64
+    let commonDirectoryBirthSeconds: Int64
+    let commonDirectoryBirthNanoseconds: Int64
+    /// Exact linked-worktree instance. Older records decode these as nil and
+    /// therefore fail closed for every distinct project/worktree admission.
+    let projectRoot: RecentAgentTaskFilesystemObjectProof?
+    let projectGitDirectory: RecentAgentTaskFilesystemObjectProof?
+    let worktreeRoot: RecentAgentTaskFilesystemObjectProof?
+    let worktreeGitDirectory: RecentAgentTaskFilesystemObjectProof?
+
+    init(
+        commonDirectoryDevice: UInt64,
+        commonDirectoryInode: UInt64,
+        commonDirectoryGeneration: UInt64,
+        commonDirectoryBirthSeconds: Int64,
+        commonDirectoryBirthNanoseconds: Int64,
+        projectRoot: RecentAgentTaskFilesystemObjectProof? = nil,
+        projectGitDirectory: RecentAgentTaskFilesystemObjectProof? = nil,
+        worktreeRoot: RecentAgentTaskFilesystemObjectProof? = nil,
+        worktreeGitDirectory: RecentAgentTaskFilesystemObjectProof? = nil
+    ) {
+        self.commonDirectoryDevice = commonDirectoryDevice
+        self.commonDirectoryInode = commonDirectoryInode
+        self.commonDirectoryGeneration = commonDirectoryGeneration
+        self.commonDirectoryBirthSeconds = commonDirectoryBirthSeconds
+        self.commonDirectoryBirthNanoseconds = commonDirectoryBirthNanoseconds
+        self.projectRoot = projectRoot
+        self.projectGitDirectory = projectGitDirectory
+        self.worktreeRoot = worktreeRoot
+        self.worktreeGitDirectory = worktreeGitDirectory
+    }
+
+    var hasExactWorktreeInstance: Bool {
+        projectRoot != nil
+            && projectGitDirectory != nil
+            && worktreeRoot != nil
+            && worktreeGitDirectory != nil
+    }
+
+    func identifiesSameRepository(
+        as other: RecentAgentTaskRepositoryProof
+    ) -> Bool {
+        commonDirectoryDevice == other.commonDirectoryDevice
+            && commonDirectoryInode == other.commonDirectoryInode
+            && commonDirectoryGeneration == other.commonDirectoryGeneration
+            && commonDirectoryBirthSeconds
+                == other.commonDirectoryBirthSeconds
+            && commonDirectoryBirthNanoseconds
+                == other.commonDirectoryBirthNanoseconds
+    }
+}
+
+nonisolated private struct RecentAgentTaskProjectRecord:
+    Codable, Equatable, Sendable {
+    let identity: AgentTaskProjectIdentity
+    let repositoryProof: RecentAgentTaskRepositoryProof?
+}
+
+nonisolated private func unsignedFilesystemIdentity<Identity>(
+    _ identity: Identity
+) -> UInt64 where Identity: FixedWidthInteger {
+    // Darwin's `dev_t` is signed on supported SDKs. A value with its high bit
+    // set must preserve that kernel bit pattern rather than trap in UInt64's
+    // checked signed conversion. This also leaves unsigned `ino_t` unchanged.
+    UInt64(truncatingIfNeeded: identity)
+}
+
+nonisolated private struct StableFilesystemObjectIdentity: Equatable, Sendable {
+    let device: UInt64
+    let inode: UInt64
+    let generation: UInt64
+    let birthSeconds: Int64
+    let birthNanoseconds: Int64
+    let kind: UInt16
+
+    init(_ information: stat) {
+        device = unsignedFilesystemIdentity(information.st_dev)
+        inode = unsignedFilesystemIdentity(information.st_ino)
+        generation = unsignedFilesystemIdentity(information.st_gen)
+        birthSeconds = Int64(information.st_birthtimespec.tv_sec)
+        birthNanoseconds = Int64(information.st_birthtimespec.tv_nsec)
+        kind = information.st_mode & S_IFMT
+    }
+
+    init(
+        device: UInt64,
+        inode: UInt64,
+        generation: UInt64,
+        birthSeconds: Int64,
+        birthNanoseconds: Int64,
+        kind: UInt16
+    ) {
+        self.device = device
+        self.inode = inode
+        self.generation = generation
+        self.birthSeconds = birthSeconds
+        self.birthNanoseconds = birthNanoseconds
+        self.kind = kind
+    }
+
+    var persistedProof: RecentAgentTaskFilesystemObjectProof {
+        RecentAgentTaskFilesystemObjectProof(
+            device: device,
+            inode: inode,
+            generation: generation,
+            birthSeconds: birthSeconds,
+            birthNanoseconds: birthNanoseconds,
+            kind: kind
+        )
+    }
+}
+
+/// A descriptor-held path witness. Keeping the descriptor alive prevents the
+/// validated object from disappearing while every graph edge is rechecked;
+/// comparing its captured identity with both `fstat` and the current path
+/// rejects atomic path replacement without doing filesystem I/O on MainActor.
+nonisolated private final class StablePathDescriptor: @unchecked Sendable {
+    let url: URL
+    let descriptor: Int32
+    let information: stat
+    let kind: UInt16
+    private let parent: StablePathDescriptor?
+    private let entryName: String?
+
+    init?(url: URL, kind: UInt16) {
+        let flags = O_RDONLY | O_CLOEXEC | O_NOFOLLOW
+            | (kind == S_IFDIR ? O_DIRECTORY : 0)
+        let descriptor = Darwin.open(url.path, flags)
+        guard descriptor >= 0 else { return nil }
+        var information = stat()
+        var currentPath = stat()
+        guard fstat(descriptor, &information) == 0,
+              (information.st_mode & S_IFMT) == kind,
+              lstat(url.path, &currentPath) == 0,
+              RecentAgentTaskFilesystemValidator.stableIdentityMatches(
+                  information,
+                  currentPath,
+                  kind: kind
+              ) else {
+            Darwin.close(descriptor)
+            return nil
+        }
+        self.url = url
+        self.descriptor = descriptor
+        self.information = information
+        self.kind = kind
+        parent = nil
+        entryName = nil
+    }
+
+    init?(
+        parent: StablePathDescriptor,
+        entryName: String,
+        url: URL,
+        kind: UInt16
+    ) {
+        let flags = O_RDONLY | O_CLOEXEC | O_NOFOLLOW
+            | (kind == S_IFDIR ? O_DIRECTORY : 0)
+        let descriptor = entryName.withCString {
+            Darwin.openat(parent.descriptor, $0, flags)
+        }
+        guard descriptor >= 0 else { return nil }
+        var information = stat()
+        var currentEntry = stat()
+        let entryResult = entryName.withCString {
+            Darwin.fstatat(
+                parent.descriptor,
+                $0,
+                &currentEntry,
+                AT_SYMLINK_NOFOLLOW
+            )
+        }
+        guard fstat(descriptor, &information) == 0,
+              entryResult == 0,
+              RecentAgentTaskFilesystemValidator.stableIdentityMatches(
+                  information,
+                  currentEntry,
+                  kind: kind
+              ) else {
+            Darwin.close(descriptor)
+            return nil
+        }
+        self.url = url
+        self.descriptor = descriptor
+        self.information = information
+        self.kind = kind
+        self.parent = parent
+        self.entryName = entryName
+    }
+
+    deinit {
+        Darwin.close(descriptor)
+    }
+
+    func revalidate() -> Bool {
+        var descriptorState = stat()
+        var pathState = stat()
+        let pathResult: Int32
+        if let parent, let entryName {
+            pathResult = entryName.withCString {
+                Darwin.fstatat(
+                    parent.descriptor,
+                    $0,
+                    &pathState,
+                    AT_SYMLINK_NOFOLLOW
+                )
+            }
+        } else {
+            pathResult = lstat(url.path, &pathState)
+        }
+        guard fstat(descriptor, &descriptorState) == 0,
+              pathResult == 0,
+              RecentAgentTaskFilesystemValidator.stableIdentityMatches(
+                  information,
+                  descriptorState,
+                  kind: kind
+              ),
+              RecentAgentTaskFilesystemValidator.stableIdentityMatches(
+                  descriptorState,
+                  pathState,
+                  kind: kind
+              ) else { return false }
+        if kind == S_IFREG {
+            return RecentAgentTaskFilesystemValidator
+                .stableFileMetadataMatches(information, descriptorState)
+        }
+        return true
+    }
+}
+
+/// Binds an intermediate symbolic-link edge to both its filesystem identity
+/// and exact target text. The target is resolved explicitly by the descriptor
+/// walker; no later open is allowed to follow an unrecorded link implicitly.
+nonisolated private final class StableSymlinkWitness: @unchecked Sendable {
+    let parent: StablePathDescriptor
+    let entryName: String
+    let information: stat
+    let target: String
+
+    init?(parent: StablePathDescriptor, entryName: String) {
+        guard let snapshot = Self.snapshot(
+            parent: parent,
+            entryName: entryName
+        ) else { return nil }
+        self.parent = parent
+        self.entryName = entryName
+        information = snapshot.information
+        target = snapshot.target
+    }
+
+    func revalidate() -> Bool {
+        guard let current = Self.snapshot(
+            parent: parent,
+            entryName: entryName
+        ) else { return false }
+        return RecentAgentTaskFilesystemValidator.stableIdentityMatches(
+            information,
+            current.information,
+            kind: S_IFLNK
+        ) && current.target == target
+    }
+
+    private static func snapshot(
+        parent: StablePathDescriptor,
+        entryName: String
+    ) -> (information: stat, target: String)? {
+        var before = stat()
+        let beforeResult = entryName.withCString {
+            Darwin.fstatat(
+                parent.descriptor,
+                $0,
+                &before,
+                AT_SYMLINK_NOFOLLOW
+            )
+        }
+        guard beforeResult == 0,
+              (before.st_mode & S_IFMT) == S_IFLNK else { return nil }
+        var bytes = [UInt8](repeating: 0, count: Int(PATH_MAX) + 1)
+        let count = entryName.withCString { name in
+            bytes.withUnsafeMutableBytes { buffer in
+                Darwin.readlinkat(
+                    parent.descriptor,
+                    name,
+                    buffer.baseAddress,
+                    Int(PATH_MAX)
+                )
+            }
+        }
+        guard count > 0, count <= Int(PATH_MAX) else { return nil }
+        var after = stat()
+        let afterResult = entryName.withCString {
+            Darwin.fstatat(
+                parent.descriptor,
+                $0,
+                &after,
+                AT_SYMLINK_NOFOLLOW
+            )
+        }
+        guard afterResult == 0,
+              RecentAgentTaskFilesystemValidator.stableIdentityMatches(
+                  before,
+                  after,
+                  kind: S_IFLNK
+              ),
+              let target = String(
+                  bytes: bytes.prefix(count),
+                  encoding: .utf8
+              ),
+              !target.isEmpty,
+              !target.utf8.contains(0) else { return nil }
+        return (before, target)
+    }
+}
+
+/// Records that `commondir` did not exist relative to the exact Git directory
+/// descriptor. A creation after graph resolution changes repository meaning
+/// and must invalidate the whole lease.
+nonisolated private struct MissingDirectoryEntryWitness: @unchecked Sendable {
+    let parent: StablePathDescriptor
+    let entryName: String
+
+    func revalidate() -> Bool {
+        var information = stat()
+        let result = entryName.withCString {
+            Darwin.fstatat(
+                parent.descriptor,
+                $0,
+                &information,
+                AT_SYMLINK_NOFOLLOW
+            )
+        }
+        return result == -1 && errno == ENOENT
+    }
+}
+
+/// Holds every filesystem object and absent edge used to derive one project /
+/// worktree relationship. Callers retain this through their final MainActor
+/// commit and perform a detached revalidation immediately before mutation.
+nonisolated final class RecentAgentTaskFilesystemValidationLease:
+    @unchecked Sendable {
+    let identity: AgentTaskProjectIdentity
+    let proof: RecentAgentTaskRepositoryProof?
+    let canonicalWorktree: URL
+    private let descriptors: [StablePathDescriptor]
+    private let symlinks: [StableSymlinkWitness]
+    private let missingEntries: [MissingDirectoryEntryWitness]
+
+    fileprivate init(
+        identity: AgentTaskProjectIdentity,
+        proof: RecentAgentTaskRepositoryProof?,
+        canonicalWorktree: URL,
+        descriptors: [StablePathDescriptor],
+        symlinks: [StableSymlinkWitness],
+        missingEntries: [MissingDirectoryEntryWitness]
+    ) {
+        self.identity = identity
+        self.proof = proof
+        self.canonicalWorktree = canonicalWorktree
+        self.descriptors = descriptors
+        self.symlinks = symlinks
+        self.missingEntries = missingEntries
+    }
+
+    func revalidate() -> Bool {
+        descriptors.allSatisfy { $0.revalidate() }
+            && symlinks.allSatisfy { $0.revalidate() }
+            && missingEntries.allSatisfy { $0.revalidate() }
+    }
+}
+
+nonisolated private struct PreparedQuickTerminalAgentScope: @unchecked Sendable {
+    let registration: QuickTerminalAgentScopeRegistration
+    let sourceRecord: RecentAgentTaskProjectRecord?
+    let lease: RecentAgentTaskFilesystemValidationLease
+}
+
+/// Immutable filesystem validation used only from detached tasks. It owns no
+/// application state and never hops onto the main actor for path, stat, or
+/// bounded Git-control-file I/O.
+nonisolated enum RecentAgentTaskFilesystemValidator {
+    private struct WorkingTreeGraph {
+        let workingTreeURL: URL
+        let root: StablePathDescriptor
+        let gitDirectory: StablePathDescriptor
+        let commonDirectory: StablePathDescriptor
+        let descriptors: [StablePathDescriptor]
+        let symlinks: [StableSymlinkWitness]
+        let missingEntries: [MissingDirectoryEntryWitness]
+    }
+
+    private struct DirectoryDescriptorWalk {
+        let final: StablePathDescriptor
+        let descriptors: [StablePathDescriptor]
+        let symlinks: [StableSymlinkWitness]
+    }
+
+    fileprivate static func preparedRegistration(
+        workingDirectory: URL,
+        requestedSurface: AgentTaskTerminalSurface,
+        record: RecentAgentTaskProjectRecord?
+    ) -> PreparedQuickTerminalAgentScope? {
+        guard requestedSurface.isQuickTerminal,
+              let canonicalWorkingDirectory = canonicalExistingDirectory(
+                  workingDirectory
+              ),
+              let standaloneLease = validationLease(
+                  for: AgentTaskProjectIdentity(
+                      canonicalProjectPath: canonicalWorkingDirectory.path,
+                      canonicalWorktreePath: canonicalWorkingDirectory.path
+                  ),
+                  expectedProof: nil
+              ) else { return nil }
+        if requestedSurface == .quickTerminalProject,
+           let record,
+           record.identity.canonicalWorktreePath
+                == canonicalWorkingDirectory.path,
+           let projectLease = validationLease(
+               for: record.identity,
+               expectedProof: record.repositoryProof
+           ) {
+            return PreparedQuickTerminalAgentScope(
+                registration: QuickTerminalAgentScopeRegistration(
+                    project: record.identity,
+                    surface: .quickTerminalProject
+                ),
+                sourceRecord: record,
+                lease: projectLease
+            )
+        }
+        return PreparedQuickTerminalAgentScope(
+            registration: QuickTerminalAgentScopeRegistration(
+                project: standaloneLease.identity,
+                surface: .quickTerminalStandalone
+            ),
+            sourceRecord: record,
+            lease: standaloneLease
+        )
+    }
+
+    fileprivate static func validationLease(
+        for identity: AgentTaskProjectIdentity,
+        expectedProof: RecentAgentTaskRepositoryProof?
+    ) -> RecentAgentTaskFilesystemValidationLease? {
+        let projectURL = URL(
+            fileURLWithPath: identity.canonicalProjectPath,
+            isDirectory: true
+        ).standardizedFileURL
+        let worktreeURL = URL(
+            fileURLWithPath: identity.canonicalWorktreePath,
+            isDirectory: true
+        ).standardizedFileURL
+        guard projectURL.path == identity.canonicalProjectPath,
+              worktreeURL.path == identity.canonicalWorktreePath else {
+            return nil
+        }
+
+        if projectURL == worktreeURL {
+            guard expectedProof == nil,
+                  let root = canonicalDirectoryDescriptor(projectURL) else {
+                return nil
+            }
+            let lease = RecentAgentTaskFilesystemValidationLease(
+                identity: identity,
+                proof: nil,
+                canonicalWorktree: worktreeURL,
+                descriptors: [root],
+                symlinks: [],
+                missingEntries: []
+            )
+            return lease.revalidate() ? lease : nil
+        }
+
+        guard let expectedProof,
+              let project = workingTreeGraph(projectURL),
+              let worktree = workingTreeGraph(worktreeURL),
+              project.workingTreeURL == projectURL,
+              worktree.workingTreeURL == worktreeURL,
+              project.commonDirectory.url.path
+                == worktree.commonDirectory.url.path,
+              StableFilesystemObjectIdentity(
+                  project.commonDirectory.information
+              ) == StableFilesystemObjectIdentity(
+                  worktree.commonDirectory.information
+              ) else { return nil }
+        let proof = repositoryProof(
+            project: project,
+            worktree: worktree
+        )
+        guard expectedProof.hasExactWorktreeInstance,
+              proof == expectedProof else { return nil }
+        let lease = RecentAgentTaskFilesystemValidationLease(
+            identity: identity,
+            proof: proof,
+            canonicalWorktree: worktreeURL,
+            descriptors: project.descriptors + worktree.descriptors,
+            symlinks: project.symlinks + worktree.symlinks,
+            missingEntries: project.missingEntries
+                + worktree.missingEntries
+        )
+        return lease.revalidate() ? lease : nil
+    }
+
+    static func repositoryProof(
+        for identity: AgentTaskProjectIdentity,
+        afterGraphResolution: (() -> Void)? = nil
+    ) -> RecentAgentTaskRepositoryProof? {
+        guard identity.canonicalProjectPath
+                != identity.canonicalWorktreePath,
+              let project = workingTreeGraph(URL(
+                  fileURLWithPath: identity.canonicalProjectPath,
+                  isDirectory: true
+              )),
+              let worktree = workingTreeGraph(URL(
+                  fileURLWithPath: identity.canonicalWorktreePath,
+                  isDirectory: true
+              )),
+              project.workingTreeURL.path
+                == identity.canonicalProjectPath,
+              worktree.workingTreeURL.path
+                == identity.canonicalWorktreePath,
+              project.commonDirectory.url.path
+                == worktree.commonDirectory.url.path,
+              StableFilesystemObjectIdentity(
+                  project.commonDirectory.information
+              ) == StableFilesystemObjectIdentity(
+                  worktree.commonDirectory.information
+              ) else { return nil }
+        let proof = repositoryProof(
+            project: project,
+            worktree: worktree
+        )
+        let lease = RecentAgentTaskFilesystemValidationLease(
+            identity: identity,
+            proof: proof,
+            canonicalWorktree: worktree.workingTreeURL,
+            descriptors: project.descriptors + worktree.descriptors,
+            symlinks: project.symlinks + worktree.symlinks,
+            missingEntries: project.missingEntries
+                + worktree.missingEntries
+        )
+        afterGraphResolution?()
+        return lease.revalidate() ? proof : nil
+    }
+
+    /// Captures the repository instance before a managed worktree mutation.
+    /// The worktree service compares this token with the linked worktree's
+    /// common-directory token after creation, so a path replacement at any
+    /// suspension boundary fails closed instead of changing logical owner.
+    static func repositoryProof(
+        forRepository repository: URL
+    ) -> RecentAgentTaskRepositoryProof? {
+        guard let graph = workingTreeGraph(repository),
+              graph.workingTreeURL.path == repository.path else { return nil }
+        let proof = repositoryProof(commonDirectory: graph.commonDirectory)
+        let lease = RecentAgentTaskFilesystemValidationLease(
+            identity: AgentTaskProjectIdentity(
+                canonicalProjectPath: graph.workingTreeURL.path,
+                canonicalWorktreePath: graph.workingTreeURL.path
+            ),
+            proof: proof,
+            canonicalWorktree: graph.workingTreeURL,
+            descriptors: graph.descriptors,
+            symlinks: graph.symlinks,
+            missingEntries: graph.missingEntries
+        )
+        return lease.revalidate() ? proof : nil
+    }
+
+    private static func repositoryProof(
+        commonDirectory: StablePathDescriptor
+    ) -> RecentAgentTaskRepositoryProof {
+        let identity = StableFilesystemObjectIdentity(
+            commonDirectory.information
+        )
+        return RecentAgentTaskRepositoryProof(
+            commonDirectoryDevice: identity.device,
+            commonDirectoryInode: identity.inode,
+            commonDirectoryGeneration: identity.generation,
+            commonDirectoryBirthSeconds: identity.birthSeconds,
+            commonDirectoryBirthNanoseconds: identity.birthNanoseconds
+        )
+    }
+
+    private static func repositoryProof(
+        project: WorkingTreeGraph,
+        worktree: WorkingTreeGraph
+    ) -> RecentAgentTaskRepositoryProof {
+        let common = StableFilesystemObjectIdentity(
+            project.commonDirectory.information
+        )
+        return RecentAgentTaskRepositoryProof(
+            commonDirectoryDevice: common.device,
+            commonDirectoryInode: common.inode,
+            commonDirectoryGeneration: common.generation,
+            commonDirectoryBirthSeconds: common.birthSeconds,
+            commonDirectoryBirthNanoseconds: common.birthNanoseconds,
+            projectRoot: StableFilesystemObjectIdentity(
+                project.root.information
+            ).persistedProof,
+            projectGitDirectory: StableFilesystemObjectIdentity(
+                project.gitDirectory.information
+            ).persistedProof,
+            worktreeRoot: StableFilesystemObjectIdentity(
+                worktree.root.information
+            ).persistedProof,
+            worktreeGitDirectory: StableFilesystemObjectIdentity(
+                worktree.gitDirectory.information
+            ).persistedProof
+        )
+    }
+
+    private static func workingTreeGraph(
+        _ workingTree: URL
+    ) -> WorkingTreeGraph? {
+        let workingTreeURL = workingTree.standardizedFileURL
+        guard let rootWalk = directoryDescriptorWalk(
+            workingTreeURL
+        ) else {
+            return nil
+        }
+        let root = rootWalk.final
+        var descriptors = rootWalk.descriptors
+        var symlinks = rootWalk.symlinks
+        var missingEntries: [MissingDirectoryEntryWitness] = []
+        let controlPath = workingTreeURL.appendingPathComponent(
+            ".git",
+            isDirectory: false
+        )
+        var controlState = stat()
+        guard lstat(controlPath.path, &controlState) == 0 else { return nil }
+
+        let gitDirectory: StablePathDescriptor
+        switch controlState.st_mode & S_IFMT {
+        case S_IFDIR:
+            guard let walk = directoryDescriptorWalk(controlPath) else {
+                return nil
+            }
+            gitDirectory = walk.final
+            descriptors.append(contentsOf: walk.descriptors)
+            symlinks.append(contentsOf: walk.symlinks)
+        case S_IFREG:
+            guard let control = StablePathDescriptor(
+                parent: root,
+                entryName: ".git",
+                url: controlPath,
+                kind: S_IFREG
+            ), let contents = boundedGitPathFile(control),
+                contents.hasPrefix("gitdir: ") else { return nil }
+            descriptors.append(control)
+            let path = String(contents.dropFirst("gitdir: ".count))
+            guard !path.isEmpty else { return nil }
+            let candidate = path.hasPrefix("/")
+                ? URL(fileURLWithPath: path, isDirectory: true)
+                : root.url.appendingPathComponent(path, isDirectory: true)
+            guard let walk = directoryDescriptorWalk(
+                candidate
+            ) else { return nil }
+            gitDirectory = walk.final
+            descriptors.append(contentsOf: walk.descriptors)
+            symlinks.append(contentsOf: walk.symlinks)
+        default:
+            return nil
+        }
+
+        var commonControlState = stat()
+        let commonControlResult = "commondir".withCString {
+            Darwin.fstatat(
+                gitDirectory.descriptor,
+                $0,
+                &commonControlState,
+                AT_SYMLINK_NOFOLLOW
+            )
+        }
+        if commonControlResult == -1 {
+            guard errno == ENOENT else { return nil }
+            missingEntries.append(MissingDirectoryEntryWitness(
+                parent: gitDirectory,
+                entryName: "commondir"
+            ))
+            let graph = WorkingTreeGraph(
+                workingTreeURL: workingTreeURL,
+                root: root,
+                gitDirectory: gitDirectory,
+                commonDirectory: gitDirectory,
+                descriptors: descriptors,
+                symlinks: symlinks,
+                missingEntries: missingEntries
+            )
+            return graphIsStable(graph) ? graph : nil
+        }
+
+        guard (commonControlState.st_mode & S_IFMT) == S_IFREG else {
+            return nil
+        }
+        let commonControlPath = gitDirectory.url.appendingPathComponent(
+            "commondir",
+            isDirectory: false
+        )
+        guard let commonControl = StablePathDescriptor(
+            parent: gitDirectory,
+            entryName: "commondir",
+            url: commonControlPath,
+            kind: S_IFREG
+        ), let commonPath = boundedGitPathFile(commonControl) else {
+            return nil
+        }
+        descriptors.append(commonControl)
+        let candidate = commonPath.hasPrefix("/")
+            ? URL(fileURLWithPath: commonPath, isDirectory: true)
+            : gitDirectory.url.appendingPathComponent(
+                commonPath,
+                isDirectory: true
+            )
+        guard let commonWalk = directoryDescriptorWalk(
+            candidate
+        ) else { return nil }
+        let commonDirectory = commonWalk.final
+        descriptors.append(contentsOf: commonWalk.descriptors)
+        symlinks.append(contentsOf: commonWalk.symlinks)
+        let graph = WorkingTreeGraph(
+            workingTreeURL: workingTreeURL,
+            root: root,
+            gitDirectory: gitDirectory,
+            commonDirectory: commonDirectory,
+            descriptors: descriptors,
+            symlinks: symlinks,
+            missingEntries: missingEntries
+        )
+        return graphIsStable(graph) ? graph : nil
+    }
+
+    private static func graphIsStable(_ graph: WorkingTreeGraph) -> Bool {
+        graph.descriptors.allSatisfy { $0.revalidate() }
+            && graph.symlinks.allSatisfy { $0.revalidate() }
+            && graph.missingEntries.allSatisfy { $0.revalidate() }
+    }
+
+    private static func canonicalDirectoryDescriptor(
+        _ candidate: URL
+    ) -> StablePathDescriptor? {
+        let canonical = candidate.resolvingSymlinksInPath().standardizedFileURL
+        return directoryDescriptorWalk(canonical)?.final
+    }
+
+    /// Opens each canonical path component separately with `O_NOFOLLOW` and
+    /// retains every descriptor in the resulting validation graph. Git path
+    /// expressions that contain an intermediate symlink therefore fail
+    /// closed; replacing a previously ordinary component with a symlink (or
+    /// any other object) invalidates its retained descriptor/path token.
+    private static func directoryDescriptorWalk(
+        _ candidate: URL
+    ) -> DirectoryDescriptorWalk? {
+        guard let normalizedPath = lexicallyNormalizedAbsolutePath(
+            candidate.path
+        ) else { return nil }
+        var currentURL = URL(fileURLWithPath: "/", isDirectory: true)
+        guard let root = StablePathDescriptor(
+            url: currentURL,
+            kind: S_IFDIR
+        ) else { return nil }
+        var descriptors = [root]
+        var symlinks: [StableSymlinkWitness] = []
+        var current = root
+        var components = normalizedPath.split(separator: "/").map(String.init)
+        var followedLinkCount = 0
+        while !components.isEmpty {
+            let component = components.removeFirst()
+            guard component != ".", component != "..", !component.isEmpty
+            else { return nil }
+            var entryState = stat()
+            let entryResult = component.withCString {
+                Darwin.fstatat(
+                    current.descriptor,
+                    $0,
+                    &entryState,
+                    AT_SYMLINK_NOFOLLOW
+                )
+            }
+            guard entryResult == 0 else { return nil }
+            if (entryState.st_mode & S_IFMT) == S_IFLNK {
+                guard followedLinkCount < 40 else { return nil }
+                guard let witness = StableSymlinkWitness(
+                          parent: current,
+                          entryName: component
+                      ) else {
+                    return nil
+                }
+                followedLinkCount += 1
+                symlinks.append(witness)
+                var targetPath = witness.target.hasPrefix("/")
+                    ? witness.target
+                    : currentURL.path + "/" + witness.target
+                if !components.isEmpty {
+                    targetPath += "/" + components.joined(separator: "/")
+                }
+                guard let resolvedPath = lexicallyNormalizedAbsolutePath(
+                    targetPath
+                ) else { return nil }
+                components = resolvedPath.split(separator: "/")
+                    .map(String.init)
+                current = root
+                currentURL = URL(
+                    fileURLWithPath: "/",
+                    isDirectory: true
+                )
+                continue
+            }
+            guard (entryState.st_mode & S_IFMT) == S_IFDIR else {
+                return nil
+            }
+            let nextURL = currentURL.appendingPathComponent(
+                component,
+                isDirectory: true
+            )
+            guard let next = StablePathDescriptor(
+                parent: current,
+                entryName: component,
+                url: nextURL,
+                kind: S_IFDIR
+            ) else { return nil }
+            descriptors.append(next)
+            current = next
+            currentURL = nextURL
+        }
+        return DirectoryDescriptorWalk(
+            final: current,
+            descriptors: descriptors,
+            symlinks: symlinks
+        )
+    }
+
+    /// Foundation canonicalizes `/private/var` back to `/var` on macOS. That
+    /// is useful for app identity but would loop while explicitly resolving
+    /// `/var -> private/var`. Git control paths need purely lexical dot-segment
+    /// removal so the descriptor walker, not Foundation, owns every symlink.
+    private static func lexicallyNormalizedAbsolutePath(
+        _ path: String
+    ) -> String? {
+        guard path.hasPrefix("/") else { return nil }
+        var result: [Substring] = []
+        for component in path.split(separator: "/", omittingEmptySubsequences: true) {
+            switch component {
+            case ".":
+                continue
+            case "..":
+                guard !result.isEmpty else { return nil }
+                result.removeLast()
+            default:
+                result.append(component)
+            }
+        }
+        return "/" + result.joined(separator: "/")
+    }
+
+    fileprivate static func canonicalExistingDirectory(
+        _ candidate: URL
+    ) -> URL? {
+        guard let descriptor = canonicalDirectoryDescriptor(candidate),
+              descriptor.revalidate() else { return nil }
+        return candidate.standardizedFileURL
+    }
+
+    fileprivate static func boundedGitPathFile(
+        _ url: URL,
+        beforeRead: (() -> Void)? = nil
+    ) -> String? {
+        guard let descriptor = StablePathDescriptor(
+            url: url,
+            kind: S_IFREG
+        ), let data = stableRegularFileBytes(
+            descriptor,
+            byteLimit: 4_096,
+            beforeRead: beforeRead
+        ), let text = String(data: data, encoding: .utf8) else { return nil }
+        return boundedGitPathLine(text)
+    }
+
+    private static func boundedGitPathFile(
+        _ descriptor: StablePathDescriptor
+    ) -> String? {
+        guard let data = stableRegularFileBytes(
+            descriptor,
+            byteLimit: 4_096
+        ), let text = String(data: data, encoding: .utf8) else { return nil }
+        return boundedGitPathLine(text)
+    }
+
+    private static func boundedGitPathLine(_ text: String) -> String? {
+        var bytes = Array(text.utf8)
+        if bytes.suffix(2).elementsEqual([0x0D, 0x0A]) {
+            bytes.removeLast(2)
+        } else if bytes.last == 0x0A {
+            bytes.removeLast()
+        }
+        guard !bytes.isEmpty,
+              !bytes.contains(0x00),
+              !bytes.contains(0x0A),
+              !bytes.contains(0x0D) else { return nil }
+        return String(bytes: bytes, encoding: .utf8)
+    }
+
+    private static func stableRegularFileBytes(
+        _ descriptor: StablePathDescriptor,
+        byteLimit: Int,
+        beforeRead: (() -> Void)? = nil
+    ) -> Data? {
+        guard byteLimit > 0 else { return nil }
+        let before = descriptor.information
+        guard (before.st_mode & S_IFMT) == S_IFREG,
+              before.st_size > 0,
+              before.st_size <= Int64(byteLimit) else { return nil }
+        beforeRead?()
+
+        var bytes = [UInt8](repeating: 0, count: byteLimit + 1)
+        var count = 0
+        var reachedEndOfFile = false
+        while count < bytes.count {
+            let readCount = bytes.withUnsafeMutableBytes { buffer in
+                Darwin.read(
+                    descriptor.descriptor,
+                    buffer.baseAddress?.advanced(by: count),
+                    buffer.count - count
+                )
+            }
+            if readCount < 0 {
+                guard errno == EINTR else { return nil }
+                continue
+            }
+            if readCount == 0 {
+                reachedEndOfFile = true
+                break
+            }
+            count += readCount
+        }
+
+        var after = stat()
+        guard fstat(descriptor.descriptor, &after) == 0,
+              stableFileMetadataMatches(before, after),
+              descriptor.revalidate(),
+              reachedEndOfFile,
+              Int64(count) == before.st_size,
+              count <= byteLimit else { return nil }
+        return Data(bytes.prefix(count))
+    }
+
+    fileprivate static func stableFileMetadataMatches(
+        _ lhs: stat,
+        _ rhs: stat
+    ) -> Bool {
+        stableIdentityMatches(lhs, rhs, kind: S_IFREG)
+            && lhs.st_mode == rhs.st_mode
+            && lhs.st_size == rhs.st_size
+            && lhs.st_nlink == rhs.st_nlink
+            && lhs.st_mtimespec.tv_sec == rhs.st_mtimespec.tv_sec
+            && lhs.st_mtimespec.tv_nsec == rhs.st_mtimespec.tv_nsec
+            && lhs.st_ctimespec.tv_sec == rhs.st_ctimespec.tv_sec
+            && lhs.st_ctimespec.tv_nsec == rhs.st_ctimespec.tv_nsec
+    }
+
+    fileprivate static func stableIdentityMatches(
+        _ lhs: stat,
+        _ rhs: stat,
+        kind: UInt16
+    ) -> Bool {
+        let left = StableFilesystemObjectIdentity(lhs)
+        let right = StableFilesystemObjectIdentity(rhs)
+        return left == right && left.kind == kind
+    }
+}
 
 nonisolated enum AgentInboxNavigationResult: Equatable, Sendable {
     case focused(AgentTaskRoute)
@@ -23,6 +1008,21 @@ nonisolated enum AgentInboxRecoveryResult: Equatable, Sendable {
     case unavailable(AgentTaskRecoveryUnavailableReason)
     case changedWhilePreparing
     case launchRejected
+}
+
+nonisolated struct QuickTerminalAgentScopeRegistration: Equatable, Sendable {
+    let project: AgentTaskProjectIdentity
+    let surface: AgentTaskTerminalSurface
+}
+
+/// Weak runtime boundary from durable task metadata back to the single
+/// application-owned Quick Terminal. ProjectRegistry retains no panel, tab,
+/// process, or detector object through this protocol.
+@MainActor
+protocol QuickTerminalAgentRouting: AnyObject {
+    func resolveQuickTerminalAgentRoute(for task: AgentTask) -> AgentTaskRoute?
+    func revealQuickTerminalAgentRoute(for task: AgentTask) -> AgentTaskRoute?
+    func isQuickTerminalAgentTaskPresented(_ task: AgentTask) -> Bool
 }
 
 #if DEBUG
@@ -120,8 +1120,12 @@ final class ProjectRegistry: LSPSettingsObserver {
     let lspSettings: LSPSettings
     /// Application-lifetime durable agent identity across every project.
     let agentTasks: AgentTaskRegistry
+    @ObservationIgnored
+    weak var quickTerminalAgentRouter: (any QuickTerminalAgentRouting)?
 
     private static let recentProjectsKey = "recentProjectPaths"
+    private static let recentProjectAgentIdentitiesKey =
+        "recentProjectAgentTaskIdentities"
     private static let maxRecentProjects = 10
     @ObservationIgnored private let defaults: UserDefaults
     @ObservationIgnored private let fileManager: FileManager
@@ -129,6 +1133,13 @@ final class ProjectRegistry: LSPSettingsObserver {
     @ObservationIgnored private let agentProcessSnapshotPoller: AgentProcessSnapshotPoller
     @ObservationIgnored private let agentInboxProjectCanonicalizer:
         @Sendable (URL) async -> URL
+    /// Testable suspension boundary between detached validation and its final
+    /// detached revalidation. Production is a no-op; no filesystem operation
+    /// from this protocol executes on MainActor.
+    @ObservationIgnored private let agentTaskFilesystemValidationCommitSeam:
+        @Sendable () async -> Void
+    @ObservationIgnored private let agentTaskWorkspaceValidationSeam:
+        @Sendable () async -> Void
     @ObservationIgnored private let contextPresentationGate =
         ContextPresentationCommandGate()
     @ObservationIgnored private var contextPresentationEpochs: [URL: UInt64] = [:]
@@ -158,7 +1169,27 @@ final class ProjectRegistry: LSPSettingsObserver {
             recomputeAgentInboxAttentionCounts()
         }
     }
-
+    /// Exact repository/worktree identities retained independently of live
+    /// managers so Quick Terminal never fabricates project ownership from a
+    /// recent worktree URL after background reclamation or app relaunch.
+    @ObservationIgnored
+    private var recentAgentTaskProjectsByRoot: [
+        URL: RecentAgentTaskProjectRecord
+    ] = [:]
+    /// Rotates whenever the persisted Recent identity inventory changes.
+    /// Async Recent admission captures this token with its exact record and
+    /// checks both again after the final detached filesystem revalidation, so
+    /// remove/re-add and A -> B -> A record ABA cannot commit stale authority.
+    @ObservationIgnored
+    private var recentAgentTaskRecordsGeneration = UUID()
+    /// Admission-time proof for live managers. It is deliberately not
+    /// regenerated while that manager remains admitted: replacing both the
+    /// repository and worktree directories at the same paths must not bless a
+    /// stale manager with the replacement repository's identity.
+    @ObservationIgnored
+    private var agentTaskRepositoryProofsByRoot: [
+        URL: RecentAgentTaskRepositoryProof
+    ] = [:]
     /// Per-project count of durable agent tasks in the Inbox's
     /// `needsAttention` section, keyed by canonical project URL (#1337).
     ///
@@ -192,6 +1223,8 @@ final class ProjectRegistry: LSPSettingsObserver {
                 ProjectRegistry.canonicalProjectURL(rawURL)
             }.value
         },
+        agentTaskFilesystemValidationCommitSeam: @escaping @Sendable () async -> Void = {},
+        agentTaskWorkspaceValidationSeam: @escaping @Sendable () async -> Void = {},
         agentDetectionProcessRunner: @escaping ProcessRunner = runRealProcess,
         agentDetectionPollInterval: TimeInterval = 2.0,
         agentDetectionInitialPollDelay: TimeInterval? = nil,
@@ -207,6 +1240,9 @@ final class ProjectRegistry: LSPSettingsObserver {
         self.fileManager = fileManager
         self.agentRecoveryInspector = agentRecoveryInspector
         self.agentInboxProjectCanonicalizer = agentInboxProjectCanonicalizer
+        self.agentTaskFilesystemValidationCommitSeam =
+            agentTaskFilesystemValidationCommitSeam
+        self.agentTaskWorkspaceValidationSeam = agentTaskWorkspaceValidationSeam
         self.agentProcessSnapshotPoller = AgentProcessSnapshotPoller(
             processRunner: agentDetectionProcessRunner,
             pollInterval: agentDetectionPollInterval,
@@ -216,6 +1252,9 @@ final class ProjectRegistry: LSPSettingsObserver {
         self.backgroundReclamationBatchSize = max(1, backgroundReclamationBatchSize)
         if clearRecentProjects {
             defaults.removeObject(forKey: Self.recentProjectsKey)
+            defaults.removeObject(
+                forKey: Self.recentProjectAgentIdentitiesKey
+            )
         }
         loadRecentProjects()
         #if DEBUG
@@ -261,6 +1300,63 @@ final class ProjectRegistry: LSPSettingsObserver {
         )
     }
 
+    /// Opens one Recent entry through its persisted immutable identity.
+    ///
+    /// Linked worktrees must never pass through the ordinary URL-only opener,
+    /// which intentionally models an independently opened folder as
+    /// `project == worktree`. This path instead captures the exact Recent
+    /// record and generation, builds a descriptor-held graph lease off-main,
+    /// crosses the injectable suspension boundary, then revalidates both the
+    /// lease and record immediately before the synchronous admission commit.
+    /// A stale or missing linked-worktree proof fails closed without rewriting
+    /// the persisted record.
+    func projectManagerForRecentProject(
+        _ projectURL: URL
+    ) async -> ProjectManager? {
+        guard !isProjectAdmissionFrozenForTermination else { return nil }
+        let canonical = await Task.detached(priority: .utility) {
+            Self.canonicalProjectURL(projectURL)
+        }.value
+        guard !Task.isCancelled,
+              !isProjectAdmissionFrozenForTermination else { return nil }
+
+        let capturedRecord = recentAgentTaskProjectsByRoot[canonical]
+        let capturedGeneration = recentAgentTaskRecordsGeneration
+        let identity = capturedRecord?.identity ?? AgentTaskProjectIdentity(
+            canonicalProjectPath: canonical.path,
+            canonicalWorktreePath: canonical.path
+        )
+        guard identity.canonicalWorktreePath == canonical.path else {
+            return nil
+        }
+        let expectedProof = capturedRecord?.repositoryProof
+        let lease = await Task.detached(priority: .utility) {
+            RecentAgentTaskFilesystemValidator.validationLease(
+                for: identity,
+                expectedProof: expectedProof
+            )
+        }.value
+        guard !Task.isCancelled, let lease else { return nil }
+
+        await agentTaskFilesystemValidationCommitSeam()
+        let isStillValid = await Task.detached(priority: .utility) {
+            lease.revalidate()
+        }.value
+        guard !Task.isCancelled,
+              isStillValid,
+              !isProjectAdmissionFrozenForTermination,
+              recentAgentTaskRecordsGeneration == capturedGeneration,
+              recentAgentTaskProjectsByRoot[canonical] == capturedRecord else {
+            return nil
+        }
+        return projectManager(
+            forCanonicalWorktree: canonical,
+            identity: identity,
+            repositoryProof: expectedProof,
+            validationLease: lease
+        )
+    }
+
     /// Non-admitting lookup for SwiftUI scene roots that may outlive their
     /// native window. A stale hidden `ProjectWindowView` must never recreate a
     /// manager after bounded reclamation.
@@ -268,10 +1364,158 @@ final class ProjectRegistry: LSPSettingsObserver {
         openProjects[canonicalProjectURL(projectURL)]
     }
 
+    /// Registers the immutable persistence/ownership scope captured when the
+    /// keep-alive Quick Terminal session is first created. A project-backed
+    /// session reuses the exact open worktree identity when available; the
+    /// standalone fallback remains explicitly distinguished by its route
+    /// surface and is never presented as a project in Agent Inbox.
+    func resolveQuickTerminalAgentScope(
+        workingDirectory: URL,
+        surface: AgentTaskTerminalSurface
+    ) async -> QuickTerminalAgentScopeRegistration? {
+        guard surface.isQuickTerminal else { return nil }
+        let canonical = await Task.detached(priority: .utility) {
+            RecentAgentTaskFilesystemValidator.canonicalExistingDirectory(
+                workingDirectory
+            )
+        }.value
+        guard !Task.isCancelled, let canonical else { return nil }
+
+        let exactProjectRecord = exactAgentTaskProjectRecord(for: canonical)
+        let prepared = await Task.detached(priority: .utility) {
+            RecentAgentTaskFilesystemValidator.preparedRegistration(
+                workingDirectory: canonical,
+                requestedSurface: surface,
+                record: exactProjectRecord
+            )
+        }.value
+        guard !Task.isCancelled, let prepared else { return nil }
+        let isStillValid = await Task.detached(priority: .utility) {
+            prepared.lease.revalidate()
+        }.value
+        guard !Task.isCancelled, isStillValid else { return nil }
+        if prepared.registration.surface == .quickTerminalProject {
+            guard exactAgentTaskProjectRecord(for: canonical)
+                == exactProjectRecord else { return nil }
+        }
+        return prepared.registration
+    }
+
+    /// Final scope commit invoked only after the controller's generation and
+    /// termination fences accepted the prepared registration. The graph is
+    /// rebuilt from the current immutable registry record, an injectable
+    /// suspension is crossed, then every held descriptor/path/absence witness
+    /// is revalidated off-main immediately before the no-await registration.
+    func commitQuickTerminalAgentScope(
+        _ registration: QuickTerminalAgentScopeRegistration,
+        workingDirectory: URL,
+        requestedSurface: AgentTaskTerminalSurface
+    ) async -> Bool {
+        guard requestedSurface.isQuickTerminal else { return false }
+        let canonical = await Task.detached(priority: .utility) {
+            RecentAgentTaskFilesystemValidator.canonicalExistingDirectory(
+                workingDirectory
+            )
+        }.value
+        guard !Task.isCancelled, let canonical else { return false }
+        let exactProjectRecord = exactAgentTaskProjectRecord(for: canonical)
+        let prepared = await Task.detached(priority: .utility) {
+            RecentAgentTaskFilesystemValidator.preparedRegistration(
+                workingDirectory: canonical,
+                requestedSurface: requestedSurface,
+                record: exactProjectRecord
+            )
+        }.value
+        guard !Task.isCancelled,
+              let prepared,
+              prepared.registration == registration else { return false }
+        await agentTaskFilesystemValidationCommitSeam()
+        let isStillValid = await Task.detached(priority: .utility) {
+            prepared.lease.revalidate()
+        }.value
+        guard !Task.isCancelled,
+              isStillValid,
+              exactAgentTaskProjectRecord(for: canonical)
+                == exactProjectRecord else { return false }
+        agentTasks.registerProject(registration.project)
+        return true
+    }
+
+    /// Rebuilds the exact filesystem lease for a later lazy consumer such as
+    /// Quick Terminal PTY start. Registration never turns a path into a
+    /// permanently trusted capability.
+    func validateQuickTerminalAgentScope(
+        _ registration: QuickTerminalAgentScopeRegistration,
+        workingDirectory: URL
+    ) async -> Bool {
+        let canonical = await Task.detached(priority: .utility) {
+            RecentAgentTaskFilesystemValidator.canonicalExistingDirectory(
+                workingDirectory
+            )
+        }.value
+        guard !Task.isCancelled, let canonical else { return false }
+        let record = exactAgentTaskProjectRecord(for: canonical)
+        let prepared = await Task.detached(priority: .utility) {
+            RecentAgentTaskFilesystemValidator.preparedRegistration(
+                workingDirectory: canonical,
+                requestedSurface: registration.surface,
+                record: record
+            )
+        }.value
+        guard !Task.isCancelled,
+              let prepared,
+              prepared.registration == registration else { return false }
+        let valid = await Task.detached(priority: .utility) {
+            prepared.lease.revalidate()
+        }.value
+        return !Task.isCancelled
+            && valid
+            && exactAgentTaskProjectRecord(for: canonical) == record
+    }
+
+    private func exactAgentTaskProjectRecord(
+        for canonical: URL
+    ) -> RecentAgentTaskProjectRecord? {
+        if let liveIdentity = agentTaskProjectsByRoot[canonical] {
+            return RecentAgentTaskProjectRecord(
+                identity: liveIdentity,
+                repositoryProof: agentTaskRepositoryProofsByRoot[canonical]
+            )
+        }
+        return recentAgentTaskProjectsByRoot[canonical]
+    }
+
+    /// Attaches the keep-alive Quick Terminal to the same application-owned
+    /// process poller as project terminals. The opt-out matches project
+    /// detection and this method never creates a second capture source.
+    @discardableResult
+    func subscribeQuickTerminalAgentSnapshots(
+        _ consumer: any AgentProcessSnapshotConsuming
+    ) -> Bool {
+        guard !Self.isAgentDetectionDisabled else { return false }
+        agentProcessSnapshotPoller.subscribe(consumer)
+        return true
+    }
+
+    func unsubscribeQuickTerminalAgentSnapshots(
+        _ consumer: any AgentProcessSnapshotConsuming
+    ) {
+        agentProcessSnapshotPoller.unsubscribe(consumer)
+    }
+
+    private static var isAgentDetectionDisabled: Bool {
+        CommandLine.arguments.contains("--disable-agent-detection")
+            || ProcessInfo.processInfo.environment[
+                "PINE_DISABLE_AGENT_DETECTION"
+            ] != nil
+    }
+
     /// Opens a Pine-managed worktree while retaining the owning repository as
     /// the shared project scope. Sibling worktrees therefore remain comparable
     /// without sharing terminal, task, event, checkpoint, or notification IDs.
-    func projectManager(for worktree: AgentManagedWorktree) -> ProjectManager? {
+    func projectManager(
+        for worktree: AgentManagedWorktree
+    ) async -> ProjectManager? {
         let repository = canonicalProjectURL(worktree.repositoryRoot)
         let managedRoot = canonicalProjectURL(worktree.managedRoot)
         let worktreeRoot = canonicalProjectURL(worktree.worktreeRoot)
@@ -281,12 +1525,27 @@ final class ProjectRegistry: LSPSettingsObserver {
               worktreeRoot.deletingLastPathComponent() == managedRoot else {
             return nil
         }
+        let identity = AgentTaskProjectIdentity(
+            canonicalProjectPath: repository.path,
+            canonicalWorktreePath: worktreeRoot.path
+        )
+        let lease = await Task.detached(priority: .utility) {
+            RecentAgentTaskFilesystemValidator.validationLease(
+                for: identity,
+                expectedProof: worktree.repositoryProof
+            )
+        }.value
+        guard !Task.isCancelled, let lease else { return nil }
+        await agentTaskFilesystemValidationCommitSeam()
+        let isStillValid = await Task.detached(priority: .utility) {
+            lease.revalidate()
+        }.value
+        guard !Task.isCancelled, isStillValid else { return nil }
         return projectManager(
             forCanonicalWorktree: worktreeRoot,
-            identity: AgentTaskProjectIdentity(
-                canonicalProjectPath: repository.path,
-                canonicalWorktreePath: worktreeRoot.path
-            )
+            identity: identity,
+            repositoryProof: worktree.repositoryProof,
+            validationLease: lease
         )
     }
 
@@ -296,7 +1555,7 @@ final class ProjectRegistry: LSPSettingsObserver {
         for identity: AgentTaskProjectIdentity,
         reopenBackgroundProject: Bool = true,
         admitMissingProjectInBackground: Bool = false
-    ) -> ProjectManager? {
+    ) async -> ProjectManager? {
         let project = canonicalProjectURL(URL(
             fileURLWithPath: identity.canonicalProjectPath,
             isDirectory: true
@@ -309,9 +1568,37 @@ final class ProjectRegistry: LSPSettingsObserver {
               worktree.path == identity.canonicalWorktreePath else {
             return nil
         }
+        var validationLease: RecentAgentTaskFilesystemValidationLease?
+        var repositoryProof: RecentAgentTaskRepositoryProof?
+        if project != worktree {
+            guard let exactRecord = exactAgentTaskProjectRecord(for: worktree),
+                  exactRecord.identity == identity,
+                  let expectedProof = exactRecord.repositoryProof else {
+                return nil
+            }
+            let lease = await Task.detached(priority: .utility) {
+                RecentAgentTaskFilesystemValidator.validationLease(
+                    for: identity,
+                    expectedProof: expectedProof
+                )
+            }.value
+            guard !Task.isCancelled, let lease else { return nil }
+            await agentTaskFilesystemValidationCommitSeam()
+            let isStillValid = await Task.detached(priority: .utility) {
+                lease.revalidate()
+            }.value
+            guard !Task.isCancelled,
+                  isStillValid,
+                  exactAgentTaskProjectRecord(for: worktree)
+                    == exactRecord else { return nil }
+            repositoryProof = expectedProof
+            validationLease = lease
+        }
         return projectManager(
             forCanonicalWorktree: worktree,
             identity: identity,
+            repositoryProof: repositoryProof,
+            validationLease: validationLease,
             reopenBackgroundProject: reopenBackgroundProject,
             admitMissingProjectInBackground: admitMissingProjectInBackground
         )
@@ -320,45 +1607,72 @@ final class ProjectRegistry: LSPSettingsObserver {
     private func projectManager(
         forCanonicalWorktree canonical: URL,
         identity: AgentTaskProjectIdentity,
+        repositoryProof: RecentAgentTaskRepositoryProof? = nil,
+        validationLease: RecentAgentTaskFilesystemValidationLease? = nil,
         reopenBackgroundProject: Bool = true,
         admitMissingProjectInBackground: Bool = false
     ) -> ProjectManager? {
+        // Retain descriptor ownership through the entire synchronous commit.
+        // Distinct project/worktree callers cannot enter without this lease.
+        guard identity.canonicalProjectPath == identity.canonicalWorktreePath
+                || validationLease != nil else { return nil }
+        let hasValidatedFilesystem = validationLease?.identity == identity
+            && validationLease?.canonicalWorktree == canonical
+        guard validationLease == nil || hasValidatedFilesystem else {
+            return nil
+        }
         if let existing = openProjects[canonical] {
             guard agentTaskProjectsByRoot[canonical] == identity else {
                 return nil
             }
+            if identity.canonicalProjectPath
+                != identity.canonicalWorktreePath {
+                guard let validationLease else { return nil }
+                existing.replaceAgentTaskFilesystemAdmission(
+                    validationLease,
+                    identity: identity
+                )
+            }
             // Verify directory still exists when reopening from background
             if backgroundProjects.contains(canonical) {
-                var isDir: ObjCBool = false
-                guard fileManager.fileExists(atPath: canonical.path, isDirectory: &isDir),
-                      isDir.boolValue else {
-                    // Directory was deleted while in background — clean up
-                    existing.requestUserTaskShutdown()
-                    existing.terminal.terminateAll()
-                    existing.shutdownReclaimableProject()
-                    let ownerID = ObjectIdentifier(existing)
-                    detachedTaskCleanupProjects[ownerID] = existing
-                    Task { @MainActor [weak self] in
-                        let didStop = await existing.shutdownUserTasks(
-                            until: .now() + 2
-                        )
-                        if didStop {
-                            self?.detachedTaskCleanupProjects.removeValue(
-                                forKey: ownerID
+                if !hasValidatedFilesystem {
+                    var isDir: ObjCBool = false
+                    guard fileManager.fileExists(
+                        atPath: canonical.path,
+                        isDirectory: &isDir
+                    ), isDir.boolValue else {
+                        // Directory was deleted while in background — clean up
+                        existing.requestUserTaskShutdown()
+                        existing.terminal.terminateAll()
+                        existing.shutdownReclaimableProject()
+                        let ownerID = ObjectIdentifier(existing)
+                        detachedTaskCleanupProjects[ownerID] = existing
+                        Task { @MainActor [weak self] in
+                            let didStop = await existing.shutdownUserTasks(
+                                until: .now() + 2
                             )
+                            if didStop {
+                                self?.detachedTaskCleanupProjects.removeValue(
+                                    forKey: ownerID
+                                )
+                            }
                         }
+                        openProjects.removeValue(forKey: canonical)
+                        agentTaskProjectsByRoot.removeValue(forKey: canonical)
+                        agentTaskRepositoryProofsByRoot.removeValue(
+                            forKey: canonical
+                        )
+                        backgroundProjects.remove(canonical)
+                        agentTasks.setWindowOpen(
+                            false,
+                            project: identity
+                        )
+                        existing.terminal.setAgentTaskWindowOpen(false)
+                        recentProjects.removeAll { $0 == canonical }
+                        removeRecentAgentTaskRecord(for: canonical)
+                        saveRecentProjects()
+                        return nil
                     }
-                    openProjects.removeValue(forKey: canonical)
-                    agentTaskProjectsByRoot.removeValue(forKey: canonical)
-                    backgroundProjects.remove(canonical)
-                    agentTasks.setWindowOpen(
-                        false,
-                        project: identity
-                    )
-                    existing.terminal.setAgentTaskWindowOpen(false)
-                    recentProjects.removeAll { $0 == canonical }
-                    saveRecentProjects()
-                    return nil
                 }
                 if reopenBackgroundProject {
                     existing.prepareForWindowPresentation()
@@ -369,22 +1683,27 @@ final class ProjectRegistry: LSPSettingsObserver {
                     )
                 }
             }
-            addToRecent(canonical)
+            addToRecent(canonical, identity: identity)
             return existing
         }
         // Validate that the directory still exists
-        var isDir: ObjCBool = false
-        guard fileManager.fileExists(atPath: canonical.path, isDirectory: &isDir),
-              isDir.boolValue else {
-            recentProjects.removeAll { $0 == canonical }
-            saveRecentProjects()
-            return nil
+        if !hasValidatedFilesystem {
+            var isDir: ObjCBool = false
+            guard fileManager.fileExists(
+                atPath: canonical.path,
+                isDirectory: &isDir
+            ), isDir.boolValue else {
+                recentProjects.removeAll { $0 == canonical }
+                removeRecentAgentTaskRecord(for: canonical)
+                saveRecentProjects()
+                return nil
+            }
+            var isProjectDir: ObjCBool = false
+            guard fileManager.fileExists(
+                atPath: identity.canonicalProjectPath,
+                isDirectory: &isProjectDir
+            ), isProjectDir.boolValue else { return nil }
         }
-        var isProjectDir: ObjCBool = false
-        guard fileManager.fileExists(
-            atPath: identity.canonicalProjectPath,
-            isDirectory: &isProjectDir
-        ), isProjectDir.boolValue else { return nil }
         guard !isProjectAdmissionFrozenForTermination else { return nil }
         agentTasks.registerProject(identity)
         let contextEpoch = contextPresentationEpochs[canonical, default: 0] &+ 1
@@ -393,6 +1712,8 @@ final class ProjectRegistry: LSPSettingsObserver {
             lspSettings: lspSettings,
             agentProcessSnapshotPoller: agentProcessSnapshotPoller,
             agentTaskRegistry: agentTasks,
+            workspaceFilesystemValidationSeam:
+                agentTaskWorkspaceValidationSeam,
             contextFileWriter: ContextFileWriter(
                 presentationGate: contextPresentationGate
             ),
@@ -403,9 +1724,17 @@ final class ProjectRegistry: LSPSettingsObserver {
         if isAutoSaveFrozenForTermination {
             pm.freezeAutoSaveForTermination()
         }
-        pm.loadDirectory(url: canonical, agentTaskProject: identity)
+        pm.loadDirectory(
+            url: canonical,
+            agentTaskProject: identity,
+            filesystemAdmission: validationLease
+        )
         openProjects[canonical] = pm
         agentTaskProjectsByRoot[canonical] = identity
+        if let repositoryProof,
+           identity.canonicalProjectPath != identity.canonicalWorktreePath {
+            agentTaskRepositoryProofsByRoot[canonical] = repositoryProof
+        }
         if admitMissingProjectInBackground {
             backgroundProjects.insert(canonical)
             pm.suspendEditorServices()
@@ -417,7 +1746,7 @@ final class ProjectRegistry: LSPSettingsObserver {
             agentTasks.setWindowOpen(true, project: identity)
             pm.terminal.setAgentTaskWindowOpen(true)
         }
-        addToRecent(canonical)
+        addToRecent(canonical, identity: identity)
         #if DEBUG
         seedAgentRecoveryUITestFixture(
             project: identity
@@ -701,6 +2030,7 @@ final class ProjectRegistry: LSPSettingsObserver {
     func runAgentProcessSnapshotForTesting() {
         agentProcessSnapshotPoller.runSnapshotForTesting()
     }
+
     #endif
 
     /// Processes at most one fixed-size batch. Retained projects rotate to the
@@ -739,6 +2069,7 @@ final class ProjectRegistry: LSPSettingsObserver {
             manager.shutdownReclaimableProject()
             openProjects.removeValue(forKey: canonical)
             agentTaskProjectsByRoot.removeValue(forKey: canonical)
+            agentTaskRepositoryProofsByRoot.removeValue(forKey: canonical)
             backgroundProjects.remove(canonical)
         }
         #if DEBUG
@@ -839,6 +2170,11 @@ final class ProjectRegistry: LSPSettingsObserver {
                   terminalID: task.route.terminalID,
                   runID: run.id
               ) else { return false }
+        if task.route.surface.isQuickTerminal {
+            return quickTerminalAgentRouter?
+                .isQuickTerminalAgentTaskPresented(task) == true
+        }
+        guard task.route.surface == .projectWindow else { return false }
         let projectURL = URL(
             fileURLWithPath: task.project.canonicalWorktreePath,
             isDirectory: true
@@ -888,6 +2224,19 @@ final class ProjectRegistry: LSPSettingsObserver {
                   terminalID: task.route.terminalID,
                   runID: run.id
               ) else { return nil }
+        if task.route.surface.isQuickTerminal {
+            guard let route = quickTerminalAgentRouter?
+                    .resolveQuickTerminalAgentRoute(for: task),
+                  route == task.route,
+                  agentTasks.task(for: taskID) == task,
+                  agentTasks.isExactLiveOwner(
+                    taskID: taskID,
+                    terminalID: route.terminalID,
+                    runID: run.id
+                  ) else { return nil }
+            return route
+        }
+        guard task.route.surface == .projectWindow else { return nil }
         let rawURL = URL(
             fileURLWithPath: task.project.canonicalWorktreePath,
             isDirectory: true
@@ -974,6 +2323,35 @@ final class ProjectRegistry: LSPSettingsObserver {
             return .routeStale
         }
 
+        if initialTask.route.surface.isQuickTerminal {
+            guard let run = initialTask.runs.last,
+                  run.liveness == .live,
+                  run.endedAt == nil,
+                  agentTasks.isExactLiveOwner(
+                    taskID: taskID,
+                    terminalID: initialTask.route.terminalID,
+                    runID: run.id
+                  ),
+                  let route = quickTerminalAgentRouter?
+                    .revealQuickTerminalAgentRoute(for: initialTask),
+                  route == initialTask.route,
+                  let currentTask = agentTasks.task(for: taskID),
+                  currentTask == initialTask,
+                  matches(currentTask, expectedNotificationRoute),
+                  agentTasks.isExactLiveOwner(
+                    taskID: taskID,
+                    terminalID: route.terminalID,
+                    runID: run.id
+                  ) else {
+                return .routeStale
+            }
+            _ = agentTasks.setReviewed(true, taskID: taskID)
+            return .focused(route)
+        }
+        guard initialTask.route.surface == .projectWindow else {
+            return .routeStale
+        }
+
         let rawURL = URL(
             fileURLWithPath: initialTask.project.canonicalWorktreePath,
             isDirectory: true
@@ -1045,6 +2423,12 @@ final class ProjectRegistry: LSPSettingsObserver {
         guard let initialTask = agentTasks.task(for: taskID) else {
             return .taskMissing
         }
+        // Recovery currently launches only into project-pane TerminalManager.
+        // Quick Terminal tasks must never fall through this path and admit a
+        // project manager from durable path metadata.
+        guard initialTask.route.surface == .projectWindow else {
+            return .launchRejected
+        }
         let rawURL = URL(
             fileURLWithPath: initialTask.project.canonicalWorktreePath,
             isDirectory: true
@@ -1078,6 +2462,11 @@ final class ProjectRegistry: LSPSettingsObserver {
             }
             return .launchRejected
         }
+
+        guard await manager.revalidateAgentTaskFilesystemAdmission(
+            expectedIdentity: initialTask.project,
+            workingDirectory: plan.workingDirectory
+        ) else { return .changedWhilePreparing }
 
         // No suspension occurs between this full ownership fence and launch.
         // A concurrent presentation, stale close, reclaim, task mutation, or
@@ -1144,24 +2533,17 @@ final class ProjectRegistry: LSPSettingsObserver {
                 == task.project.canonicalProjectPath else {
             return nil
         }
-        let manager: ProjectManager
-        if let existing = openProjects[projectURL] {
-            guard agentTaskProjectsByRoot[projectURL] == task.project,
-                  existing.rootURL == projectURL else {
-                return nil
-            }
-            manager = existing
-        } else {
-            guard let admitted = projectManager(
-                for: task.project,
-                reopenBackgroundProject: false,
-                admitMissingProjectInBackground: true
-            ), admitted.rootURL == projectURL,
-                agentTasks.task(for: task.id) == task,
-                agentTaskProjectsByRoot[projectURL] == task.project else {
-                return nil
-            }
-            manager = admitted
+        // Even an already-retained background manager must cross the same
+        // repository-instance validation boundary. Path equality alone cannot
+        // resume A after its repository/worktree paths were replaced by B.
+        guard let manager = await projectManager(
+            for: task.project,
+            reopenBackgroundProject: false,
+            admitMissingProjectInBackground: true
+        ), manager.rootURL == projectURL,
+            agentTasks.task(for: task.id) == task,
+            agentTaskProjectsByRoot[projectURL] == task.project else {
+            return nil
         }
         let hasEligibleCurrentOwner = manager.dialogOwnerWindow.map {
             DialogPresenter.isEligibleApplicationOwner($0)
@@ -1235,6 +2617,10 @@ final class ProjectRegistry: LSPSettingsObserver {
             }
             return nil
         }
+        guard await manager.revalidateAgentTaskFilesystemAdmission(
+            expectedIdentity: task.project,
+            workingDirectory: projectURL
+        ) else { return nil }
         guard markProjectWindowOpen(
             projectURL,
             identity: task.project,
@@ -1323,6 +2709,7 @@ final class ProjectRegistry: LSPSettingsObserver {
         _ task: AgentTask,
         targetTerminalID: UUID
     ) async -> AgentTaskRoute? {
+        guard task.route.surface == .projectWindow else { return nil }
         let rawURL = URL(
             fileURLWithPath: task.project.canonicalWorktreePath,
             isDirectory: true
@@ -1671,6 +3058,7 @@ final class ProjectRegistry: LSPSettingsObserver {
         }
         openProjects.removeAll()
         agentTaskProjectsByRoot.removeAll()
+        agentTaskRepositoryProofsByRoot.removeAll()
         backgroundProjects.removeAll()
         detachedTaskCleanupProjects.removeAll()
         return true
@@ -1787,6 +3175,7 @@ final class ProjectRegistry: LSPSettingsObserver {
     func removeFromRecent(_ url: URL) {
         let canonical = canonicalProjectURL(url)
         recentProjects.removeAll { $0 == canonical }
+        removeRecentAgentTaskRecord(for: canonical)
         saveRecentProjects()
     }
 
@@ -1794,16 +3183,43 @@ final class ProjectRegistry: LSPSettingsObserver {
     /// Welcome, and Dock menu) through the registry's single shared source.
     func clearRecentProjects() {
         recentProjects.removeAll()
+        if !recentAgentTaskProjectsByRoot.isEmpty {
+            recentAgentTaskProjectsByRoot.removeAll()
+            recentAgentTaskRecordsGeneration = UUID()
+        }
         saveRecentProjects()
     }
 
-    private func addToRecent(_ url: URL) {
-        let canonical = canonicalProjectURL(url)
+    private func addToRecent(
+        _ url: URL,
+        identity: AgentTaskProjectIdentity
+    ) {
+        // Every caller has already resolved the registry key. Avoid repeating
+        // filesystem canonicalization on MainActor at the admission commit.
+        let canonical = url.standardizedFileURL
         recentProjects.removeAll { $0 == canonical }
         recentProjects.insert(canonical, at: 0)
+        let retainedProof: RecentAgentTaskRepositoryProof? = if let liveProof =
+            agentTaskRepositoryProofsByRoot[canonical] {
+            liveProof
+        } else if recentAgentTaskProjectsByRoot[canonical]?.identity
+                    == identity {
+            recentAgentTaskProjectsByRoot[canonical]?.repositoryProof
+        } else {
+            nil
+        }
+        recentAgentTaskProjectsByRoot[canonical] =
+            RecentAgentTaskProjectRecord(
+                identity: identity,
+                repositoryProof: retainedProof
+            )
         if recentProjects.count > Self.maxRecentProjects {
             recentProjects = Array(recentProjects.prefix(Self.maxRecentProjects))
         }
+        recentAgentTaskProjectsByRoot = recentAgentTaskProjectsByRoot.filter {
+            recentProjects.contains($0.key)
+        }
+        recentAgentTaskRecordsGeneration = UUID()
         saveRecentProjects()
     }
 
@@ -1828,6 +3244,7 @@ final class ProjectRegistry: LSPSettingsObserver {
             return canonical
         }
         recentProjects = Array(recentProjects.prefix(Self.maxRecentProjects))
+        loadRecentAgentTaskProjectIdentities()
         if paths != recentProjects.map(\.path) {
             saveRecentProjects()
         }
@@ -1836,7 +3253,97 @@ final class ProjectRegistry: LSPSettingsObserver {
     private func saveRecentProjects() {
         let paths = recentProjects.map(\.path)
         defaults.set(paths, forKey: Self.recentProjectsKey)
+        let records = recentProjects.compactMap {
+            recentAgentTaskProjectsByRoot[$0]
+        }
+        if let data = try? JSONEncoder().encode(records) {
+            defaults.set(data, forKey: Self.recentProjectAgentIdentitiesKey)
+        }
     }
+
+    private func loadRecentAgentTaskProjectIdentities() {
+        guard let data = defaults.data(
+            forKey: Self.recentProjectAgentIdentitiesKey
+        ), let records = try? JSONDecoder().decode(
+            [RecentAgentTaskProjectRecord].self,
+            from: data
+        ) else {
+            recentAgentTaskProjectsByRoot = [:]
+            recentAgentTaskRecordsGeneration = UUID()
+            return
+        }
+        let recentByPath = Dictionary(
+            uniqueKeysWithValues: recentProjects.map { ($0.path, $0) }
+        )
+        recentAgentTaskProjectsByRoot = records.reduce(into: [:]) { result, record in
+            let identity = record.identity
+            let project = URL(
+                fileURLWithPath: identity.canonicalProjectPath,
+                isDirectory: true
+            ).standardizedFileURL
+            let worktree = URL(
+                fileURLWithPath: identity.canonicalWorktreePath,
+                isDirectory: true
+            ).standardizedFileURL
+            guard project.path == identity.canonicalProjectPath,
+                  worktree.path == identity.canonicalWorktreePath,
+                  let canonical = recentByPath[worktree.path],
+                  result[canonical] == nil,
+                  project == worktree || record.repositoryProof != nil else {
+                return
+            }
+            result[canonical] = record
+        }
+        recentAgentTaskRecordsGeneration = UUID()
+    }
+
+    private func removeRecentAgentTaskRecord(for canonical: URL) {
+        guard recentAgentTaskProjectsByRoot.removeValue(
+            forKey: canonical
+        ) != nil else { return }
+        recentAgentTaskRecordsGeneration = UUID()
+    }
+
+    #if DEBUG
+    nonisolated static func unsignedFilesystemIdentityForTesting(
+        _ value: Int64
+    ) -> UInt64 {
+        unsignedFilesystemIdentity(value)
+    }
+
+    nonisolated static func filesystemIdentityMatchesForTesting(
+        leftGeneration: UInt64,
+        rightGeneration: UInt64
+    ) -> Bool {
+        let left = StableFilesystemObjectIdentity(
+            device: 1,
+            inode: 2,
+            generation: leftGeneration,
+            birthSeconds: 3,
+            birthNanoseconds: 4,
+            kind: S_IFREG
+        )
+        let right = StableFilesystemObjectIdentity(
+            device: 1,
+            inode: 2,
+            generation: rightGeneration,
+            birthSeconds: 3,
+            birthNanoseconds: 4,
+            kind: S_IFREG
+        )
+        return left == right
+    }
+
+    nonisolated static func boundedGitPathFileForTesting(
+        _ url: URL,
+        beforeRead: @escaping () -> Void
+    ) -> String? {
+        RecentAgentTaskFilesystemValidator.boundedGitPathFile(
+            url,
+            beforeRead: beforeRead
+        )
+    }
+    #endif
 
     func canonicalProjectURL(_ projectURL: URL) -> URL {
         Self.canonicalProjectURL(projectURL)

--- a/Pine/QuickTerminal/QuickTerminalAgentDetection.swift
+++ b/Pine/QuickTerminal/QuickTerminalAgentDetection.swift
@@ -1,0 +1,108 @@
+//
+//  QuickTerminalAgentDetection.swift
+//  Pine
+//
+//  Snapshot-consuming agent detection for the application-wide Quick Terminal.
+//  Snapshot capture is intentionally owned elsewhere so this seam can attach
+//  to the application-level source introduced by #1421 without creating a
+//  second ps timer.
+//
+
+import Foundation
+
+/// Reconciles injected process snapshots against one keep-alive terminal
+/// inventory. This type never captures processes or schedules polling.
+@MainActor
+final class QuickTerminalAgentDetection: AgentProcessSnapshotConsuming {
+    let detector = AgentDetector()
+
+    private weak var controller: QuickTerminalController?
+    private var isFrozenForTermination = false
+    #if DEBUG
+    private(set) var receivedSnapshotCountForTesting = 0
+    #endif
+
+    init(controller: QuickTerminalController? = nil) {
+        self.controller = controller
+    }
+
+    func bind(controller: QuickTerminalController) {
+        self.controller = controller
+    }
+
+    func consumeAgentProcessSnapshot(
+        _ processes: [DetectedProcess],
+        observation: AgentObservationStamp
+    ) {
+        guard !isFrozenForTermination, let controller else { return }
+        #if DEBUG
+        receivedSnapshotCountForTesting += 1
+        #endif
+        let newlyTerminated = detector.processSnapshotDidUpdate(
+            processes,
+            observation: observation
+        )
+        for tab in controller.agentTerminalTabs {
+            let previous = tab.agentSession
+            let current = AgentDetectionCoordinator.reconciledSession(
+                previous: previous,
+                ownership: TerminalAgentOwnershipEvidence(
+                    foreground: tab.foregroundProcessSnapshot(),
+                    processes: processes
+                ),
+                detector: detector,
+                agentIdentityStillMatches: {
+                    tab.agentProcessIdentityStillMatches($0)
+                },
+                newlyTerminated: newlyTerminated
+            )
+            if let current {
+                controller.bridgeQuickTerminalAgentSession(
+                    current,
+                    replacing: previous,
+                    in: tab
+                )
+            }
+            tab.agentSession = current
+        }
+        controller.refreshQuickTerminalAgentTasks(
+            sessions: detector.detectedSessions
+        )
+    }
+
+    func consumeAgentProcessSnapshotFailure(
+        observation: AgentObservationStamp
+    ) {
+        guard !isFrozenForTermination, let controller else { return }
+        #if DEBUG
+        receivedSnapshotCountForTesting += 1
+        #endif
+        detector.processSnapshotDidFail(observation: observation)
+        controller.refreshQuickTerminalAgentTasks(
+            sessions: detector.detectedSessions
+        )
+        for tab in controller.agentTerminalTabs
+        where AgentDetectionCoordinator.shouldExpireAfterFailedSnapshot(
+            tab.agentSession
+        ) {
+            tab.agentSession = nil
+        }
+    }
+
+    func freezeForTermination() {
+        isFrozenForTermination = true
+    }
+
+    func cancelTermination() {
+        isFrozenForTermination = false
+    }
+
+    func stop() {
+        isFrozenForTermination = true
+        guard let controller else { return }
+        controller.markQuickTerminalAgentEvidenceUnavailable(
+            sessionIDs: detector.detectedSessions.map(\.id)
+        )
+        controller.agentTerminalTabs.forEach { $0.agentSession = nil }
+    }
+}

--- a/Pine/QuickTerminal/QuickTerminalContentView.swift
+++ b/Pine/QuickTerminal/QuickTerminalContentView.swift
@@ -1,0 +1,51 @@
+//
+//  QuickTerminalContentView.swift
+//  Pine
+//
+//  Shared terminal content plus truthful agent status for Quick Terminal.
+//
+
+import SwiftUI
+
+struct QuickTerminalContentView: View {
+    let paneState: TerminalPaneState
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let tab = paneState.activeTab {
+                HStack(spacing: 0) {
+                    TerminalTabIdentityLabel(tab: tab)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel(
+                            Self.agentIdentityAccessibilityLabel(for: tab)
+                        )
+                        .accessibilityIdentifier(
+                            AccessibilityID.quickTerminalAgentIdentity
+                        )
+                    Spacer(minLength: 0)
+                }
+                .padding(.horizontal, 10)
+                .frame(height: LayoutMetrics.tabBarHeight)
+                .background(Color(nsColor: .windowBackgroundColor))
+                Divider()
+            }
+            TerminalContentView(
+                terminalPaneState: paneState,
+                canAttemptFocusRequest: { _ in true }
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .background(Color(nsColor: .textBackgroundColor))
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier(AccessibilityID.quickTerminalContent)
+    }
+
+    static func agentIdentityAccessibilityLabel(
+        for tab: TerminalTab
+    ) -> String {
+        guard let session = tab.agentSession else { return tab.name }
+        let agent = session.agentType.displayName
+        let state = AgentTabBadge.userFacingState(for: session).displayName
+        return "\(tab.name), \(agent), \(state)"
+    }
+}

--- a/Pine/QuickTerminal/QuickTerminalController.swift
+++ b/Pine/QuickTerminal/QuickTerminalController.swift
@@ -3,12 +3,12 @@
 //  Pine
 //
 //  Owns the single global quick-terminal session: a keep-alive
-//  `QuickTerminalWindow` hosting one `TerminalTab` inside a
-//  `TerminalContainerView`. Toggled by a system-wide hotkey (#1113).
+//  `QuickTerminalWindow` hosting one `TerminalTab`. Toggled by a
+//  system-wide hotkey (#1113).
 //
-//  The session reuses the in-window terminal stack (`TerminalPaneState` +
-//  `TerminalTab` + `TerminalContainerView`), so agent detection (#950),
-//  file:line links (#949), and search (#308) work identically.
+//  The session reuses the in-window terminal stack and consumes the shared
+//  process snapshots used by project terminals, while retaining a distinct
+//  routing surface and keep-alive lifecycle.
 //
 
 import AppKit
@@ -17,6 +17,11 @@ import SwiftUI
 @MainActor
 @Observable
 final class QuickTerminalController {
+    private struct AgentScope {
+        let project: AgentTaskProjectIdentity
+        let surface: AgentTaskTerminalSurface
+    }
+
     /// Per-pane state reused as the quick terminal's tab container. Holds
     /// exactly one `TerminalTab` for the quick-terminal session.
     let paneState: TerminalPaneState
@@ -27,13 +32,46 @@ final class QuickTerminalController {
     /// Project registry used to resolve the working directory (frontmost
     /// open project → recent project → home). Weakly held; the registry
     /// outlives the coordinator (owned by AppDelegate).
-    weak var registry: ProjectRegistry?
+    weak var registry: ProjectRegistry? {
+        didSet {
+            guard registry !== oldValue else { return }
+            if isAgentDetectionSubscribed {
+                oldValue?.unsubscribeQuickTerminalAgentSnapshots(
+                    agentDetection
+                )
+                isAgentDetectionSubscribed = false
+            }
+            if agentScope == nil, let agentScopeTarget {
+                cancelAgentScopeResolution()
+                beginAgentScopeResolution(agentScopeTarget)
+            } else {
+                startAgentDetectionIfNeeded()
+            }
+        }
+    }
 
     /// User-facing preferences (hotkey, geometry, display). Read live so
     /// the panel tracks the current edge / size / display on every show.
     let settings: QuickTerminalSettings
 
     private var window: QuickTerminalWindow?
+    private let agentRouteOwnerID = UUID()
+    private let agentDetection: QuickTerminalAgentDetection
+    private var agentScope: AgentScope?
+    private var agentScopeTarget: (
+        workingDirectory: URL,
+        surface: AgentTaskTerminalSurface
+    )?
+    private var agentScopeResolutionTask: Task<Void, Never>?
+    private var agentScopeResolutionGeneration: UInt64 = 0
+    private let agentScopeResolver: @MainActor (
+        ProjectRegistry,
+        URL,
+        AgentTaskTerminalSurface
+    ) async -> QuickTerminalAgentScopeRegistration?
+    private var isAgentDetectionSubscribed = false
+    private var areAgentTaskCallbacksFrozen = false
+    private var isPermanentlyShutDown = false
     /// See `TerminalTab.themeChangeObserver`: the observer token is created
     /// on the main actor and only removed from nonisolated `deinit`.
     @ObservationIgnored
@@ -47,16 +85,58 @@ final class QuickTerminalController {
     /// `show`/`hide`; exposing the frame avoids reaching into the NSPanel.
     var presentedFrame: NSRect? { window?.frame }
 
+    /// Injection seam for the application-level process snapshot source. This
+    /// controller never owns a timer or invokes `ps` itself (#1421 boundary).
+    var agentSnapshotConsumer: any AgentProcessSnapshotConsuming {
+        agentDetection
+    }
+
+    var agentDetector: AgentDetector { agentDetection.detector }
+
+    var agentTerminalTabs: [TerminalTab] { paneState.terminalTabs }
+
+    #if DEBUG
+    var isAgentDetectionSubscribedForTesting: Bool {
+        isAgentDetectionSubscribed
+    }
+
+    var receivedAgentSnapshotCountForTesting: Int {
+        agentDetection.receivedSnapshotCountForTesting
+    }
+
+    var isAgentScopeReadyForTesting: Bool { agentScope != nil }
+
+    var agentScopeSurfaceForTesting: AgentTaskTerminalSurface? {
+        agentScope?.surface
+    }
+
+    func waitForAgentScopeResolutionForTesting() async {
+        await agentScopeResolutionTask?.value
+    }
+    #endif
+
     init(
         settings: QuickTerminalSettings = .shared,
         themeSettings: TerminalThemeSettings = .shared,
-        cursorSettings: TerminalCursorSettings = .shared
+        cursorSettings: TerminalCursorSettings = .shared,
+        agentScopeResolver: @escaping @MainActor (
+            ProjectRegistry,
+            URL,
+            AgentTaskTerminalSurface
+        ) async -> QuickTerminalAgentScopeRegistration? = { registry, workingDirectory, surface in
+            await registry.resolveQuickTerminalAgentScope(
+                workingDirectory: workingDirectory,
+                surface: surface
+            )
+        }
     ) {
         self.settings = settings
         self.paneState = TerminalPaneState(
             themeSettings: themeSettings,
             cursorSettings: cursorSettings
         )
+        self.agentDetection = QuickTerminalAgentDetection()
+        self.agentScopeResolver = agentScopeResolver
         self.settingsNotificationCenter = settings.notificationCenter
         self.settingsObserver = settings.notificationCenter.addObserver(
             forName: QuickTerminalSettings.didChangeNotification,
@@ -65,6 +145,16 @@ final class QuickTerminalController {
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 self?.applySettingsChange()
+            }
+        }
+        self.agentDetection.bind(controller: self)
+        self.paneState.onTabCreated = { [weak self] tab in
+            self?.configureAgentLifecycle(for: tab)
+            tab.configureWorkingDirectoryValidation { [weak self] directory in
+                guard let self else { return false }
+                return await self.validateWorkingDirectoryForProcessStart(
+                    directory
+                )
             }
         }
     }
@@ -91,10 +181,16 @@ final class QuickTerminalController {
     }
 
     func show() {
+        guard !isPermanentlyShutDown else { return }
         guard settings.enabled else {
             hide()
             return
         }
+        presentKeepAliveWindow()
+    }
+
+    private func presentKeepAliveWindow() {
+        guard !isPermanentlyShutDown else { return }
         ensureWindow()
         repositionDropDown()
         window?.makeKeyAndOrderFront(nil)
@@ -130,6 +226,11 @@ final class QuickTerminalController {
     /// termination so the PTY child does not outlive Pine, matching
     /// `registry.destroyAllProjects()` for project windows (#1113 review).
     func shutdown() {
+        guard !isPermanentlyShutDown else { return }
+        isPermanentlyShutDown = true
+        cancelAgentScopeResolution()
+        unsubscribeAgentDetection()
+        agentDetection.stop()
         for tab in paneState.terminalTabs { tab.stop() }
         if let windowResignObserver {
             windowNotificationCenter.removeObserver(windowResignObserver)
@@ -138,6 +239,32 @@ final class QuickTerminalController {
         window?.close()
         window = nil
         isVisible = false
+    }
+
+    /// Freezes injected detector callbacks before the durable application-quit
+    /// snapshot. Hide/show deliberately never calls this method.
+    func freezeAgentTasksForTermination() {
+        guard !areAgentTaskCallbacksFrozen,
+              !isPermanentlyShutDown else { return }
+        areAgentTaskCallbacksFrozen = true
+        if agentScope == nil {
+            cancelAgentScopeResolution()
+        }
+        agentDetection.freezeForTermination()
+        unsubscribeAgentDetection()
+    }
+
+    /// Restores snapshot consumption after the user cancels Quit.
+    func cancelAgentTaskTermination() {
+        guard areAgentTaskCallbacksFrozen,
+              !isPermanentlyShutDown else { return }
+        areAgentTaskCallbacksFrozen = false
+        agentDetection.cancelTermination()
+        if agentScope == nil, let agentScopeTarget {
+            beginAgentScopeResolution(agentScopeTarget)
+        } else {
+            startAgentDetectionIfNeeded()
+        }
     }
 
     // MARK: - Window lifecycle
@@ -152,8 +279,12 @@ final class QuickTerminalController {
         // PTY lazily from `TerminalContainerView.layout()` once the view has
         // real bounds (issue #661 guard).
         if paneState.terminalTabs.isEmpty {
-            paneState.addTab(workingDirectory: resolveCwd())
+            let target = resolveSessionTarget()
+            agentScopeTarget = target
+            paneState.addTab(workingDirectory: target.workingDirectory)
+            beginAgentScopeResolution(target)
         }
+        startAgentDetectionIfNeeded()
 
         let rect = dropDownRect()
         let win = QuickTerminalWindow(contentRect: rect)
@@ -168,20 +299,31 @@ final class QuickTerminalController {
             }
         }
 
-        // Host the same NSView the in-window terminal panes use. Setting it
-        // as contentView triggers `viewDidMoveToWindow` → observer install +
-        // `layout()` → `showTab(activeTab)` → `startIfNeeded()`.
-        let container = TerminalContainerView(frame: rect)
-        container.bind(to: paneState)
-        win.contentView = container
-        // Explicit `showTab` matches the in-window pattern
-        // (`TerminalContentView.updateNSView`) and makes the PTY-spawn path
-        // robust against future changes to `TerminalContainerView.layout()`'s
-        // contract — `layout()`'s else-branch already calls `showTab`, but
-        // only when the container has real bounds on that specific pass.
-        container.showTab(paneState.activeTab)
+        // Host the shared terminal content below the same truthful agent badge
+        // used by project terminal tabs. The NSViewRepresentable still starts
+        // the PTY lazily after it receives real window bounds.
+        win.contentView = NSHostingView(
+            rootView: QuickTerminalContentView(paneState: paneState)
+        )
 
         window = win
+    }
+
+    private func startAgentDetectionIfNeeded() {
+        guard !isAgentDetectionSubscribed,
+              !areAgentTaskCallbacksFrozen,
+              !isPermanentlyShutDown,
+              agentScope != nil,
+              !paneState.terminalTabs.isEmpty,
+              let registry else { return }
+        isAgentDetectionSubscribed = registry
+            .subscribeQuickTerminalAgentSnapshots(agentDetection)
+    }
+
+    private func unsubscribeAgentDetection() {
+        guard isAgentDetectionSubscribed else { return }
+        registry?.unsubscribeQuickTerminalAgentSnapshots(agentDetection)
+        isAgentDetectionSubscribed = false
     }
 
     /// Recomputes the drop-down frame against the current screen so the
@@ -268,19 +410,161 @@ final class QuickTerminalController {
     /// Resolving via the key window (rather than `openProjects.keys.first`,
     /// whose order is unspecified) means the quick terminal opens in the
     /// project the user is actually looking at, not an arbitrary one.
-    private func resolveCwd() -> URL? {
+    private func resolveSessionTarget() -> (
+        workingDirectory: URL,
+        surface: AgentTaskTerminalSurface
+    ) {
         // 1. The key window's project root — the project the user is
         //    currently working in. Resolved via the window delegate that
         //    Pine installs on every project window (CloseDelegate).
         if let keyProject = keyWindowProjectRoot() {
-            return keyProject
+            return (keyProject, .quickTerminalProject)
         }
         // 2. Fall back to the most-recent project.
         if let recent = registry?.recentProjects.first {
-            return recent
+            return (recent, .quickTerminalProject)
         }
         // 3. Last resort: home directory.
-        return URL(fileURLWithPath: NSHomeDirectory())
+        return (
+            URL(fileURLWithPath: NSHomeDirectory()),
+            .quickTerminalStandalone
+        )
+    }
+
+    private func beginAgentScopeResolution(
+        _ target: (
+            workingDirectory: URL,
+            surface: AgentTaskTerminalSurface
+        )
+    ) {
+        guard agentScope == nil,
+              agentScopeResolutionTask == nil,
+              !areAgentTaskCallbacksFrozen,
+              !isPermanentlyShutDown,
+              let registry else { return }
+        agentScopeResolutionGeneration &+= 1
+        let generation = agentScopeResolutionGeneration
+        let resolver = agentScopeResolver
+        agentScopeResolutionTask = Task { @MainActor [weak self, weak registry] in
+            guard let registry else { return }
+            let registration = await resolver(
+                registry,
+                target.workingDirectory,
+                target.surface
+            )
+            guard let self,
+                  generation == self.agentScopeResolutionGeneration else {
+                return
+            }
+            defer {
+                if generation == self.agentScopeResolutionGeneration {
+                    self.agentScopeResolutionTask = nil
+                }
+            }
+            guard !Task.isCancelled,
+                  !self.areAgentTaskCallbacksFrozen,
+                  !self.isPermanentlyShutDown,
+                  self.registry === registry,
+                  self.agentScopeTarget?.workingDirectory
+                    == target.workingDirectory,
+                  self.agentScopeTarget?.surface == target.surface,
+                  let registration else { return }
+            guard await registry.commitQuickTerminalAgentScope(
+                registration,
+                workingDirectory: target.workingDirectory,
+                requestedSurface: target.surface
+            ), generation == self.agentScopeResolutionGeneration,
+                !Task.isCancelled,
+                !self.areAgentTaskCallbacksFrozen,
+                !self.isPermanentlyShutDown,
+                self.registry === registry,
+                self.agentScopeTarget?.workingDirectory
+                    == target.workingDirectory,
+                self.agentScopeTarget?.surface == target.surface else {
+                return
+            }
+            self.agentScope = AgentScope(
+                project: registration.project,
+                surface: registration.surface
+            )
+            self.startAgentDetectionIfNeeded()
+        }
+    }
+
+    private func cancelAgentScopeResolution() {
+        agentScopeResolutionGeneration &+= 1
+        agentScopeResolutionTask?.cancel()
+        agentScopeResolutionTask = nil
+    }
+
+    private func configureAgentLifecycle(for tab: TerminalTab) {
+        tab.onLifecycleEnded = { [weak self] terminalID in
+            guard let self, let agentScope else { return }
+            registry?.agentTasks.markTerminalClosed(
+                terminalID: terminalID,
+                project: agentScope.project,
+                surface: agentScope.surface
+            )
+        }
+    }
+
+    private func validateWorkingDirectoryForProcessStart(
+        _ directory: URL
+    ) async -> Bool {
+        let resolution = agentScopeResolutionTask
+        await resolution?.value
+        guard !Task.isCancelled,
+              !areAgentTaskCallbacksFrozen,
+              !isPermanentlyShutDown,
+              let registry,
+              let agentScope,
+              let target = agentScopeTarget,
+              target.workingDirectory.standardizedFileURL
+                == directory.standardizedFileURL else { return false }
+        return await registry.validateQuickTerminalAgentScope(
+            QuickTerminalAgentScopeRegistration(
+                project: agentScope.project,
+                surface: agentScope.surface
+            ),
+            workingDirectory: directory
+        )
+    }
+
+    func bridgeQuickTerminalAgentSession(
+        _ session: AgentSession,
+        replacing previous: AgentSession?,
+        in tab: TerminalTab
+    ) {
+        guard let registry,
+              let agentScope,
+              paneState.terminalTabs.contains(where: { $0 === tab }) else {
+            return
+        }
+        registry.agentTasks.bridge(
+            session,
+            replacing: previous,
+            context: AgentTaskBridgeContext(
+                project: agentScope.project,
+                route: AgentTaskRoute(
+                    surface: agentScope.surface,
+                    paneID: agentRouteOwnerID,
+                    tabID: tab.id,
+                    terminalID: tab.id
+                ),
+                presentationContext: AgentTaskPresentationContext(
+                    terminalStableLabel: Strings.quickTerminalText()
+                ),
+                origin: .discoveredInTerminal
+            )
+        )
+    }
+
+    func refreshQuickTerminalAgentTasks(sessions: [AgentSession]) {
+        registry?.agentTasks.refresh(sessions: sessions)
+    }
+
+    func markQuickTerminalAgentEvidenceUnavailable(sessionIDs: [UUID]) {
+        registry?.agentTasks.markEvidenceUnavailable(sessionIDs: sessionIDs)
     }
 
     /// Returns the project root URL associated with the current key window,
@@ -303,5 +587,64 @@ final class QuickTerminalController {
         let canonical = registry.canonicalProjectURL(url)
         guard registry.openProjects[canonical] != nil else { return nil }
         return url
+    }
+}
+
+extension QuickTerminalController: QuickTerminalAgentRouting {
+    func resolveQuickTerminalAgentRoute(
+        for task: AgentTask
+    ) -> AgentTaskRoute? {
+        guard task.route.surface.isQuickTerminal,
+              let registry,
+              let agentScope,
+              task.project == agentScope.project,
+              task.route.surface == agentScope.surface,
+              task.route.paneID == agentRouteOwnerID,
+              task.route.tabID == task.route.terminalID,
+              let tab = paneState.terminalTabs.first(where: {
+                $0.id == task.route.terminalID
+              }),
+              let session = tab.agentSession,
+              let run = task.runs.last,
+              task.lifecycle == .active,
+              task.route.availability == .available,
+              run.id == session.id,
+              run.terminalID == tab.id,
+              run.liveness == .live,
+              run.endedAt == nil,
+              session.liveness == .live,
+              session.agentType == task.descriptor.agentType,
+              let evidence = session.processEvidence,
+              run.process.identifiesSameProcess(as: evidence),
+              registry.agentTasks.isExactLiveOwner(
+                taskID: task.id,
+                terminalID: tab.id,
+                runID: session.id
+              ) else {
+            return nil
+        }
+        return task.route
+    }
+
+    func revealQuickTerminalAgentRoute(
+        for task: AgentTask
+    ) -> AgentTaskRoute? {
+        guard let route = resolveQuickTerminalAgentRoute(for: task) else {
+            return nil
+        }
+        // An explicit Inbox/notification action remains able to reveal a live
+        // keep-alive process even when the global hotkey preference is off.
+        presentKeepAliveWindow()
+        guard resolveQuickTerminalAgentRoute(for: task) == route else {
+            return nil
+        }
+        return route
+    }
+
+    func isQuickTerminalAgentTaskPresented(_ task: AgentTask) -> Bool {
+        isVisible
+            && window?.isVisible == true
+            && window?.isKeyWindow == true
+            && resolveQuickTerminalAgentRoute(for: task) != nil
     }
 }

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -1408,6 +1408,13 @@ enum Strings {
     static let menuTerminal: LocalizedStringKey = "menu.terminal"
     static let menuNewTerminalTab: LocalizedStringKey = "menu.newTerminalTab"
     static let menuQuickTerminal: LocalizedStringKey = "menu.quickTerminal"
+    static func quickTerminalText(locale: Locale = .current) -> String {
+        localizedString(
+            forKey: "menu.quickTerminal",
+            fallback: "Quick Terminal",
+            locale: locale
+        )
+    }
     static let menuTogglePreview: LocalizedStringKey = "menu.togglePreview"
     static let menuView: LocalizedStringKey = "menu.view"
     static let menuGit: LocalizedStringKey = "menu.git"

--- a/Pine/TerminalBarView.swift
+++ b/Pine/TerminalBarView.swift
@@ -126,6 +126,29 @@ struct TerminalAgentResumeAction: Identifiable {
     let action: () -> Void
 }
 
+/// Shared identity/status label used by project terminal tabs and Quick
+/// Terminal. Reusing the same `AgentTabBadge` keeps liveness, attention,
+/// lifecycle-accuracy and Reduce Motion semantics identical on both surfaces.
+struct TerminalTabIdentityLabel: View {
+    let tab: TerminalTab
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "terminal")
+                .font(.system(size: 9))
+                .foregroundStyle(.secondary)
+
+            Text(tab.name)
+                .font(.system(size: 11))
+                .lineLimit(1)
+
+            if let session = tab.agentSession {
+                AgentTabBadge(session: session)
+            }
+        }
+    }
+}
+
 struct TerminalNativeTabItem: View {
     let tab: TerminalTab
     let isActive: Bool
@@ -160,17 +183,7 @@ struct TerminalNativeTabItem: View {
                     .reportsTabCloseGlyphFrame()
             }
 
-            Image(systemName: "terminal")
-                .font(.system(size: 9))
-                .foregroundStyle(.secondary)
-
-            Text(tab.name)
-                .font(.system(size: 11))
-                .lineLimit(1)
-
-            if let session = tab.agentSession {
-                AgentTabBadge(session: session)
-            }
+            TerminalTabIdentityLabel(tab: tab)
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 4)

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -1882,6 +1882,17 @@ final class TerminalTab: Identifiable, Hashable {
     private let shellSettings: ShellSettings
     private let agentHandoffSettings: AgentHandoffSettings
     private var processStarted = false
+    private var processStartValidationTask: Task<Void, Never>?
+    private var processStartValidationGeneration = UUID()
+    private var workingDirectoryValidator:
+        (@Sendable (URL) async -> Bool)?
+    #if DEBUG
+    var validationCommitSeamForTesting:
+        @Sendable () async -> Void = {}
+    var isStartValidationPendingForTesting: Bool {
+        processStartValidationTask != nil
+    }
+    #endif
     /// Stable Pine-owned duplicate of SwiftTerm's master PTY. The holder has
     /// its own lock so nonisolated `deinit` can close it safely as a final
     /// lifecycle backstop.
@@ -2079,6 +2090,19 @@ final class TerminalTab: Identifiable, Hashable {
         self.initialProcess = initialProcess
     }
 
+    /// Installs the project admission validator used immediately before a
+    /// lazy PTY launch. The validator performs filesystem work off-main and
+    /// its generation is rotated so an older suspended result cannot start a
+    /// process after the tab was rebound or torn down.
+    func configureWorkingDirectoryValidation(
+        _ validator: (@Sendable (URL) async -> Bool)?
+    ) {
+        processStartValidationGeneration = UUID()
+        processStartValidationTask?.cancel()
+        processStartValidationTask = nil
+        workingDirectoryValidator = validator
+    }
+
     /// Builds the environment dictionary for the terminal child process.
     ///
     /// Starts from the current process environment, removes host-terminal-
@@ -2165,9 +2189,38 @@ final class TerminalTab: Identifiable, Hashable {
     func startIfNeeded() {
         // Final project reclamation may race a delayed NSViewRepresentable
         // update. A terminated tab is a tombstone and must never fork again.
-        guard !isTerminated, !processStarted else { return }
+        guard !isTerminated, !processStarted,
+              processStartValidationTask == nil else { return }
         guard terminalView.frame.size.width > 0,
               terminalView.frame.size.height > 0 else { return }
+        if let workingDirectory, let workingDirectoryValidator {
+            let generation = processStartValidationGeneration
+            processStartValidationTask = Task { @MainActor [weak self] in
+                guard await workingDirectoryValidator(workingDirectory) else {
+                    self?.processStartValidationTask = nil
+                    return
+                }
+                #if DEBUG
+                await self?.validationCommitSeamForTesting()
+                #endif
+                let valid = await workingDirectoryValidator(workingDirectory)
+                guard let self else { return }
+                self.processStartValidationTask = nil
+                guard !Task.isCancelled,
+                      valid,
+                      !self.isTerminated,
+                      !self.processStarted,
+                      self.processStartValidationGeneration == generation,
+                      self.workingDirectory == workingDirectory else { return }
+                self.startProcessNow()
+            }
+            return
+        }
+        startProcessNow()
+    }
+
+    private func startProcessNow() {
+        guard !isTerminated, !processStarted else { return }
         processStarted = true
 
         let env = buildEnvironment()
@@ -2196,6 +2249,9 @@ final class TerminalTab: Identifiable, Hashable {
         }
         guard !isTerminated else { return }
         isTerminated = true
+        processStartValidationGeneration = UUID()
+        processStartValidationTask?.cancel()
+        processStartValidationTask = nil
         acknowledgedPTYLease.invalidate()
         terminalView.terminate()
     }

--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -294,27 +294,26 @@ struct WelcomeView: View {
             return
         }
         NativeCommandDelivery.deferToNextMainRunLoop {
-            _ = openProject(at: url)
+            Task { @MainActor in
+                guard let projectManager = await registry
+                        .projectManagerForRecentProject(url),
+                      !Task.isCancelled,
+                      let canonical = projectManager.rootURL?
+                        .standardizedFileURL,
+                      registry.openProjects[canonical] === projectManager
+                else { return }
+                openProjectWindow(canonical)
+                closeWelcome()
+            }
         }
     }
 
     @discardableResult
     private func openProject(at url: URL) -> ProjectManager? {
         let canonical = registry.canonicalProjectURL(url)
-        if let appDelegate {
-            guard appDelegate.openRecentProject(
-                canonical,
-                fallbackOpenProjectWindow: { url in
-                    openProjectWindow(url)
-                }
-            ) else {
-                return nil
-            }
-            return registry.openProjects[canonical]
-        }
-
-        // Preview/fallback hosts without AppDelegate still preserve the
-        // registry's retained ProjectManager instead of rebuilding it.
+        // Environment, drop, and folder-picker opens are ordinary folder
+        // admissions. Only explicit Recent actions consume persisted
+        // project/worktree identity through the async exact-record path above.
         guard let projectManager = registry.projectManager(for: canonical) else {
             return nil
         }

--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -376,6 +376,8 @@ final class WorkspaceManager {
         let progressID = showProgress
             ? progressTracker?.beginOperation(Strings.progressLoadingProject)
             : nil
+        let filesystemValidator = filesystemValidator
+        let filesystemValidationSeam = filesystemValidationSeam
 
         loadingTask = Task.detached(priority: .userInitiated) { [weak self] in
             // Shared cleanup closure — ends the progress operation on MainActor.
@@ -389,13 +391,13 @@ final class WorkspaceManager {
                 }
             }
 
-            if let validator = await self?.filesystemValidator {
+            if let validator = filesystemValidator {
                 guard await validator() else {
                     await self?.invalidateFilesystemLoad(generation: generation)
                     await cleanupProgress()
                     return
                 }
-                await self?.filesystemValidationSeam()
+                await filesystemValidationSeam()
                 guard !Task.isCancelled, await validator() else {
                     await self?.invalidateFilesystemLoad(generation: generation)
                     await cleanupProgress()
@@ -418,7 +420,7 @@ final class WorkspaceManager {
             }
             let shallowChildren = shallowResult.root.children ?? []
 
-            if let validator = await self?.filesystemValidator,
+            if let validator = filesystemValidator,
                !(await validator()) {
                 await self?.invalidateFilesystemLoad(generation: generation)
                 await cleanupProgress()
@@ -482,7 +484,7 @@ final class WorkspaceManager {
                 )
             }
 
-            if let validator = await self?.filesystemValidator,
+            if let validator = filesystemValidator,
                !(await validator()) {
                 await self?.invalidateFilesystemLoad(generation: generation)
                 await cleanupProgress()

--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -68,6 +68,8 @@ final class WorkspaceManager {
     private let fileWatcherFactory: (
         @escaping @MainActor () -> Void
     ) -> any WorkspaceFileWatching
+    private let filesystemValidationSeam: @Sendable () async -> Void
+    private var filesystemValidator: (@Sendable () async -> Bool)?
     private(set) var isSuspended = false
 
     /// Incremented on every file-watcher event so ContentView can trigger
@@ -99,9 +101,12 @@ final class WorkspaceManager {
                 debounceInterval: WorkspaceManager.watcherDebounce,
                 callback: callback
             )
-        }
+        },
+        filesystemValidationSeam:
+            @escaping @Sendable () async -> Void = {}
     ) {
         self.fileWatcherFactory = fileWatcherFactory
+        self.filesystemValidationSeam = filesystemValidationSeam
     }
 
     /// Debounce interval for `onRootNodesChanged` notifications.
@@ -210,7 +215,11 @@ final class WorkspaceManager {
         loadDirectory(url: url)
     }
 
-    func loadDirectory(url: URL) {
+    func loadDirectory(
+        url: URL,
+        filesystemValidator: (@Sendable () async -> Bool)? = nil
+    ) {
+        self.filesystemValidator = filesystemValidator
         isSuspended = false
         // Stop old watcher immediately so it cannot fire events
         // that would bump loadGeneration and race with the new load.
@@ -380,6 +389,20 @@ final class WorkspaceManager {
                 }
             }
 
+            if let validator = await self?.filesystemValidator {
+                guard await validator() else {
+                    await self?.invalidateFilesystemLoad(generation: generation)
+                    await cleanupProgress()
+                    return
+                }
+                await self?.filesystemValidationSeam()
+                guard !Task.isCancelled, await validator() else {
+                    await self?.invalidateFilesystemLoad(generation: generation)
+                    await cleanupProgress()
+                    return
+                }
+            }
+
             // 1. Git setup — pure nonisolated work using static helpers.
             //    No `@MainActor` object is created off-main: avoids the
             //    `nonisolated-check:ignore` workaround the GCD path needed.
@@ -394,6 +417,13 @@ final class WorkspaceManager {
                 )
             }
             let shallowChildren = shallowResult.root.children ?? []
+
+            if let validator = await self?.filesystemValidator,
+               !(await validator()) {
+                await self?.invalidateFilesystemLoad(generation: generation)
+                await cleanupProgress()
+                return
+            }
 
             if Task.isCancelled { await cleanupProgress(); return }
 
@@ -452,6 +482,13 @@ final class WorkspaceManager {
                 )
             }
 
+            if let validator = await self?.filesystemValidator,
+               !(await validator()) {
+                await self?.invalidateFilesystemLoad(generation: generation)
+                await cleanupProgress()
+                return
+            }
+
             if Task.isCancelled { await cleanupProgress(); return }
 
             await MainActor.run { [weak self] in
@@ -471,6 +508,16 @@ final class WorkspaceManager {
                 if let progressID { self.progressTracker?.endOperation(progressID) }
             }
         }
+    }
+
+    private func invalidateFilesystemLoad(generation: Int) {
+        guard loadGeneration == generation else { return }
+        loadGeneration &+= 1
+        fileWatcher?.stop()
+        fileWatcher = nil
+        isSuspended = true
+        isLoading = false
+        resumeLoadingContinuations()
     }
 
     /// Plain-data snapshot of the git state captured off-main during a load.

--- a/PineTests/AgentInboxTests.swift
+++ b/PineTests/AgentInboxTests.swift
@@ -1283,6 +1283,7 @@ struct AgentInboxTests {
         return AgentInboxRow(
             id: id,
             section: .working,
+            surface: .projectWindow,
             projectPath: "/tmp/Pine Demo",
             worktreePath: "/tmp/Pine Demo",
             projectName: "Pine Demo",

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -2872,8 +2872,9 @@ struct AgentTaskRegistryTests {
         ])
         let route = try #require(task["route"] as? [String: Any])
         #expect(Set(route.keys) == [
-            "availability", "paneID", "tabID", "terminalID",
+            "availability", "paneID", "surface", "tabID", "terminalID",
         ])
+        #expect(route["surface"] as? String == "projectWindow")
         let descriptor = try #require(task["descriptor"] as? [String: Any])
         #expect(Set(descriptor.keys) == ["launchExecutable", "typeIdentifier"])
         #expect(descriptor["launchExecutable"] as? String == "claude")

--- a/PineTests/AgentWorktreeServiceTests.swift
+++ b/PineTests/AgentWorktreeServiceTests.swift
@@ -299,8 +299,12 @@ struct AgentWorktreeServiceTests {
             defaults: defaults,
             agentTasks: taskRegistry
         )
-        let leftManager = try #require(projects.projectManager(for: left))
-        let rightManager = try #require(projects.projectManager(for: right))
+        let leftManager = try #require(
+            await projects.projectManager(for: left)
+        )
+        let rightManager = try #require(
+            await projects.projectManager(for: right)
+        )
         _ = await taskRegistry.flushPersistence()
 
         let leftTab = try terminalTab(in: leftManager, at: left.worktreeRoot)

--- a/PineTests/DockMenuTests.swift
+++ b/PineTests/DockMenuTests.swift
@@ -12,11 +12,16 @@ import Testing
 @Suite("Dock Menu Tests")
 @MainActor
 struct DockMenuTests {
-    private func settleDeferredCommand() async {
+    private func settleDeferredCommand(
+        until condition: @MainActor () -> Bool
+    ) async {
         await withCheckedContinuation { continuation in
             DispatchQueue.main.async {
                 continuation.resume()
             }
+        }
+        for _ in 0..<200 where !condition() {
+            try? await Task.sleep(for: .milliseconds(10))
         }
     }
 
@@ -161,7 +166,7 @@ struct DockMenuTests {
 
         delegate.dockMenuOpenProject(item)
         #expect(openedURL == nil)
-        await settleDeferredCommand()
+        await settleDeferredCommand { openedURL != nil }
 
         #expect(openedURL == canonical)
         #expect(delegate.registry.isProjectOpen(canonical))
@@ -213,13 +218,15 @@ struct DockMenuTests {
         #expect(!openCalled)
     }
 
-    @Test func dockMenuOpenProjectReopensBackgroundProject() async throws {
+    @Test func dockMenuOpenProjectRequestsReopenForBackgroundProject() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
 
         let canonical = dir.resolvingSymlinksInPath()
         let delegate = makeDelegate()
-        _ = delegate.registry.projectManager(for: canonical)
+        let manager = try #require(
+            delegate.registry.projectManager(for: canonical)
+        )
         // Move to background (simulates window close)
         delegate.registry.closeProjectWindow(canonical)
         #expect(delegate.registry.backgroundProjects.contains(canonical))
@@ -232,9 +239,13 @@ struct DockMenuTests {
 
         delegate.dockMenuOpenProject(item)
         #expect(openedURL == nil)
-        await settleDeferredCommand()
+        await settleDeferredCommand { openedURL != nil }
 
         #expect(openedURL == canonical)
-        #expect(!delegate.registry.backgroundProjects.contains(canonical))
+        // The stub records the SwiftUI scene request but does not create its
+        // replacement window. The manager stays retained in the background
+        // until that new scene binds it to a live AppKit window.
+        #expect(delegate.registry.openProjects[canonical] === manager)
+        #expect(delegate.registry.backgroundProjects.contains(canonical))
     }
 }

--- a/PineTests/NativeFileWindowMenuTests.swift
+++ b/PineTests/NativeFileWindowMenuTests.swift
@@ -669,7 +669,7 @@ struct NativeFileWindowMenuTests {
     }
 
     @Test("Open Recent uses the Welcome fallback without a SwiftUI bridge")
-    func openRecentUsesWelcomeFallback() throws {
+    func openRecentUsesWelcomeFallback() async throws {
         let directory = try makeTemporaryDirectory(
             prefix: "pine-recent-fallback"
         )
@@ -679,7 +679,7 @@ struct NativeFileWindowMenuTests {
         delegate.openProjectWindow = nil
         var openedURL: URL?
 
-        let didOpen = delegate.openRecentProject(
+        let didOpen = await delegate.openRecentProject(
             directory,
             fallbackOpenProjectWindow: { openedURL = $0 }
         )
@@ -711,6 +711,9 @@ struct NativeFileWindowMenuTests {
             DispatchQueue.main.async {
                 continuation.resume()
             }
+        }
+        for _ in 0..<200 where openedURL == nil {
+            try? await Task.sleep(for: .milliseconds(2))
         }
 
         let canonical = delegate.registry.canonicalProjectURL(directory)

--- a/PineTests/QuickTerminalAgentDetectionTests.swift
+++ b/PineTests/QuickTerminalAgentDetectionTests.swift
@@ -1,0 +1,2457 @@
+//
+//  QuickTerminalAgentDetectionTests.swift
+//  PineTests
+//
+//  Exact detection, ownership, routing, privacy, and quit coverage for #1420.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import Pine
+
+nonisolated private final class QuickSnapshotRunCounter:
+    @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedCount = 0
+
+    var count: Int {
+        lock.withLock { storedCount }
+    }
+
+    func record() {
+        lock.withLock { storedCount += 1 }
+    }
+
+    func recordRun() -> ProcessRunResult {
+        lock.withLock { storedCount += 1 }
+        return ProcessRunResult(
+            stdout: "",
+            stderr: "",
+            exitCode: 0,
+            timedOut: false
+        )
+    }
+}
+
+private actor QuickAgentScopeResolutionGate {
+    private var didEnter = false
+    private var isReleased = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func suspendUntilReleased() async {
+        didEnter = true
+        guard !isReleased else { return }
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func waitUntilEntered() async {
+        while !didEnter { await Task.yield() }
+    }
+
+    func release() {
+        isReleased = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+@Suite("Quick Terminal agent detection (#1420)", .serialized)
+@MainActor
+struct QuickTerminalAgentDetectionTests {
+    @Test("Quick Terminal uses one shared poller subscription across lifecycle")
+    func sharedPollerSubscriptionFollowsLifecycleExactlyOnce() async throws {
+        let counter = QuickSnapshotRunCounter()
+        let fixture = try QuickTerminalAgentFixture(
+            processRunner: { _, _, _, _ in counter.recordRun() }
+        )
+        defer { fixture.cleanUp() }
+        _ = try await fixture.start()
+
+        #expect(fixture.registry.agentSnapshotSubscriberCountForTesting == 1)
+        #expect(fixture.controller.isAgentDetectionSubscribedForTesting)
+        fixture.registry.runAgentProcessSnapshotForTesting()
+        #expect(counter.count == 1)
+        #expect(
+            fixture.controller.receivedAgentSnapshotCountForTesting == 1
+        )
+
+        fixture.controller.hide()
+        fixture.controller.show()
+        fixture.controller.show()
+        #expect(fixture.registry.agentSnapshotSubscriberCountForTesting == 1)
+
+        fixture.controller.freezeAgentTasksForTermination()
+        fixture.controller.freezeAgentTasksForTermination()
+        #expect(fixture.registry.agentSnapshotSubscriberCountForTesting == 0)
+        #expect(!fixture.controller.isAgentDetectionSubscribedForTesting)
+        fixture.registry.runAgentProcessSnapshotForTesting()
+        #expect(counter.count == 2)
+        #expect(
+            fixture.controller.receivedAgentSnapshotCountForTesting == 1
+        )
+
+        fixture.controller.cancelAgentTaskTermination()
+        fixture.controller.cancelAgentTaskTermination()
+        #expect(fixture.registry.agentSnapshotSubscriberCountForTesting == 1)
+        fixture.registry.runAgentProcessSnapshotForTesting()
+        #expect(counter.count == 3)
+        #expect(
+            fixture.controller.receivedAgentSnapshotCountForTesting == 2
+        )
+
+        fixture.controller.shutdown()
+        fixture.controller.shutdown()
+        #expect(fixture.registry.agentSnapshotSubscriberCountForTesting == 0)
+        fixture.registry.runAgentProcessSnapshotForTesting()
+        #expect(counter.count == 4)
+        #expect(
+            fixture.controller.receivedAgentSnapshotCountForTesting == 2
+        )
+    }
+
+    @Test("Async scope resolution is fenced by freeze and shutdown")
+    func asyncScopeResolutionRespectsLifecycleFences() async throws {
+        let freezeGate = QuickAgentScopeResolutionGate()
+        let freezeCompletions = QuickSnapshotRunCounter()
+        let frozenFixture = try QuickTerminalAgentFixture(
+            agentScopeResolver: { registry, workingDirectory, surface in
+                await freezeGate.suspendUntilReleased()
+                let result = await registry.resolveQuickTerminalAgentScope(
+                    workingDirectory: workingDirectory,
+                    surface: surface
+                )
+                freezeCompletions.record()
+                return result
+            }
+        )
+        defer { frozenFixture.cleanUp() }
+        frozenFixture.controller.show()
+        await freezeGate.waitUntilEntered()
+        #expect(!frozenFixture.controller.isAgentScopeReadyForTesting)
+        #expect(
+            frozenFixture.registry.agentSnapshotSubscriberCountForTesting == 0
+        )
+
+        frozenFixture.controller.freezeAgentTasksForTermination()
+        await freezeGate.release()
+        while freezeCompletions.count < 1 { await Task.yield() }
+        #expect(!frozenFixture.controller.isAgentScopeReadyForTesting)
+        #expect(
+            frozenFixture.registry.agentSnapshotSubscriberCountForTesting == 0
+        )
+
+        frozenFixture.controller.cancelAgentTaskTermination()
+        await frozenFixture.controller.waitForAgentScopeResolutionForTesting()
+        #expect(frozenFixture.controller.isAgentScopeReadyForTesting)
+        #expect(
+            frozenFixture.registry.agentSnapshotSubscriberCountForTesting == 1
+        )
+
+        let shutdownGate = QuickAgentScopeResolutionGate()
+        let shutdownCompletions = QuickSnapshotRunCounter()
+        let shutdownFixture = try QuickTerminalAgentFixture(
+            agentScopeResolver: { registry, workingDirectory, surface in
+                await shutdownGate.suspendUntilReleased()
+                let result = await registry.resolveQuickTerminalAgentScope(
+                    workingDirectory: workingDirectory,
+                    surface: surface
+                )
+                shutdownCompletions.record()
+                return result
+            }
+        )
+        defer { shutdownFixture.cleanUp() }
+        shutdownFixture.controller.show()
+        await shutdownGate.waitUntilEntered()
+        shutdownFixture.controller.shutdown()
+        await shutdownGate.release()
+        while shutdownCompletions.count < 1 { await Task.yield() }
+        #expect(!shutdownFixture.controller.isAgentScopeReadyForTesting)
+        #expect(
+            shutdownFixture.registry.agentSnapshotSubscriberCountForTesting
+                == 0
+        )
+    }
+
+    @Test("Pi, Claude, and Codex retain exact detected process generations")
+    func firstPartyAgentsRetainExactProcessGeneration() async throws {
+        let cases: [(String, AgentType)] = [
+            ("pi", .pi),
+            ("claude", .claudeCode),
+            ("codex", .codex),
+        ]
+
+        for (index, testCase) in cases.enumerated() {
+            let fixture = try QuickTerminalAgentFixture()
+            defer { fixture.cleanUp() }
+            let tab = try await fixture.start()
+            let process = quickAgentProcess(
+                pid: Int32(7_100 + index),
+                parent: 7_000,
+                group: Int32(7_100 + index),
+                command: testCase.0,
+                startedAt: TimeInterval(7_100 + index)
+            )
+            setQuickAgentIdentity(process, on: tab)
+            setQuickForeground(process, on: tab)
+
+            fixture.consume([process], sequence: 1)
+
+            let session = try #require(tab.agentSession)
+            let evidence = try #require(session.processEvidence)
+            let taskID = try #require(
+                fixture.registry.agentTasks.taskID(forSessionID: session.id)
+            )
+            let task = try #require(
+                fixture.registry.agentTasks.task(for: taskID)
+            )
+            let run = try #require(task.runs.last)
+            #expect(session.agentType == testCase.1)
+            #expect(evidence.processGeneration == 1)
+            #expect(run.process == evidence)
+            #expect(run.process.processIdentifier == process.pid)
+            #expect(run.process.startIdentifier == process.startIdentifier)
+            #expect(run.process.observedStartedAt == process.preciseStartedAt)
+            #expect(task.route.surface.isQuickTerminal)
+            #expect(task.route.terminalID == tab.id)
+            #expect(
+                fixture.registry.agentTasks.isExactLiveOwner(
+                    taskID: taskID,
+                    terminalID: tab.id,
+                    runID: session.id
+                )
+            )
+            #expect(AgentTabBadge.userFacingState(for: session) == .idle)
+        }
+    }
+
+    @Test("Surface identity rejects a project/Quick Terminal UUID collision")
+    func routeSurfaceRejectsTerminalIDCollision() throws {
+        let taskRegistry = AgentTaskRegistry(
+            persistence: QuickTerminalAgentTaskStore()
+        )
+        let identity = AgentTaskProjectIdentity(
+            canonicalProjectPath: "/tmp/PineCollision",
+            canonicalWorktreePath: "/tmp/PineCollision"
+        )
+        let terminalID = UUID()
+        let projectSession = quickDetectedSession(
+            agentType: .claudeCode,
+            processID: 7_201,
+            generation: 1
+        )
+        let quickSession = quickDetectedSession(
+            agentType: .codex,
+            processID: 7_202,
+            generation: 2
+        )
+        let projectRoute = AgentTaskRoute(
+            surface: .projectWindow,
+            paneID: terminalID,
+            tabID: terminalID,
+            terminalID: terminalID
+        )
+        let quickRoute = AgentTaskRoute(
+            surface: .quickTerminalProject,
+            paneID: terminalID,
+            tabID: terminalID,
+            terminalID: terminalID
+        )
+        taskRegistry.bridge(
+            projectSession,
+            replacing: nil,
+            context: AgentTaskBridgeContext(
+                project: identity,
+                route: projectRoute,
+                origin: .discoveredInTerminal
+            )
+        )
+        taskRegistry.bridge(
+            quickSession,
+            replacing: nil,
+            context: AgentTaskBridgeContext(
+                project: identity,
+                route: quickRoute,
+                origin: .discoveredInTerminal
+            )
+        )
+
+        let projectTaskID = try #require(
+            taskRegistry.taskID(forSessionID: projectSession.id)
+        )
+        let quickTaskID = try #require(
+            taskRegistry.taskID(forSessionID: quickSession.id)
+        )
+        #expect(projectTaskID != quickTaskID)
+        #expect(taskRegistry.tasks.count == 2)
+        #expect(taskRegistry.isExactLiveOwner(
+            taskID: projectTaskID,
+            terminalID: terminalID,
+            runID: projectSession.id
+        ))
+        #expect(taskRegistry.isExactLiveOwner(
+            taskID: quickTaskID,
+            terminalID: terminalID,
+            runID: quickSession.id
+        ))
+
+        taskRegistry.setWindowOpen(false, project: identity)
+        #expect(
+            taskRegistry.task(for: projectTaskID)?.route.availability
+                == .background
+        )
+        #expect(
+            taskRegistry.task(for: quickTaskID)?.route.availability
+                == .available
+        )
+        taskRegistry.setWindowOpen(true, project: identity)
+        #expect(
+            taskRegistry.task(for: projectTaskID)?.route.availability
+                == .available
+        )
+        #expect(
+            taskRegistry.task(for: quickTaskID)?.route.availability
+                == .available
+        )
+
+        taskRegistry.markTerminalClosed(
+            terminalID: terminalID,
+            project: identity,
+            surface: .quickTerminalProject
+        )
+
+        #expect(
+            taskRegistry.task(for: projectTaskID)?.route.availability
+                == .available
+        )
+        #expect(
+            taskRegistry.task(for: quickTaskID)?.route.availability
+                == .missing
+        )
+    }
+
+    @Test("Quick Terminal project scope is immutable across project switches")
+    func projectScopeDoesNotFollowLaterProjectSwitches() async throws {
+        let first = try makeQuickTerminalDirectory(name: "First")
+        let second = try makeQuickTerminalDirectory(name: "Second")
+        defer {
+            removeQuickTerminalDirectory(first)
+            removeQuickTerminalDirectory(second)
+        }
+        let fixture = try QuickTerminalAgentFixture(recentProjects: [first])
+        defer { fixture.cleanUp() }
+        let tab = try await fixture.start()
+        fixture.registry.recentProjects = [second]
+        fixture.controller.hide()
+        fixture.controller.show()
+        let process = quickAgentProcess(
+            pid: 7_301,
+            parent: 7_300,
+            group: 7_301,
+            command: "claude",
+            startedAt: 7_301
+        )
+        setQuickAgentIdentity(process, on: tab)
+        setQuickForeground(process, on: tab)
+        fixture.consume([process], sequence: 1)
+
+        let session = try #require(tab.agentSession)
+        let taskID = try #require(
+            fixture.registry.agentTasks.taskID(forSessionID: session.id)
+        )
+        let task = try #require(
+            fixture.registry.agentTasks.task(for: taskID)
+        )
+        #expect(tab.workingDirectoryURL?.standardizedFileURL == first)
+        #expect(task.route.surface == .quickTerminalProject)
+        #expect(task.project.canonicalProjectPath == first.path)
+        #expect(task.project.canonicalWorktreePath == first.path)
+        #expect(task.project.canonicalProjectPath != second.path)
+    }
+
+    @Test("Standalone Inbox origin never projects the home path")
+    func standaloneInboxOriginIsPrivacySafe() throws {
+        let taskRegistry = AgentTaskRegistry(
+            persistence: QuickTerminalAgentTaskStore()
+        )
+        let privatePath = NSHomeDirectory()
+        let privateName = URL(fileURLWithPath: privatePath).lastPathComponent
+        let project = AgentTaskProjectIdentity(
+            canonicalProjectPath: privatePath,
+            canonicalWorktreePath: privatePath
+        )
+        let session = quickDetectedSession(
+            agentType: .pi,
+            processID: 7_401,
+            generation: 1
+        )
+        let terminalID = UUID()
+        taskRegistry.bridge(
+            session,
+            replacing: nil,
+            context: AgentTaskBridgeContext(
+                project: project,
+                route: AgentTaskRoute(
+                    surface: .quickTerminalStandalone,
+                    paneID: UUID(),
+                    tabID: terminalID,
+                    terminalID: terminalID
+                ),
+                presentationContext: AgentTaskPresentationContext(
+                    terminalStableLabel: Strings.quickTerminalText()
+                ),
+                origin: .discoveredInTerminal
+            )
+        )
+
+        let row = try #require(
+            AgentInboxSnapshot(tasks: taskRegistry.tasks).rows.first
+        )
+        #expect(row.surface == .quickTerminalStandalone)
+        #expect(row.projectPath.isEmpty)
+        #expect(row.worktreePath.isEmpty)
+        #expect(row.projectName == Strings.quickTerminalText())
+        #expect(row.worktreeName == nil)
+        #expect(row.terminalLabel == Strings.quickTerminalText())
+        #expect(
+            !AgentInboxView.accessibilityLabel(for: row)
+                .contains(privatePath)
+        )
+        let task = try #require(taskRegistry.tasks.first)
+        let dockTitle = AgentPresenceController.dockMenuAgentTitle(for: task)
+        #expect(dockTitle.contains(Strings.quickTerminalText()))
+        #expect(!dockTitle.contains(privatePath))
+        #expect(!dockTitle.contains(privateName))
+        let projectBacked = quickRecoveryTask(
+            surface: .quickTerminalProject,
+            lifecycle: .paused,
+            privatePath: "/tmp/visible-project"
+        )
+        let projectOptions = AgentNotificationSettingsProjection
+            .projectOptions(tasks: [task, projectBacked])
+        #expect(projectOptions.map(\.path) == ["/tmp/visible-project"])
+        #expect(!projectOptions.contains { $0.path == privatePath })
+        #expect(!projectOptions.contains { $0.label == privateName })
+    }
+
+    @Test("Unverified recent project scope downgrades to standalone")
+    func unverifiedRecentProjectScopeIsPrivacySafe() async throws {
+        let project = try makeQuickTerminalDirectory(name: "Unverified")
+        defer { removeQuickTerminalDirectory(project) }
+        let fixture = try QuickTerminalAgentFixture(
+            recentProjects: [project],
+            proveRecentProjectIdentity: false
+        )
+        defer { fixture.cleanUp() }
+        let tab = try await fixture.start()
+        let process = quickAgentProcess(
+            pid: 7_451,
+            parent: 7_450,
+            group: 7_451,
+            command: "codex",
+            startedAt: 7_451
+        )
+        setQuickAgentIdentity(process, on: tab)
+        setQuickForeground(process, on: tab)
+        fixture.consume([process], sequence: 1)
+
+        let task = try #require(fixture.registry.agentTasks.tasks.first)
+        #expect(task.route.surface == .quickTerminalStandalone)
+        let row = try #require(
+            AgentInboxSnapshot(tasks: [task]).rows.first
+        )
+        #expect(row.projectPath.isEmpty)
+        #expect(row.worktreePath.isEmpty)
+        #expect(row.projectName == Strings.quickTerminalText())
+        #expect(!AgentPresenceController.dockMenuAgentTitle(for: task)
+            .contains(project.lastPathComponent))
+    }
+
+    @Test("Quick task recovery never admits a project-window manager")
+    func quickRecoveryFailsClosedBeforeProjectAdmission() async throws {
+        let canonicalizationCounter = QuickSnapshotRunCounter()
+        let taskRegistry = AgentTaskRegistry(
+            persistence: QuickTerminalAgentTaskStore()
+        )
+        let registry = ProjectRegistry(
+            agentTasks: taskRegistry,
+            agentInboxProjectCanonicalizer: { url in
+                canonicalizationCounter.record()
+                return url
+            },
+            agentDetectionProcessRunner: { _, _, _, _ in
+                ProcessRunResult(
+                    stdout: "",
+                    stderr: "",
+                    exitCode: 0,
+                    timedOut: false
+                )
+            },
+            agentDetectionPollInterval: 3_600
+        )
+        let standalone = quickRecoveryTask(
+            surface: .quickTerminalStandalone,
+            lifecycle: .paused,
+            privatePath: "/Users/recovery-private-home"
+        )
+        let projectBacked = quickRecoveryTask(
+            surface: .quickTerminalProject,
+            lifecycle: .completed,
+            privatePath: "/tmp/recovery-private-worktree"
+        )
+        taskRegistry.setTasksForTesting([standalone, projectBacked])
+
+        let snapshot = AgentInboxSnapshot(tasks: taskRegistry.tasks)
+        #expect(snapshot.rows.count == 2)
+        #expect(snapshot.rows.allSatisfy { !$0.canRecover })
+
+        var openedProjectWindow = false
+        for task in [standalone, projectBacked] {
+            let result = await registry.recoverAgentTaskFromInbox(
+                task.id,
+                action: .startNewSession,
+                openProjectWindow: { _ in openedProjectWindow = true },
+                waitUntilPresented: { _ in true },
+                activateApplication: { _ in }
+            )
+            #expect(result == .launchRejected)
+        }
+        #expect(!openedProjectWindow)
+        #expect(registry.openProjects.isEmpty)
+        #expect(canonicalizationCounter.count < 1)
+    }
+
+    @Test("Managed-worktree Quick scope survives reclaim and relaunch")
+    func managedWorktreeRecentIdentitySurvivesReclaimAndRelaunch() async throws {
+        let root = try makeQuickTerminalDirectory(name: "ManagedScope")
+        defer { removeQuickTerminalDirectory(root) }
+        let repository = root.appendingPathComponent(
+            "Repository",
+            isDirectory: true
+        )
+        let managedRoot = root.appendingPathComponent(
+            "Managed",
+            isDirectory: true
+        )
+        let worktreeRoot = managedRoot.appendingPathComponent(
+            "feature-branch",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: managedRoot,
+            withIntermediateDirectories: true
+        )
+        try makeQuickGitRepository(at: repository, seed: "repository-a")
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/quick-agent", "--",
+            worktreeRoot.path,
+        ], at: repository)
+        _ = try runQuickGit(
+            ["config", "core.logAllRefUpdates", "false"],
+            at: repository
+        )
+        _ = try runQuickGit(
+            ["reflog", "expire", "--expire=all", "--all"],
+            at: repository
+        )
+        try? FileManager.default.removeItem(
+            at: repository.appendingPathComponent(".git/logs")
+        )
+        let baseCommit = try runQuickGit(
+            ["rev-parse", "HEAD"],
+            at: repository
+        )
+        let managed = AgentManagedWorktree(
+            taskID: UUID(),
+            repositoryRoot: repository,
+            managedRoot: managedRoot,
+            worktreeRoot: worktreeRoot,
+            branchName: "feature/quick-agent",
+            baseCommit: baseCommit,
+            repositoryProof: try await quickRepositoryProof(
+                repository: repository,
+                worktree: worktreeRoot
+            )
+        )
+        let defaultsDomain = "QuickManagedIdentity-\(UUID().uuidString)"
+        let settingsDomain = "QuickManagedSettings-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsDomain))
+        let settingsDefaults = try #require(
+            UserDefaults(suiteName: settingsDomain)
+        )
+        defaults.removePersistentDomain(forName: defaultsDomain)
+        settingsDefaults.removePersistentDomain(forName: settingsDomain)
+        defer {
+            defaults.removePersistentDomain(forName: defaultsDomain)
+            settingsDefaults.removePersistentDomain(forName: settingsDomain)
+        }
+        let noProcessSnapshot: ProcessRunner = { _, _, _, _ in
+            ProcessRunResult(
+                stdout: "",
+                stderr: "",
+                exitCode: 0,
+                timedOut: false
+            )
+        }
+        let registry = ProjectRegistry(
+            defaults: defaults,
+            agentTasks: AgentTaskRegistry(
+                persistence: QuickTerminalAgentTaskStore()
+            ),
+            agentDetectionProcessRunner: noProcessSnapshot,
+            agentDetectionPollInterval: 3_600
+        )
+        let original = try #require(
+            await registry.projectManager(for: managed)
+        )
+        let canonicalWorktree = registry.canonicalProjectURL(worktreeRoot)
+        registry.closeProjectWindow(worktreeRoot)
+        registry.runBackgroundReclamationPassForTesting()
+        #expect(registry.openProjects[canonicalWorktree] == nil)
+
+        let reopened = try #require(
+            await registry.projectManager(for: managed)
+        )
+        #expect(reopened !== original)
+        registry.closeProjectWindow(worktreeRoot)
+        registry.runBackgroundReclamationPassForTesting()
+        #expect(registry.openProjects[canonicalWorktree] == nil)
+
+        let settings = QuickTerminalSettings(
+            defaults: settingsDefaults,
+            notificationCenter: NotificationCenter()
+        )
+        settings.enabled = true
+        settings.hideOnFocusLoss = false
+        let firstController = QuickTerminalController(settings: settings)
+        firstController.registry = registry
+        registry.quickTerminalAgentRouter = firstController
+        firstController.show()
+        await firstController.waitForAgentScopeResolutionForTesting()
+        #expect(firstController.isAgentScopeReadyForTesting)
+        let firstTab = try #require(firstController.paneState.activeTab)
+        let firstProcess = quickAgentProcess(
+            pid: 7_801,
+            parent: 7_800,
+            group: 7_801,
+            command: "codex",
+            startedAt: 7_801
+        )
+        setQuickAgentIdentity(firstProcess, on: firstTab)
+        setQuickForeground(firstProcess, on: firstTab)
+        firstController.agentSnapshotConsumer.consumeAgentProcessSnapshot(
+            [firstProcess],
+            observation: quickObservation(sequence: 1)
+        )
+        let firstTask = try #require(registry.agentTasks.tasks.first)
+        #expect(firstTask.route.surface == .quickTerminalProject)
+        #expect(firstTask.project.canonicalProjectPath == repository.path)
+        #expect(firstTask.project.canonicalWorktreePath == worktreeRoot.path)
+        firstController.shutdown()
+
+        // Repository proof is filesystem-instance identity only. Enabling,
+        // expiring, and repopulating reflogs cannot invalidate it.
+        _ = try runQuickGit(
+            ["config", "core.logAllRefUpdates", "true"],
+            at: repository
+        )
+        try Data("before expiry".utf8).write(
+            to: repository.appendingPathComponent("later.txt"),
+            options: .atomic
+        )
+        _ = try runQuickGit(["add", "--", "later.txt"], at: repository)
+        _ = try runQuickGit(
+            ["commit", "-m", "before reflog expiry"],
+            at: repository
+        )
+        _ = try runQuickGit(
+            ["reflog", "expire", "--expire=all", "--all"],
+            at: repository
+        )
+        try Data("after expiry".utf8).write(
+            to: repository.appendingPathComponent("after.txt"),
+            options: .atomic
+        )
+        _ = try runQuickGit(["add", "--", "after.txt"], at: repository)
+        _ = try runQuickGit(
+            ["commit", "-m", "after reflog expiry"],
+            at: repository
+        )
+
+        let relaunchedRegistry = ProjectRegistry(
+            defaults: defaults,
+            agentTasks: AgentTaskRegistry(
+                persistence: QuickTerminalAgentTaskStore()
+            ),
+            agentDetectionProcessRunner: noProcessSnapshot,
+            agentDetectionPollInterval: 3_600
+        )
+        #expect(relaunchedRegistry.recentProjects.first == canonicalWorktree)
+        let relaunchedController = QuickTerminalController(settings: settings)
+        defer { relaunchedController.shutdown() }
+        relaunchedController.registry = relaunchedRegistry
+        relaunchedRegistry.quickTerminalAgentRouter = relaunchedController
+        relaunchedController.show()
+        await relaunchedController.waitForAgentScopeResolutionForTesting()
+        #expect(relaunchedController.isAgentScopeReadyForTesting)
+        let relaunchedTab = try #require(
+            relaunchedController.paneState.activeTab
+        )
+        let relaunchedProcess = quickAgentProcess(
+            pid: 7_802,
+            parent: 7_800,
+            group: 7_802,
+            command: "claude",
+            startedAt: 7_802
+        )
+        setQuickAgentIdentity(relaunchedProcess, on: relaunchedTab)
+        setQuickForeground(relaunchedProcess, on: relaunchedTab)
+        relaunchedController.agentSnapshotConsumer
+            .consumeAgentProcessSnapshot(
+                [relaunchedProcess],
+                observation: quickObservation(sequence: 2)
+            )
+        let relaunchedTask = try #require(
+            relaunchedRegistry.agentTasks.tasks.first
+        )
+        #expect(relaunchedTask.route.surface == .quickTerminalProject)
+        #expect(
+            relaunchedTask.project.canonicalProjectPath == repository.path
+        )
+        #expect(
+            relaunchedTask.project.canonicalWorktreePath == worktreeRoot.path
+        )
+    }
+
+    @Test("Actual Recent flow reopens one retained exact worktree manager")
+    func actualRecentFlowReopensRetainedExactManager() async throws {
+        let fixture = try await makeQuickRecentManagedFixture(
+            name: "RecentRetained"
+        )
+        defer { fixture.cleanUp() }
+        let registry = ProjectRegistry(defaults: fixture.defaults)
+        let original = try #require(
+            await registry.projectManager(for: fixture.managed)
+        )
+        let canonical = registry.canonicalProjectURL(fixture.worktree)
+        registry.closeProjectWindow(canonical)
+        #expect(registry.backgroundProjects.contains(canonical))
+
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        delegate.openProjectWindow = nil
+        var openedURL: URL?
+        let didOpen = await delegate.openRecentProject(
+            canonical,
+            fallbackOpenProjectWindow: { openedURL = $0 }
+        )
+
+        #expect(didOpen)
+        #expect(openedURL == canonical)
+        #expect(registry.openProjects[canonical] === original)
+        #expect(await registry.projectManager(for: fixture.managed) === original)
+    }
+
+    @Test("Actual Recent flow restores exact identity after reclaim and relaunch")
+    func actualRecentFlowRestoresReclaimedExactIdentity() async throws {
+        let fixture = try await makeQuickRecentManagedFixture(
+            name: "RecentRelaunch"
+        )
+        defer { fixture.cleanUp() }
+        let seed = ProjectRegistry(defaults: fixture.defaults)
+        _ = try #require(await seed.projectManager(for: fixture.managed))
+        let canonical = seed.canonicalProjectURL(fixture.worktree)
+        seed.closeProjectWindow(canonical)
+        seed.runBackgroundReclamationPassForTesting()
+        #expect(seed.openProjects[canonical] == nil)
+
+        let relaunched = ProjectRegistry(defaults: fixture.defaults)
+        let delegate = AppDelegate()
+        delegate.registry = relaunched
+        delegate.openProjectWindow = nil
+        var openedURL: URL?
+        #expect(await delegate.openRecentProject(
+            canonical,
+            fallbackOpenProjectWindow: { openedURL = $0 }
+        ))
+        let restored = try #require(relaunched.openProjects[canonical])
+        #expect(openedURL == canonical)
+        #expect(
+            await relaunched.projectManager(for: fixture.managed) === restored
+        )
+        let quickScope = try #require(
+            await relaunched.resolveQuickTerminalAgentScope(
+                workingDirectory: fixture.worktree,
+                surface: .quickTerminalProject
+            )
+        )
+        #expect(quickScope.surface == .quickTerminalProject)
+        #expect(
+            quickScope.project == AgentTaskProjectIdentity(
+                canonicalProjectPath: fixture.repository.path,
+                canonicalWorktreePath: fixture.worktree.path
+            )
+        )
+    }
+
+    @Test("Actual Recent flow rejects same-path replacement without losing proof")
+    func actualRecentFlowRejectsReplacementAndRetainsProof() async throws {
+        let fixture = try await makeQuickRecentManagedFixture(
+            name: "RecentReplacement"
+        )
+        defer { fixture.cleanUp() }
+        let seed = ProjectRegistry(defaults: fixture.defaults)
+        _ = try #require(await seed.projectManager(for: fixture.managed))
+        let canonical = seed.canonicalProjectURL(fixture.worktree)
+        seed.closeProjectWindow(canonical)
+        seed.runBackgroundReclamationPassForTesting()
+        let relaunched = ProjectRegistry(defaults: fixture.defaults)
+
+        let displacedRepository = fixture.root.appendingPathComponent(
+            "Repository-A",
+            isDirectory: true
+        )
+        let displacedWorktree = fixture.managedRoot.appendingPathComponent(
+            "worktree-A",
+            isDirectory: true
+        )
+        try FileManager.default.moveItem(
+            at: fixture.worktree,
+            to: displacedWorktree
+        )
+        try FileManager.default.moveItem(
+            at: fixture.repository,
+            to: displacedRepository
+        )
+        try makeQuickGitRepository(at: fixture.repository, seed: "replacement")
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/replacement", "--",
+            fixture.worktree.path,
+        ], at: fixture.repository)
+
+        let delegate = AppDelegate()
+        delegate.registry = relaunched
+        delegate.openProjectWindow = nil
+        var openedReplacement = false
+        #expect(!(await delegate.openRecentProject(
+            canonical,
+            fallbackOpenProjectWindow: { _ in openedReplacement = true }
+        )))
+        #expect(!openedReplacement)
+        #expect(relaunched.openProjects.isEmpty)
+
+        try FileManager.default.removeItem(at: fixture.worktree)
+        try FileManager.default.removeItem(at: fixture.repository)
+        try FileManager.default.moveItem(
+            at: displacedRepository,
+            to: fixture.repository
+        )
+        try FileManager.default.moveItem(
+            at: displacedWorktree,
+            to: fixture.worktree
+        )
+
+        var openedOriginal: URL?
+        #expect(await delegate.openRecentProject(
+            canonical,
+            fallbackOpenProjectWindow: { openedOriginal = $0 }
+        ))
+        #expect(openedOriginal == canonical)
+        let scope = try #require(
+            await relaunched.resolveQuickTerminalAgentScope(
+                workingDirectory: fixture.worktree,
+                surface: .quickTerminalProject
+            )
+        )
+        #expect(scope.surface == .quickTerminalProject)
+        #expect(scope.project.canonicalProjectPath == fixture.repository.path)
+        #expect(scope.project.canonicalWorktreePath == fixture.worktree.path)
+    }
+
+    @Test("Reused worktree path cannot inherit a prior repository identity")
+    func reusedWorktreePathDowngradesAfterRelaunch() async throws {
+        let root = try makeQuickTerminalDirectory(name: "PathReuse")
+        defer { removeQuickTerminalDirectory(root) }
+        let repositoryA = root.appendingPathComponent(
+            "Repository-A",
+            isDirectory: true
+        )
+        let repositoryB = root.appendingPathComponent(
+            "Repository-B",
+            isDirectory: true
+        )
+        let managedRoot = root.appendingPathComponent(
+            "Managed",
+            isDirectory: true
+        )
+        let reusedWorktree = managedRoot.appendingPathComponent(
+            "reused",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: managedRoot,
+            withIntermediateDirectories: true
+        )
+        try makeQuickGitRepository(at: repositoryA, seed: "repository-a")
+        try makeQuickGitRepository(at: repositoryB, seed: "repository-b")
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/from-a", "--",
+            reusedWorktree.path,
+        ], at: repositoryA)
+        let baseCommitA = try runQuickGit(
+            ["rev-parse", "HEAD"],
+            at: repositoryA
+        )
+
+        let defaultsDomain = "QuickPathReuseIdentity-\(UUID().uuidString)"
+        let settingsDomain = "QuickPathReuseSettings-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsDomain))
+        let settingsDefaults = try #require(
+            UserDefaults(suiteName: settingsDomain)
+        )
+        defaults.removePersistentDomain(forName: defaultsDomain)
+        settingsDefaults.removePersistentDomain(forName: settingsDomain)
+        defer {
+            defaults.removePersistentDomain(forName: defaultsDomain)
+            settingsDefaults.removePersistentDomain(forName: settingsDomain)
+        }
+        let noProcessSnapshot: ProcessRunner = { _, _, _, _ in
+            ProcessRunResult(
+                stdout: "",
+                stderr: "",
+                exitCode: 0,
+                timedOut: false
+            )
+        }
+        let firstRegistry = ProjectRegistry(
+            defaults: defaults,
+            agentTasks: AgentTaskRegistry(
+                persistence: QuickTerminalAgentTaskStore()
+            ),
+            agentDetectionProcessRunner: noProcessSnapshot,
+            agentDetectionPollInterval: 3_600
+        )
+        let managedA = AgentManagedWorktree(
+            taskID: UUID(),
+            repositoryRoot: repositoryA,
+            managedRoot: managedRoot,
+            worktreeRoot: reusedWorktree,
+            branchName: "feature/from-a",
+            baseCommit: baseCommitA,
+            repositoryProof: try await quickRepositoryProof(
+                repository: repositoryA,
+                worktree: reusedWorktree
+            )
+        )
+        _ = try #require(
+            await firstRegistry.projectManager(for: managedA)
+        )
+        firstRegistry.closeProjectWindow(reusedWorktree)
+        firstRegistry.runBackgroundReclamationPassForTesting()
+
+        _ = try runQuickGit([
+            "worktree", "remove", "--force", "--", reusedWorktree.path,
+        ], at: repositoryA)
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/from-b", "--",
+            reusedWorktree.path,
+        ], at: repositoryB)
+
+        let relaunchedRegistry = ProjectRegistry(
+            defaults: defaults,
+            agentTasks: AgentTaskRegistry(
+                persistence: QuickTerminalAgentTaskStore()
+            ),
+            agentDetectionProcessRunner: noProcessSnapshot,
+            agentDetectionPollInterval: 3_600
+        )
+        #expect(
+            relaunchedRegistry.recentProjects.first
+                == relaunchedRegistry.canonicalProjectURL(reusedWorktree)
+        )
+        let settings = QuickTerminalSettings(
+            defaults: settingsDefaults,
+            notificationCenter: NotificationCenter()
+        )
+        settings.enabled = true
+        settings.hideOnFocusLoss = false
+        let controller = QuickTerminalController(settings: settings)
+        defer { controller.shutdown() }
+        controller.registry = relaunchedRegistry
+        relaunchedRegistry.quickTerminalAgentRouter = controller
+        controller.show()
+        await controller.waitForAgentScopeResolutionForTesting()
+        #expect(controller.isAgentScopeReadyForTesting)
+        let tab = try #require(controller.paneState.activeTab)
+        let process = quickAgentProcess(
+            pid: 7_851,
+            parent: 7_850,
+            group: 7_851,
+            command: "codex",
+            startedAt: 7_851
+        )
+        setQuickAgentIdentity(process, on: tab)
+        setQuickForeground(process, on: tab)
+        controller.agentSnapshotConsumer.consumeAgentProcessSnapshot(
+            [process],
+            observation: quickObservation(sequence: 1)
+        )
+
+        let task = try #require(relaunchedRegistry.agentTasks.tasks.first)
+        #expect(task.route.surface == .quickTerminalStandalone)
+        #expect(task.project.canonicalProjectPath == reusedWorktree.path)
+        #expect(task.project.canonicalProjectPath != repositoryA.path)
+        #expect(task.project.canonicalProjectPath != repositoryB.path)
+        let row = try #require(
+            AgentInboxSnapshot(tasks: [task]).rows.first
+        )
+        #expect(row.projectPath.isEmpty)
+        #expect(row.worktreePath.isEmpty)
+        #expect(row.projectName == Strings.quickTerminalText())
+        let dockTitle = AgentPresenceController.dockMenuAgentTitle(for: task)
+        #expect(!dockTitle.contains(repositoryA.lastPathComponent))
+        #expect(!dockTitle.contains(repositoryB.lastPathComponent))
+        #expect(!dockTitle.contains(reusedWorktree.lastPathComponent))
+    }
+
+    @Test("Same-path repository replacement cannot inherit recent identity")
+    func samePathsRepositoryReplacementDowngradesAtRegistration() async throws {
+        let root = try makeQuickTerminalDirectory(name: "ExactPathReuse")
+        defer { removeQuickTerminalDirectory(root) }
+        let repository = root.appendingPathComponent(
+            "Repository",
+            isDirectory: true
+        )
+        let managedRoot = root.appendingPathComponent(
+            "Managed",
+            isDirectory: true
+        )
+        let worktree = managedRoot.appendingPathComponent(
+            "feature",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: managedRoot,
+            withIntermediateDirectories: true
+        )
+        try makeQuickGitRepository(at: repository, seed: "repository-a")
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/from-a", "--",
+            worktree.path,
+        ], at: repository)
+        let baseCommit = try runQuickGit(
+            ["rev-parse", "HEAD"],
+            at: repository
+        )
+
+        let defaultsDomain = "QuickExactPathReuse-\(UUID().uuidString)"
+        let settingsDomain = "QuickExactPathSettings-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsDomain))
+        let settingsDefaults = try #require(
+            UserDefaults(suiteName: settingsDomain)
+        )
+        defaults.removePersistentDomain(forName: defaultsDomain)
+        settingsDefaults.removePersistentDomain(forName: settingsDomain)
+        defer {
+            defaults.removePersistentDomain(forName: defaultsDomain)
+            settingsDefaults.removePersistentDomain(forName: settingsDomain)
+        }
+        let noProcessSnapshot: ProcessRunner = { _, _, _, _ in
+            ProcessRunResult(
+                stdout: "",
+                stderr: "",
+                exitCode: 0,
+                timedOut: false
+            )
+        }
+        let firstRegistry = ProjectRegistry(
+            defaults: defaults,
+            agentTasks: AgentTaskRegistry(
+                persistence: QuickTerminalAgentTaskStore()
+            ),
+            agentDetectionProcessRunner: noProcessSnapshot,
+            agentDetectionPollInterval: 3_600
+        )
+        let managedA = AgentManagedWorktree(
+            taskID: UUID(),
+            repositoryRoot: repository,
+            managedRoot: managedRoot,
+            worktreeRoot: worktree,
+            branchName: "feature/from-a",
+            baseCommit: baseCommit,
+            repositoryProof: try await quickRepositoryProof(
+                repository: repository,
+                worktree: worktree
+            )
+        )
+        _ = try #require(
+            await firstRegistry.projectManager(for: managedA)
+        )
+        firstRegistry.closeProjectWindow(worktree)
+        firstRegistry.runBackgroundReclamationPassForTesting()
+
+        // Decode A's persisted record first. Filesystem proof is deliberately
+        // deferred until Quick Terminal registration; replacing both paths
+        // here exercises that exact asynchronous validation boundary.
+        let preloadedRegistry = ProjectRegistry(
+            defaults: defaults,
+            agentTasks: AgentTaskRegistry(
+                persistence: QuickTerminalAgentTaskStore()
+            ),
+            agentDetectionProcessRunner: noProcessSnapshot,
+            agentDetectionPollInterval: 3_600
+        )
+        #expect(
+            preloadedRegistry.recentProjects.first
+                == preloadedRegistry.canonicalProjectURL(worktree)
+        )
+
+        _ = try runQuickGit([
+            "worktree", "remove", "--force", "--", worktree.path,
+        ], at: repository)
+        try FileManager.default.removeItem(at: repository)
+        try makeQuickGitRepository(at: repository, seed: "repository-b")
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/from-b", "--",
+            worktree.path,
+        ], at: repository)
+
+        // The managed token carries A's proof. Replacement before the
+        // asynchronous admission check completes cannot admit B under A's
+        // logical project/worktree identity.
+        let staleAdmissionRegistry = ProjectRegistry(
+            agentTasks: AgentTaskRegistry(
+                persistence: QuickTerminalAgentTaskStore()
+            ),
+            agentDetectionProcessRunner: noProcessSnapshot,
+            agentDetectionPollInterval: 3_600
+        )
+        let staleAdmission = await staleAdmissionRegistry.projectManager(
+            for: managedA
+        )
+        #expect(staleAdmission == nil)
+        #expect(staleAdmissionRegistry.openProjects.isEmpty)
+
+        // Persisted Inbox metadata for A must not admit or present B after an
+        // exact same-root replacement, even though every canonical string is
+        // unchanged.
+        let persistedRecoveryTask = quickProjectRecoveryTask(
+            identity: AgentTaskProjectIdentity(
+                canonicalProjectPath: repository.path,
+                canonicalWorktreePath: worktree.path
+            )
+        )
+        preloadedRegistry.agentTasks.setTasksForTesting([
+            persistedRecoveryTask,
+        ])
+        var openedPersistedReplacement = false
+        let staleRecovery = await preloadedRegistry
+            .recoverAgentTaskFromInbox(
+                persistedRecoveryTask.id,
+                action: .startNewSession,
+                openProjectWindow: { _ in
+                    openedPersistedReplacement = true
+                },
+                waitUntilPresented: { _ in true },
+                activateApplication: { _ in }
+            )
+        #expect(staleRecovery == .projectUnavailable)
+        #expect(!openedPersistedReplacement)
+        #expect(preloadedRegistry.openProjects.isEmpty)
+        preloadedRegistry.agentTasks.setTasksForTesting([])
+
+        let settings = QuickTerminalSettings(
+            defaults: settingsDefaults,
+            notificationCenter: NotificationCenter()
+        )
+        settings.enabled = true
+        settings.hideOnFocusLoss = false
+        let controller = QuickTerminalController(settings: settings)
+        defer { controller.shutdown() }
+        controller.registry = preloadedRegistry
+        preloadedRegistry.quickTerminalAgentRouter = controller
+        controller.show()
+        await controller.waitForAgentScopeResolutionForTesting()
+        #expect(controller.isAgentScopeReadyForTesting)
+        let tab = try #require(controller.paneState.activeTab)
+        let process = quickAgentProcess(
+            pid: 7_861,
+            parent: 7_860,
+            group: 7_861,
+            command: "claude",
+            startedAt: 7_861
+        )
+        setQuickAgentIdentity(process, on: tab)
+        setQuickForeground(process, on: tab)
+        controller.agentSnapshotConsumer.consumeAgentProcessSnapshot(
+            [process],
+            observation: quickObservation(sequence: 1)
+        )
+
+        let task = try #require(preloadedRegistry.agentTasks.tasks.first)
+        #expect(task.route.surface == .quickTerminalStandalone)
+        #expect(task.project.canonicalProjectPath == worktree.path)
+        #expect(task.project.canonicalWorktreePath == worktree.path)
+        #expect(preloadedRegistry.openProjects.isEmpty)
+    }
+
+    @Test("Bounded Git control reads reject growth and replacement races")
+    func boundedGitControlReadsRejectRaces() throws {
+        #expect(
+            ProjectRegistry.unsignedFilesystemIdentityForTesting(-1)
+                == UInt64.max
+        )
+        let root = try makeQuickTerminalDirectory(name: "BoundedGitRead")
+        defer { removeQuickTerminalDirectory(root) }
+        let control = root.appendingPathComponent("control", isDirectory: false)
+        let original = "gitdir: /private/tmp/repository\n"
+        try Data(original.utf8).write(to: control)
+        #expect(
+            ProjectRegistry.boundedGitPathFileForTesting(
+                control,
+                beforeRead: {}
+            )
+                == "gitdir: /private/tmp/repository"
+        )
+        #expect(
+            ProjectRegistry.filesystemIdentityMatchesForTesting(
+                leftGeneration: 7,
+                rightGeneration: 7
+            )
+        )
+        #expect(
+            !ProjectRegistry.filesystemIdentityMatchesForTesting(
+                leftGeneration: 7,
+                rightGeneration: 8
+            )
+        )
+
+        let growingHandle = try FileHandle(forWritingTo: control)
+        let growthResult = ProjectRegistry.boundedGitPathFileForTesting(control) {
+            _ = try? growingHandle.seekToEnd()
+            try? growingHandle.write(
+                contentsOf: Data(repeating: 0x61, count: 5_000)
+            )
+        }
+        try growingHandle.close()
+        #expect(growthResult == nil)
+
+        try Data(original.utf8).write(to: control)
+        let replacementResult = ProjectRegistry.boundedGitPathFileForTesting(
+            control
+        ) {
+            try? Data("gitdir: /private/tmp/replacement\n".utf8).write(
+                to: control,
+                options: .atomic
+            )
+        }
+        #expect(replacementResult == nil)
+
+        for valid in [
+            "gitdir: /private/tmp/repository",
+            "gitdir: /private/tmp/repository\n",
+            "gitdir: /private/tmp/repository\r\n",
+        ] {
+            try Data(valid.utf8).write(to: control, options: .atomic)
+            #expect(
+                ProjectRegistry.boundedGitPathFileForTesting(
+                    control,
+                    beforeRead: {}
+                ) == "gitdir: /private/tmp/repository"
+            )
+        }
+        for invalid in [
+            "\ngitdir: /private/tmp/repository",
+            "gitdir: /private/tmp/repository\n\n",
+            "gitdir: /private/tmp/repository\r",
+            "gitdir: /private/tmp/repository\r\n\n",
+            "gitdir: /private/tmp/repository\u{0}",
+        ] {
+            try Data(invalid.utf8).write(to: control, options: .atomic)
+            #expect(
+                ProjectRegistry.boundedGitPathFileForTesting(
+                    control,
+                    beforeRead: {}
+                ) == nil
+            )
+        }
+    }
+
+    @Test("Repository proof binds every Git control-graph edge")
+    func repositoryProofRejectsPostResolutionGraphReplacement() async throws {
+        let root = try makeQuickTerminalDirectory(name: "GraphBinding")
+        defer { removeQuickTerminalDirectory(root) }
+        let repository = root.appendingPathComponent(
+            "Repository",
+            isDirectory: true
+        )
+        let worktree = root.appendingPathComponent(
+            "Worktree",
+            isDirectory: true
+        )
+        try makeQuickGitRepository(at: repository, seed: "graph-a")
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/graph", "--", worktree.path,
+        ], at: repository)
+        let identity = AgentTaskProjectIdentity(
+            canonicalProjectPath: repository.path,
+            canonicalWorktreePath: worktree.path
+        )
+        let worktreeControl = worktree.appendingPathComponent(".git")
+        let originalControl = try Data(contentsOf: worktreeControl)
+        let switchedControlProof = await Task.detached(priority: .utility) {
+            RecentAgentTaskFilesystemValidator.repositoryProof(
+                for: identity,
+                afterGraphResolution: {
+                    try? originalControl.write(
+                        to: worktreeControl,
+                        options: .atomic
+                    )
+                }
+            )
+        }.value
+        #expect(switchedControlProof == nil)
+
+        // Recreate the linked-worktree control graph, then create a previously
+        // absent primary commondir immediately after graph resolution. The
+        // descriptor-relative ENOENT witness must reject that semantic edge.
+        try originalControl.write(to: worktreeControl, options: .atomic)
+        let primaryCommonControl = repository
+            .appendingPathComponent(".git", isDirectory: true)
+            .appendingPathComponent("commondir")
+        let createdCommonDirProof = await Task.detached(priority: .utility) {
+            RecentAgentTaskFilesystemValidator.repositoryProof(
+                for: identity,
+                afterGraphResolution: {
+                    try? Data(".\n".utf8).write(
+                        to: primaryCommonControl,
+                        options: .atomic
+                    )
+                }
+            )
+        }.value
+        #expect(createdCommonDirProof == nil)
+    }
+
+    @Test("Repository proof rejects an intermediate path retarget")
+    func repositoryProofRejectsIntermediateSymlinkRetarget() async throws {
+        let root = try makeQuickTerminalDirectory(name: "GraphIntermediate")
+        defer { removeQuickTerminalDirectory(root) }
+        let liveParent = root.appendingPathComponent("Live", isDirectory: true)
+        let replacementParent = root.appendingPathComponent(
+            "Replacement",
+            isDirectory: true
+        )
+        let repository = liveParent.appendingPathComponent(
+            "Repository",
+            isDirectory: true
+        )
+        let worktree = liveParent.appendingPathComponent(
+            "Worktree",
+            isDirectory: true
+        )
+        try makeQuickGitRepository(at: repository, seed: "intermediate-a")
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/intermediate", "--",
+            worktree.path,
+        ], at: repository)
+        try FileManager.default.createDirectory(
+            at: replacementParent,
+            withIntermediateDirectories: true
+        )
+        let identity = AgentTaskProjectIdentity(
+            canonicalProjectPath: repository.path,
+            canonicalWorktreePath: worktree.path
+        )
+        let displaced = root.appendingPathComponent(
+            "Displaced",
+            isDirectory: true
+        )
+        let proof = await Task.detached(priority: .utility) {
+            RecentAgentTaskFilesystemValidator.repositoryProof(
+                for: identity,
+                afterGraphResolution: {
+                    try? FileManager.default.moveItem(
+                        at: liveParent,
+                        to: displaced
+                    )
+                    try? FileManager.default.createSymbolicLink(
+                        at: liveParent,
+                        withDestinationURL: replacementParent
+                    )
+                }
+            )
+        }.value
+        #expect(proof == nil)
+    }
+
+    @Test("Same repository worktree replacement loses every old authority")
+    func sameRepositoryWorktreeReplacementFailsClosedEverywhere() async throws {
+        let root = try makeQuickTerminalDirectory(name: "SameRepoWorktree")
+        defer { removeQuickTerminalDirectory(root) }
+        let repository = root.appendingPathComponent(
+            "Repository",
+            isDirectory: true
+        )
+        let managedRoot = root.appendingPathComponent(
+            "Managed",
+            isDirectory: true
+        )
+        let worktree = managedRoot.appendingPathComponent(
+            "feature",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: managedRoot,
+            withIntermediateDirectories: true
+        )
+        try makeQuickGitRepository(at: repository, seed: "same-repo")
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/original", "--",
+            worktree.path,
+        ], at: repository)
+        let proof = try await quickRepositoryProof(
+            repository: repository,
+            worktree: worktree
+        )
+        let managed = AgentManagedWorktree(
+            taskID: UUID(),
+            repositoryRoot: repository,
+            managedRoot: managedRoot,
+            worktreeRoot: worktree,
+            branchName: "feature/original",
+            baseCommit: try runQuickGit(["rev-parse", "HEAD"], at: repository),
+            repositoryProof: proof
+        )
+        let defaultsDomain = "SameRepoWorktree-\(UUID().uuidString)"
+        let settingsDomain = "SameRepoWorktreeSettings-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsDomain))
+        let settingsDefaults = try #require(
+            UserDefaults(suiteName: settingsDomain)
+        )
+        defaults.removePersistentDomain(forName: defaultsDomain)
+        settingsDefaults.removePersistentDomain(forName: settingsDomain)
+        defer {
+            defaults.removePersistentDomain(forName: defaultsDomain)
+            settingsDefaults.removePersistentDomain(forName: settingsDomain)
+        }
+        let tasks = AgentTaskRegistry(persistence: QuickTerminalAgentTaskStore())
+        let registry = ProjectRegistry(defaults: defaults, agentTasks: tasks)
+        let retained = try #require(await registry.projectManager(for: managed))
+        let canonicalWorktree = registry.canonicalProjectURL(worktree)
+        registry.closeProjectWindow(worktree)
+        #expect(registry.openProjects[canonicalWorktree] === retained)
+        #expect(registry.backgroundProjects.contains(canonicalWorktree))
+
+        let recoveryTask = quickProjectRecoveryTask(
+            identity: AgentTaskProjectIdentity(
+                canonicalProjectPath: repository.path,
+                canonicalWorktreePath: worktree.path
+            )
+        )
+        tasks.setTasksForTesting([recoveryTask])
+        var opened = false
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 480),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.orderFront(nil)
+        defer {
+            retained.unbindDialogOwnerWindow(window)
+            window.orderOut(nil)
+        }
+        #expect(await registry.recoverAgentTaskFromInbox(
+            recoveryTask.id,
+            action: .startNewSession,
+            openProjectWindow: { _ in opened = true },
+            waitUntilPresented: { manager in
+                manager.bindDialogOwnerWindow(window)
+                _ = try? runQuickGit([
+                    "worktree", "remove", "--force", "--", worktree.path,
+                ], at: repository)
+                _ = try? runQuickGit([
+                    "worktree", "add", "-b", "feature/replacement", "--",
+                    worktree.path,
+                ], at: repository)
+                return true
+            },
+            activateApplication: { _ in }
+        ) == .projectUnavailable)
+        #expect(opened)
+        #expect(registry.openProjects[canonicalWorktree] === retained)
+        #expect(await registry.projectManager(for: managed) == nil)
+
+        let relaunched = ProjectRegistry(defaults: defaults)
+        let settings = QuickTerminalSettings(
+            defaults: settingsDefaults,
+            notificationCenter: NotificationCenter()
+        )
+        settings.enabled = true
+        settings.hideOnFocusLoss = false
+        let controller = QuickTerminalController(settings: settings)
+        defer { controller.shutdown() }
+        controller.registry = relaunched
+        relaunched.quickTerminalAgentRouter = controller
+        controller.show()
+        await controller.waitForAgentScopeResolutionForTesting()
+        #expect(controller.isAgentScopeReadyForTesting)
+        #expect(
+            controller.agentScopeSurfaceForTesting
+                == .quickTerminalStandalone
+        )
+    }
+
+    @Test("Async workspace load rejects a replaced worktree")
+    func workspaceLoadRevalidatesAdmittedInstance() async throws {
+        let root = try makeQuickTerminalDirectory(name: "WorkspaceGap")
+        defer { removeQuickTerminalDirectory(root) }
+        let repository = root.appendingPathComponent("Repository")
+        let managedRoot = root.appendingPathComponent("Managed")
+        let worktree = managedRoot.appendingPathComponent("feature")
+        try FileManager.default.createDirectory(
+            at: managedRoot,
+            withIntermediateDirectories: true
+        )
+        try makeQuickGitRepository(at: repository, seed: "workspace-gap")
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/workspace-gap", "--",
+            worktree.path,
+        ], at: repository)
+        let managed = AgentManagedWorktree(
+            taskID: UUID(),
+            repositoryRoot: repository,
+            managedRoot: managedRoot,
+            worktreeRoot: worktree,
+            branchName: "feature/workspace-gap",
+            baseCommit: try runQuickGit(["rev-parse", "HEAD"], at: repository),
+            repositoryProof: try await quickRepositoryProof(
+                repository: repository,
+                worktree: worktree
+            )
+        )
+        let gate = QuickAgentScopeResolutionGate()
+        let registry = ProjectRegistry(agentTaskWorkspaceValidationSeam: {
+            await gate.suspendUntilReleased()
+        })
+        let manager = try #require(await registry.projectManager(for: managed))
+        await gate.waitUntilEntered()
+        _ = try runQuickGit([
+            "worktree", "remove", "--force", "--", worktree.path,
+        ], at: repository)
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/workspace-replacement", "--",
+            worktree.path,
+        ], at: repository)
+        await gate.release()
+        await manager.workspace.waitForLoadingComplete()
+        #expect(manager.workspace.isSuspended)
+        #expect(!manager.workspace.hasActiveFileWatcherForTesting)
+        #expect(manager.workspace.rootNodes.isEmpty)
+    }
+
+    @Test("Lazy PTY start revalidates after its final suspension")
+    func lazyPTYStartRejectsReplacedWorktree() async throws {
+        let root = try makeQuickTerminalDirectory(name: "PTYGap")
+        defer { removeQuickTerminalDirectory(root) }
+        let repository = root.appendingPathComponent("Repository")
+        let managedRoot = root.appendingPathComponent("Managed")
+        let worktree = managedRoot.appendingPathComponent("feature")
+        try FileManager.default.createDirectory(
+            at: managedRoot,
+            withIntermediateDirectories: true
+        )
+        try makeQuickGitRepository(at: repository, seed: "pty-gap")
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/pty-gap", "--",
+            worktree.path,
+        ], at: repository)
+        let managed = AgentManagedWorktree(
+            taskID: UUID(),
+            repositoryRoot: repository,
+            managedRoot: managedRoot,
+            worktreeRoot: worktree,
+            branchName: "feature/pty-gap",
+            baseCommit: try runQuickGit(["rev-parse", "HEAD"], at: repository),
+            repositoryProof: try await quickRepositoryProof(
+                repository: repository,
+                worktree: worktree
+            )
+        )
+        let registry = ProjectRegistry()
+        let manager = try #require(await registry.projectManager(for: managed))
+        await manager.workspace.waitForLoadingComplete()
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: worktree
+        )
+        let tab = try #require(
+            manager.paneManager.terminalState(for: pane)?.activeTab
+        )
+        tab.terminalView.frame = NSRect(x: 0, y: 0, width: 640, height: 320)
+        let gate = QuickAgentScopeResolutionGate()
+        tab.validationCommitSeamForTesting = {
+            await gate.suspendUntilReleased()
+        }
+        tab.startIfNeeded()
+        await gate.waitUntilEntered()
+        _ = try runQuickGit([
+            "worktree", "remove", "--force", "--", worktree.path,
+        ], at: repository)
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/pty-replacement", "--",
+            worktree.path,
+        ], at: repository)
+        await gate.release()
+        for _ in 0..<200
+        where tab.isStartValidationPendingForTesting {
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        #expect(!tab.isStartValidationPendingForTesting)
+        #expect(!tab.isProcessRunning)
+    }
+
+    @Test("Retained background worktree refuses same-path replacement")
+    func retainedBackgroundManagerValidatesRepositoryInstance() async throws {
+        let root = try makeQuickTerminalDirectory(name: "RetainedReplacement")
+        defer { removeQuickTerminalDirectory(root) }
+        let repository = root.appendingPathComponent(
+            "Repository",
+            isDirectory: true
+        )
+        let managedRoot = root.appendingPathComponent(
+            "Managed",
+            isDirectory: true
+        )
+        let worktree = managedRoot.appendingPathComponent(
+            "feature",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: managedRoot,
+            withIntermediateDirectories: true
+        )
+        try makeQuickGitRepository(at: repository, seed: "retained-a")
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/retained-a", "--",
+            worktree.path,
+        ], at: repository)
+        let managed = AgentManagedWorktree(
+            taskID: UUID(),
+            repositoryRoot: repository,
+            managedRoot: managedRoot,
+            worktreeRoot: worktree,
+            branchName: "feature/retained-a",
+            baseCommit: try runQuickGit(["rev-parse", "HEAD"], at: repository),
+            repositoryProof: try await quickRepositoryProof(
+                repository: repository,
+                worktree: worktree
+            )
+        )
+        let taskRegistry = AgentTaskRegistry(
+            persistence: QuickTerminalAgentTaskStore()
+        )
+        let registry = ProjectRegistry(agentTasks: taskRegistry)
+        let retained = try #require(await registry.projectManager(for: managed))
+        registry.closeProjectWindow(worktree)
+        let canonicalWorktree = registry.canonicalProjectURL(worktree)
+        #expect(registry.openProjects[canonicalWorktree] === retained)
+        #expect(registry.backgroundProjects.contains(canonicalWorktree))
+
+        _ = try runQuickGit([
+            "worktree", "remove", "--force", "--", worktree.path,
+        ], at: repository)
+        try FileManager.default.removeItem(at: repository)
+        try makeQuickGitRepository(at: repository, seed: "retained-b")
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/retained-b", "--",
+            worktree.path,
+        ], at: repository)
+
+        let recoveryTask = quickProjectRecoveryTask(
+            identity: AgentTaskProjectIdentity(
+                canonicalProjectPath: repository.path,
+                canonicalWorktreePath: worktree.path
+            )
+        )
+        taskRegistry.setTasksForTesting([recoveryTask])
+        var openedReplacement = false
+        let result = await registry.recoverAgentTaskFromInbox(
+            recoveryTask.id,
+            action: .startNewSession,
+            openProjectWindow: { _ in openedReplacement = true },
+            waitUntilPresented: { _ in true },
+            activateApplication: { _ in }
+        )
+        #expect(result == .projectUnavailable)
+        #expect(!openedReplacement)
+        #expect(registry.openProjects[canonicalWorktree] === retained)
+        #expect(registry.backgroundProjects.contains(canonicalWorktree))
+    }
+
+    @Test("Managed admission revalidates after detached suspension")
+    func managedAdmissionRejectsReplacementBeforeCommit() async throws {
+        let root = try makeQuickTerminalDirectory(name: "ManagedCommitGap")
+        defer { removeQuickTerminalDirectory(root) }
+        let repository = root.appendingPathComponent(
+            "Repository",
+            isDirectory: true
+        )
+        let managedRoot = root.appendingPathComponent(
+            "Managed",
+            isDirectory: true
+        )
+        let worktree = managedRoot.appendingPathComponent(
+            "feature",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: managedRoot,
+            withIntermediateDirectories: true
+        )
+        try makeQuickGitRepository(at: repository, seed: "managed-gap")
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/managed-gap", "--",
+            worktree.path,
+        ], at: repository)
+        let managed = AgentManagedWorktree(
+            taskID: UUID(),
+            repositoryRoot: repository,
+            managedRoot: managedRoot,
+            worktreeRoot: worktree,
+            branchName: "feature/managed-gap",
+            baseCommit: try runQuickGit(["rev-parse", "HEAD"], at: repository),
+            repositoryProof: try await quickRepositoryProof(
+                repository: repository,
+                worktree: worktree
+            )
+        )
+        let commitGate = QuickAgentScopeResolutionGate()
+        let registry = ProjectRegistry(
+            agentTaskFilesystemValidationCommitSeam: {
+                await commitGate.suspendUntilReleased()
+            }
+        )
+        let admission = Task { @MainActor in
+            await registry.projectManager(for: managed)
+        }
+        await commitGate.waitUntilEntered()
+        let displaced = managedRoot.appendingPathComponent(
+            "displaced",
+            isDirectory: true
+        )
+        try FileManager.default.moveItem(at: worktree, to: displaced)
+        try FileManager.default.createDirectory(
+            at: worktree,
+            withIntermediateDirectories: false
+        )
+        await commitGate.release()
+        #expect(await admission.value == nil)
+        #expect(registry.openProjects.isEmpty)
+    }
+
+    @Test("Quick scope revalidates before registration and subscription")
+    func quickScopeRejectsReplacementBeforeCommit() async throws {
+        let root = try makeQuickTerminalDirectory(name: "QuickCommitGap")
+        defer { removeQuickTerminalDirectory(root) }
+        let repository = root.appendingPathComponent(
+            "Repository",
+            isDirectory: true
+        )
+        let managedRoot = root.appendingPathComponent(
+            "Managed",
+            isDirectory: true
+        )
+        let worktree = managedRoot.appendingPathComponent(
+            "feature",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: managedRoot,
+            withIntermediateDirectories: true
+        )
+        try makeQuickGitRepository(at: repository, seed: "quick-gap")
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/quick-gap", "--",
+            worktree.path,
+        ], at: repository)
+        let managed = AgentManagedWorktree(
+            taskID: UUID(),
+            repositoryRoot: repository,
+            managedRoot: managedRoot,
+            worktreeRoot: worktree,
+            branchName: "feature/quick-gap",
+            baseCommit: try runQuickGit(["rev-parse", "HEAD"], at: repository),
+            repositoryProof: try await quickRepositoryProof(
+                repository: repository,
+                worktree: worktree
+            )
+        )
+        let defaultsDomain = "QuickCommitGap-\(UUID().uuidString)"
+        let settingsDomain = "QuickCommitGapSettings-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsDomain))
+        let settingsDefaults = try #require(
+            UserDefaults(suiteName: settingsDomain)
+        )
+        defaults.removePersistentDomain(forName: defaultsDomain)
+        settingsDefaults.removePersistentDomain(forName: settingsDomain)
+        defer {
+            defaults.removePersistentDomain(forName: defaultsDomain)
+            settingsDefaults.removePersistentDomain(forName: settingsDomain)
+        }
+        let seedRegistry = ProjectRegistry(defaults: defaults)
+        _ = try #require(await seedRegistry.projectManager(for: managed))
+        seedRegistry.closeProjectWindow(worktree)
+        seedRegistry.runBackgroundReclamationPassForTesting()
+
+        let commitGate = QuickAgentScopeResolutionGate()
+        let registry = ProjectRegistry(
+            defaults: defaults,
+            agentTaskFilesystemValidationCommitSeam: {
+                await commitGate.suspendUntilReleased()
+            }
+        )
+        let settings = QuickTerminalSettings(
+            defaults: settingsDefaults,
+            notificationCenter: NotificationCenter()
+        )
+        settings.enabled = true
+        settings.hideOnFocusLoss = false
+        let controller = QuickTerminalController(settings: settings)
+        defer { controller.shutdown() }
+        controller.registry = registry
+        registry.quickTerminalAgentRouter = controller
+        controller.show()
+        await commitGate.waitUntilEntered()
+        let displaced = managedRoot.appendingPathComponent(
+            "displaced",
+            isDirectory: true
+        )
+        try FileManager.default.moveItem(at: worktree, to: displaced)
+        try FileManager.default.createDirectory(
+            at: worktree,
+            withIntermediateDirectories: false
+        )
+        await commitGate.release()
+        await controller.waitForAgentScopeResolutionForTesting()
+        #expect(!controller.isAgentScopeReadyForTesting)
+        #expect(!controller.isAgentDetectionSubscribedForTesting)
+        #expect(registry.agentSnapshotSubscriberCountForTesting == 0)
+        #expect(registry.openProjects.isEmpty)
+    }
+
+    @Test("Hide/show and foreground child churn retain one exact live run")
+    func hideShowAndChildChurnRetainExactRun() async throws {
+        let fixture = try QuickTerminalAgentFixture()
+        defer { fixture.cleanUp() }
+        let tab = try await fixture.start()
+        let agent = quickAgentProcess(
+            pid: 7_501,
+            parent: 7_500,
+            group: 7_501,
+            command: "codex",
+            startedAt: 7_501
+        )
+        let child = quickAgentProcess(
+            pid: 7_502,
+            parent: 7_501,
+            group: 7_502,
+            command: "swift test",
+            startedAt: 7_502
+        )
+        setQuickAgentIdentity(agent, on: tab)
+        setQuickForeground(agent, on: tab)
+        fixture.consume([agent], sequence: 1)
+        let original = try #require(tab.agentSession)
+        let taskID = try #require(
+            fixture.registry.agentTasks.taskID(forSessionID: original.id)
+        )
+
+        fixture.controller.hide()
+        #expect(!fixture.controller.isVisible)
+        setQuickForeground(child, on: tab)
+        fixture.consume([agent, child], sequence: 2)
+        #expect(tab.agentSession === original)
+        #expect(original.liveness == .live)
+
+        fixture.controller.show()
+        #expect(fixture.controller.isVisible)
+        #expect(fixture.controller.paneState.activeTab === tab)
+        setQuickForeground(agent, on: tab)
+        fixture.consume([agent], sequence: 3)
+
+        #expect(tab.agentSession === original)
+        #expect(
+            fixture.registry.agentTasks.task(for: taskID)?.runs.count == 1
+        )
+        #expect(
+            fixture.registry.agentTasks.task(for: taskID)?.runs.last?.liveness
+                == .live
+        )
+    }
+
+    @Test("Inbox routes only the exact Quick Terminal generation")
+    func inboxRoutesOnlyExactGeneration() async throws {
+        let fixture = try QuickTerminalAgentFixture()
+        defer { fixture.cleanUp() }
+        let tab = try await fixture.start()
+        let originalProcess = quickAgentProcess(
+            pid: 7_601,
+            parent: 7_600,
+            group: 7_601,
+            command: "claude",
+            startedAt: 7_601
+        )
+        setQuickAgentIdentity(originalProcess, on: tab)
+        setQuickForeground(originalProcess, on: tab)
+        fixture.consume([originalProcess], sequence: 1)
+        let originalSession = try #require(tab.agentSession)
+        let taskID = try #require(
+            fixture.registry.agentTasks.taskID(forSessionID: originalSession.id)
+        )
+        let task = try #require(fixture.registry.agentTasks.task(for: taskID))
+        let route = task.route
+        fixture.controller.hide()
+        var openedProject = false
+
+        let focused = await fixture.registry.navigateToAgentTaskFromInbox(
+            taskID,
+            openProjectWindow: { _ in openedProject = true },
+            waitUntilPresented: { _ in false },
+            activateApplication: { _ in }
+        )
+
+        #expect(focused == .focused(route))
+        #expect(!openedProject)
+        #expect(fixture.controller.isVisible)
+        #expect(
+            fixture.registry.agentTasks.task(for: taskID)?.isUnread == false
+        )
+
+        let replacement = quickAgentProcess(
+            pid: 7_601,
+            parent: 7_600,
+            group: 7_601,
+            command: "claude",
+            startedAt: 7_611
+        )
+        setQuickAgentIdentity(replacement, on: tab)
+        setQuickForeground(replacement, on: tab)
+        fixture.consume([replacement], sequence: 2)
+
+        #expect(tab.agentSession !== originalSession)
+        #expect(await fixture.registry.navigateToAgentTaskFromInbox(
+            taskID,
+            openProjectWindow: { _ in },
+            waitUntilPresented: { _ in true },
+            activateApplication: { _ in }
+        ) == .routeStale)
+    }
+
+    @Test("Quit cancel preserves detection and Quit confirmation freezes route")
+    func quitCancelAndConfirmFollowQuickTerminalLifecycle() async throws {
+        let project = try makeQuickTerminalDirectory(name: "Quit")
+        defer { removeQuickTerminalDirectory(project) }
+        let delegate = AppDelegate()
+        let registry = ProjectRegistry(
+            agentTasks: AgentTaskRegistry(
+                persistence: QuickTerminalAgentTaskStore()
+            ),
+            agentDetectionProcessRunner: { _, _, _, _ in
+                ProcessRunResult(
+                    stdout: "",
+                    stderr: "",
+                    exitCode: 0,
+                    timedOut: false
+                )
+            },
+            agentDetectionPollInterval: 3_600
+        )
+        _ = registry.projectManager(for: project)
+        delegate.registry = registry
+        let settings = delegate.quickTerminalCoordinator.settings
+        let originalEnabled = settings.enabled
+        settings.enabled = true
+        defer {
+            delegate.quickTerminalCoordinator.shutdown()
+            settings.enabled = originalEnabled
+        }
+        delegate.quickTerminalCoordinator.show()
+        await delegate.quickTerminalCoordinator
+            .waitForAgentScopeResolutionForTesting()
+        #expect(
+            delegate.quickTerminalCoordinator.isAgentScopeReadyForTesting
+        )
+        _ = await registry.agentTasks.flushPersistence()
+        let tab = try #require(
+            delegate.quickTerminalCoordinator.paneState.activeTab
+        )
+        let process = quickAgentProcess(
+            pid: 7_701,
+            parent: 7_700,
+            group: 7_701,
+            command: "pi",
+            startedAt: 7_701
+        )
+        setQuickAgentIdentity(process, on: tab)
+        setQuickForeground(process, on: tab)
+        delegate.quickTerminalCoordinator.agentSnapshotConsumer
+            .consumeAgentProcessSnapshot(
+                [process],
+                observation: quickObservation(sequence: 1)
+            )
+        let session = try #require(tab.agentSession)
+        let taskID = try #require(
+            registry.agentTasks.taskID(forSessionID: session.id)
+        )
+        delegate.quickTerminalCoordinator.hide()
+
+        let cancelled = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                template == .applicationQuitSummary
+                    ? .alertThirdButtonReturn
+                    : .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+        #expect(!cancelled)
+        delegate.quickTerminalCoordinator.agentSnapshotConsumer
+            .consumeAgentProcessSnapshot(
+                [process],
+                observation: quickObservation(sequence: 2)
+            )
+        #expect(tab.agentSession === session)
+        #expect(registry.agentTasks.task(for: taskID)?.lifecycle == .active)
+        #expect(
+            registry.agentTasks.task(for: taskID)?.route.availability
+                == .available
+        )
+
+        let confirmed = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                template == .applicationQuitSummary
+                    ? .alertSecondButtonReturn
+                    : .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+        #expect(confirmed)
+        #expect(registry.agentTasks.task(for: taskID)?.lifecycle == .paused)
+        #expect(
+            registry.agentTasks.task(for: taskID)?.route.availability
+                == .missing
+        )
+        #expect(
+            registry.agentTasks.task(for: taskID)?.runs.last?.liveness
+                == .stale
+        )
+    }
+}
+
+@MainActor
+private final class QuickTerminalAgentFixture {
+    let settingsDomain: String
+    let registryDomain: String
+    let settingsDefaults: UserDefaults
+    let registryDefaults: UserDefaults
+    let registry: ProjectRegistry
+    let controller: QuickTerminalController
+
+    init(
+        recentProjects: [URL] = [],
+        proveRecentProjectIdentity: Bool = true,
+        agentScopeResolver: (@MainActor (
+            ProjectRegistry,
+            URL,
+            AgentTaskTerminalSurface
+        ) async -> QuickTerminalAgentScopeRegistration?)? = nil,
+        processRunner: @escaping ProcessRunner = { _, _, _, _ in
+            ProcessRunResult(
+                stdout: "",
+                stderr: "",
+                exitCode: 0,
+                timedOut: false
+            )
+        }
+    ) throws {
+        settingsDomain = "QuickTerminalAgentSettings-\(UUID().uuidString)"
+        registryDomain = "QuickTerminalAgentRegistry-\(UUID().uuidString)"
+        settingsDefaults = try #require(UserDefaults(suiteName: settingsDomain))
+        registryDefaults = try #require(UserDefaults(suiteName: registryDomain))
+        settingsDefaults.removePersistentDomain(forName: settingsDomain)
+        registryDefaults.removePersistentDomain(forName: registryDomain)
+        let settings = QuickTerminalSettings(
+            defaults: settingsDefaults,
+            notificationCenter: NotificationCenter()
+        )
+        settings.enabled = true
+        settings.hideOnFocusLoss = false
+        registry = ProjectRegistry(
+            defaults: registryDefaults,
+            agentTasks: AgentTaskRegistry(
+                persistence: QuickTerminalAgentTaskStore()
+            ),
+            agentDetectionProcessRunner: processRunner,
+            agentDetectionPollInterval: 3_600
+        )
+        if proveRecentProjectIdentity {
+            for project in recentProjects.reversed() {
+                _ = registry.projectManager(for: project)
+            }
+        } else {
+            registry.recentProjects = recentProjects
+        }
+        if let agentScopeResolver {
+            controller = QuickTerminalController(
+                settings: settings,
+                agentScopeResolver: agentScopeResolver
+            )
+        } else {
+            controller = QuickTerminalController(settings: settings)
+        }
+        controller.registry = registry
+        registry.quickTerminalAgentRouter = controller
+    }
+
+    func start() async throws -> TerminalTab {
+        controller.show()
+        await controller.waitForAgentScopeResolutionForTesting()
+        #expect(controller.isAgentScopeReadyForTesting)
+        _ = await registry.agentTasks.flushPersistence()
+        return try #require(controller.paneState.activeTab)
+    }
+
+    func consume(_ processes: [DetectedProcess], sequence: UInt64) {
+        controller.agentSnapshotConsumer.consumeAgentProcessSnapshot(
+            processes,
+            observation: quickObservation(sequence: sequence)
+        )
+    }
+
+    func cleanUp() {
+        controller.shutdown()
+        settingsDefaults.removePersistentDomain(forName: settingsDomain)
+        registryDefaults.removePersistentDomain(forName: registryDomain)
+    }
+}
+
+private actor QuickTerminalAgentTaskStore: AgentTaskPersisting {
+    func load(
+        project: AgentTaskProjectIdentity
+    ) async -> AgentTaskMetadataLoadResult {
+        AgentTaskMetadataLoadResult(status: .missing, tasks: [])
+    }
+
+    func save(
+        tasks: [AgentTask],
+        project: AgentTaskProjectIdentity,
+        authorization: AgentTaskPublicationAuthorization?
+    ) async -> AgentTaskMetadataSaveResult {
+        .saved(taskCount: tasks.count)
+    }
+}
+
+@MainActor
+private struct QuickRecentManagedFixture {
+    let root: URL
+    let repository: URL
+    let managedRoot: URL
+    let worktree: URL
+    let managed: AgentManagedWorktree
+    let defaults: UserDefaults
+    let defaultsDomain: String
+
+    func cleanUp() {
+        defaults.removePersistentDomain(forName: defaultsDomain)
+        removeQuickTerminalDirectory(root)
+    }
+}
+
+@MainActor
+private func makeQuickRecentManagedFixture(
+    name: String
+) async throws -> QuickRecentManagedFixture {
+    let root = try makeQuickTerminalDirectory(name: name)
+    do {
+        let repository = root.appendingPathComponent(
+            "Repository",
+            isDirectory: true
+        )
+        let managedRoot = root.appendingPathComponent(
+            "Managed",
+            isDirectory: true
+        )
+        let worktree = managedRoot.appendingPathComponent(
+            "worktree",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: managedRoot,
+            withIntermediateDirectories: true
+        )
+        try makeQuickGitRepository(at: repository, seed: name)
+        _ = try runQuickGit([
+            "worktree", "add", "-b", "feature/\(name.lowercased())",
+            "--", worktree.path,
+        ], at: repository)
+        let defaultsDomain = "QuickRecent-\(name)-\(UUID().uuidString)"
+        let defaults = try #require(
+            UserDefaults(suiteName: defaultsDomain)
+        )
+        defaults.removePersistentDomain(forName: defaultsDomain)
+        let managed = AgentManagedWorktree(
+            taskID: UUID(),
+            repositoryRoot: repository,
+            managedRoot: managedRoot,
+            worktreeRoot: worktree,
+            branchName: "feature/\(name.lowercased())",
+            baseCommit: try runQuickGit(
+                ["rev-parse", "HEAD"],
+                at: repository
+            ),
+            repositoryProof: try await quickRepositoryProof(
+                repository: repository,
+                worktree: worktree
+            )
+        )
+        return QuickRecentManagedFixture(
+            root: root,
+            repository: repository,
+            managedRoot: managedRoot,
+            worktree: worktree,
+            managed: managed,
+            defaults: defaults,
+            defaultsDomain: defaultsDomain
+        )
+    } catch {
+        removeQuickTerminalDirectory(root)
+        throw error
+    }
+}
+
+private func quickRepositoryProof(
+    repository: URL,
+    worktree: URL
+) async throws -> RecentAgentTaskRepositoryProof {
+    let canonicalRepository = repository.resolvingSymlinksInPath()
+        .standardizedFileURL
+    let canonicalWorktree = worktree.resolvingSymlinksInPath()
+        .standardizedFileURL
+    let identity = AgentTaskProjectIdentity(
+        canonicalProjectPath: canonicalRepository.path,
+        canonicalWorktreePath: canonicalWorktree.path
+    )
+    return try #require(await Task.detached(priority: .utility) {
+        RecentAgentTaskFilesystemValidator.repositoryProof(for: identity)
+    }.value)
+}
+
+@MainActor
+private func setQuickAgentIdentity(
+    _ process: DetectedProcess,
+    on tab: TerminalTab
+) {
+    let identity = process.preciseStartedAt.flatMap {
+        TerminalProcessStartIdentity(processID: process.pid, startedAt: $0)
+    }
+    tab.agentProcessIdentityResolverForTesting = { processID in
+        processID == process.pid ? identity : nil
+    }
+}
+
+@MainActor
+private func setQuickForeground(
+    _ process: DetectedProcess,
+    on tab: TerminalTab
+) {
+    tab.foregroundProcessIDOverrideForTesting = process.processGroupID
+    tab.foregroundStartOverrideForTesting = process.preciseStartedAt.flatMap {
+        TerminalProcessStartIdentity(processID: process.pid, startedAt: $0)
+    }
+}
+
+nonisolated private func quickAgentProcess(
+    pid: Int32,
+    parent: Int32,
+    group: Int32,
+    command: String,
+    startedAt: TimeInterval
+) -> DetectedProcess {
+    DetectedProcess(
+        pid: pid,
+        parentProcessID: parent,
+        processGroupID: group,
+        command: command,
+        cpuTime: 0,
+        startIdentifier: "generation-\(startedAt)",
+        preciseStartedAt: Date(timeIntervalSince1970: startedAt)
+    )
+}
+
+nonisolated private func quickObservation(
+    sequence: UInt64
+) -> AgentObservationStamp {
+    AgentObservationStamp(
+        wallTime: Date(timeIntervalSince1970: TimeInterval(sequence)),
+        uptime: TimeInterval(sequence),
+        generation: 1,
+        sequence: sequence
+    )
+}
+
+@MainActor
+private func quickDetectedSession(
+    agentType: AgentType,
+    processID: Int32,
+    generation: UInt64
+) -> AgentSession {
+    let startedAt = Date(timeIntervalSince1970: TimeInterval(generation))
+    let session = AgentSession(agentType: agentType, startedAt: startedAt)
+    _ = session.bindProcessEvidence(AgentProcessEvidence(
+        processIdentifier: processID,
+        processGeneration: generation,
+        startIdentifier: "generation-\(generation)",
+        observedStartedAt: startedAt,
+        startIsAuthoritative: true
+    ))
+    return session
+}
+
+@MainActor
+private func quickRecoveryTask(
+    surface: AgentTaskTerminalSurface,
+    lifecycle: AgentTaskLifecycle,
+    privatePath: String
+) -> AgentTask {
+    let terminalID = UUID()
+    let timestamp = Date(timeIntervalSince1970: 8_000)
+    let context = AgentTaskBridgeContext(
+        project: AgentTaskProjectIdentity(
+            canonicalProjectPath: privatePath,
+            canonicalWorktreePath: privatePath
+        ),
+        route: AgentTaskRoute(
+            surface: surface,
+            paneID: UUID(),
+            tabID: terminalID,
+            terminalID: terminalID,
+            availability: .missing
+        ),
+        presentationContext: AgentTaskPresentationContext(
+            terminalStableLabel: Strings.quickTerminalText()
+        ),
+        origin: .pineLaunched,
+        observedAt: timestamp
+    )
+    var task = AgentTask(
+        descriptor: AgentDescriptor(
+            agentType: .codex,
+            launchExecutable: "codex"
+        ),
+        context: context,
+        title: "Private recovery",
+        objective: "Private recovery",
+        createdAt: timestamp
+    )
+    task.lifecycle = lifecycle
+    task.completedAt = lifecycle == .completed ? timestamp : nil
+    return task
+}
+
+@MainActor
+private func quickProjectRecoveryTask(
+    identity: AgentTaskProjectIdentity
+) -> AgentTask {
+    let terminalID = UUID()
+    let timestamp = Date(timeIntervalSince1970: 8_100)
+    let context = AgentTaskBridgeContext(
+        project: identity,
+        route: AgentTaskRoute(
+            surface: .projectWindow,
+            paneID: UUID(),
+            tabID: terminalID,
+            terminalID: terminalID,
+            availability: .missing
+        ),
+        presentationContext: AgentTaskPresentationContext(
+            terminalStableLabel: "Terminal"
+        ),
+        origin: .pineLaunched,
+        observedAt: timestamp
+    )
+    var task = AgentTask(
+        descriptor: AgentDescriptor(
+            agentType: .codex,
+            launchExecutable: "codex"
+        ),
+        context: context,
+        title: "Persisted recovery",
+        objective: "Persisted recovery",
+        createdAt: timestamp
+    )
+    task.lifecycle = .paused
+    return task
+}
+
+private func makeQuickTerminalDirectory(name: String) throws -> URL {
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+        "PineQuickTerminalAgent-\(name)-\(UUID().uuidString)",
+        isDirectory: true
+    )
+    try FileManager.default.createDirectory(
+        at: url,
+        withIntermediateDirectories: true
+    )
+    return url.resolvingSymlinksInPath().standardizedFileURL
+}
+
+private func makeQuickGitRepository(
+    at repository: URL,
+    seed: String
+) throws {
+    try FileManager.default.createDirectory(
+        at: repository,
+        withIntermediateDirectories: true
+    )
+    _ = try runQuickGit(["init", "--initial-branch=main"], at: repository)
+    _ = try runQuickGit(
+        ["config", "user.name", "Pine Quick Terminal Tests"],
+        at: repository
+    )
+    _ = try runQuickGit(
+        ["config", "user.email", "quick-terminal-tests@pine.invalid"],
+        at: repository
+    )
+    try Data(seed.utf8).write(
+        to: repository.appendingPathComponent("seed.txt"),
+        options: .atomic
+    )
+    _ = try runQuickGit(["add", "--", "seed.txt"], at: repository)
+    _ = try runQuickGit(
+        ["commit", "-m", "test fixture"],
+        at: repository
+    )
+}
+
+private func runQuickGit(
+    _ arguments: [String],
+    at directory: URL
+) throws -> String {
+    let result = GitCommand.run(arguments, at: directory, timeout: 5)
+    guard result.succeeded else {
+        throw QuickGitFixtureError.commandFailed(
+            arguments: arguments,
+            diagnostics: result.errorOutput
+        )
+    }
+    return result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+private enum QuickGitFixtureError: Error {
+    case commandFailed(arguments: [String], diagnostics: String)
+}
+
+private func removeQuickTerminalDirectory(_ url: URL) {
+    try? FileManager.default.removeItem(at: url)
+}

--- a/PineTests/QuickTerminalContentHostedTests.swift
+++ b/PineTests/QuickTerminalContentHostedTests.swift
@@ -1,0 +1,108 @@
+//
+//  QuickTerminalContentHostedTests.swift
+//  PineTests
+//
+//  Hosted accessibility and renderer wiring smoke for issue #1420.
+//
+
+import AppKit
+import Foundation
+import SwiftTerm
+import SwiftUI
+import Testing
+@testable import Pine
+
+@Suite("Quick Terminal hosted content (#1420)", .serialized)
+@MainActor
+struct QuickTerminalContentHostedTests {
+    @Test("Hosted content exposes agent identity and attaches terminal container")
+    func hostedAgentBadgeAndTerminalAttachment() throws {
+        let paneState = TerminalPaneState()
+        paneState.addTab(workingDirectory: nil)
+        let tab = try #require(paneState.activeTab)
+        defer { tab.stop() }
+        let session = AgentSession(
+            agentType: .codex,
+            startedAt: Date(timeIntervalSince1970: 9_000)
+        )
+        _ = session.bindProcessEvidence(AgentProcessEvidence(
+            processIdentifier: 9_001,
+            processGeneration: 1,
+            startIdentifier: "quick-hosted-generation",
+            observedStartedAt: Date(timeIntervalSince1970: 9_000),
+            startIsAuthoritative: true
+        ))
+        tab.agentSession = session
+
+        let hosted = NSHostingView(
+            rootView: QuickTerminalContentView(paneState: paneState)
+        )
+        hosted.frame = NSRect(x: 0, y: 0, width: 800, height: 320)
+        let window = NSWindow(
+            contentRect: hosted.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = hosted
+        defer {
+            window.orderOut(nil)
+            window.contentView = nil
+        }
+        hosted.layoutSubtreeIfNeeded()
+        drainMainRunLoop()
+        hosted.layoutSubtreeIfNeeded()
+
+        let container = try #require(findTerminalContainer(in: hosted))
+        #expect(container.terminalPaneState === paneState)
+        #expect(paneState.presentationOwner === container)
+        #expect(tab.presentationOwner === container)
+        #expect(tab.terminalView.superview === container)
+        #expect(container.window === window)
+        #expect(
+            tab.terminalView.accessibilityIdentifier()
+                == AccessibilityID.terminalSurface
+        )
+
+        #expect(
+            AccessibilityID.quickTerminalContent == "quickTerminalContent"
+        )
+        #expect(
+            AccessibilityID.quickTerminalAgentIdentity
+                == "quickTerminalAgentIdentity"
+        )
+        let identityLabel = QuickTerminalContentView
+            .agentIdentityAccessibilityLabel(for: tab)
+        #expect(identityLabel.contains(tab.name))
+        #expect(identityLabel.contains("Codex"))
+        #expect(identityLabel.contains(
+            AgentTabBadge.userFacingState(for: session).displayName
+        ))
+        #expect(hosted.fittingSize.height > 0)
+
+        let forcedCoreGraphics = ProcessInfo.processInfo.environment[
+            "PINE_DISABLE_METAL"
+        ] != nil
+        #expect(
+            PineTerminalView.isMetalExplicitlyDisabled == forcedCoreGraphics
+        )
+        if forcedCoreGraphics,
+           let terminalView = tab.terminalView as? PineTerminalView {
+            #expect(!terminalView.isUsingMetalRenderer)
+        }
+    }
+
+    private func findTerminalContainer(in view: NSView) -> TerminalContainerView? {
+        if let container = view as? TerminalContainerView { return container }
+        for subview in view.subviews {
+            if let match = findTerminalContainer(in: subview) { return match }
+        }
+        return nil
+    }
+
+    private func drainMainRunLoop() {
+        for _ in 0..<4 {
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1420\n\n## Summary\n\n- wires the keep-alive Quick Terminal into Pine's single application-owned agent snapshot poller;\n- adds surface-qualified Quick Terminal ownership, exact live routing, Inbox navigation, quit freeze/rollback, and standalone privacy-safe projections;\n- reuses the shared terminal identity label and agent badge in the hosted Quick Terminal content;\n- preserves managed project/worktree identity across reclaim, relaunch, and Open Recent;\n- validates exact repository/worktree filesystem instances with descriptor-held, generation-fenced leases through workspace loading, Inbox recovery, Quick registration, and lazy PTY start;\n- rejects same-path repository/worktree replacement, Git control graph swaps, symlink retargets, stale routes, and cross-surface UUID collisions.\n\n## Verification\n\n- focused Quick Terminal and Recent tests: 45/45 passed;\n- impacted PineTests: 264/264 passed;\n- production build succeeded;\n- SwiftLint strict: 0 violations;\n- git diff check clean;\n- hosted terminal wiring passed in default and forced CoreGraphics modes in the preceding security-v3 matrix.\n\nEnvironment: macOS 27.0 (26A5406e), Xcode 27.0 (27A5218g), macOS SDK 27.0 (26A5378i), deployment target 26.0.\n\nPineUITests were not run locally per user request. Runtime validation on macOS 26 and the physical Metal/CoreGraphics renderer matrix remain CI/manual gaps.\n\nThe implementation completed repeated security reviews covering filesystem identity, TOCTOU and symlink races, async admission, privacy, task routing, lifecycle cleanup, and the production Open Recent path.