### PR TITLE
test(ci): add scheduled sanitizer lanes

### DIFF
--- a/.github/SANITIZER_TESTING.md
+++ b/.github/SANITIZER_TESTING.md
@@ -1,0 +1,52 @@
+# Sanitizer testing
+
+Pine runs separate AddressSanitizer and ThreadSanitizer jobs from
+`.github/workflows/nightly-sanitizers.yml`. The workflow runs every day at
+05:00 UTC and can also be started manually from the Actions tab. It is
+scheduled-only so sanitizer adoption starts non-blocking, while findings still
+fail the individual job.
+
+Both jobs consume `.github/sanitizer-test-manifest.txt`. The manifest is kept
+small enough for a 60-minute job budget and represents Pine's highest-risk
+native and concurrency boundaries:
+
+- terminal, subprocess ownership, SwiftTerm, AppKit, and Metal;
+- agent detection, terminal ownership, and durable task persistence;
+- file watching and external-change delivery;
+- LSP process and stream lifecycle;
+- tab, pane, project, window, save, and termination races.
+
+`UserTaskRunnerTests` and `LSPProcessTransportTests` exercise real child
+processes. Their lifecycle assertions require termination and reaping before a
+test completes so one case cannot leave a process behind for the next case.
+The manifest runs serially and enables per-test timeouts as a second bound.
+
+The sanitizer command is deliberately run once. There is no
+`-retry-tests-on-failure`: an initial sanitizer finding must remain a failed
+run. Each job uploads its `.xcresult`, full `xcodebuild` console log, and any
+per-process sanitizer logs for 14 days. No suppressions are currently used.
+Any future suppression must be scoped to one report, link an owner issue, name
+an owner, and include a review date in this document and next to the option.
+
+## Promotion threshold
+
+Make the lanes required release gates only after both sanitizers achieve all
+of the following over 30 consecutive scheduled runs:
+
+- zero sanitizer findings;
+- at least 95% infrastructure completion, excluding confirmed runner outages;
+- no unbounded test or leaked-process incident.
+
+Reset the 30-run window after a sanitizer finding, a manifest expansion, or a
+new suppression. Review the threshold and manifest when promoting the jobs.
+
+## Local run
+
+Select the same Xcode used by CI, turn each non-comment manifest line into an
+`-only-testing:` argument, and run `xcodebuild test` with one of these options:
+
+- `-enableAddressSanitizer YES`
+- `-enableThreadSanitizer YES`
+
+Also pass `-parallel-testing-enabled NO`, `-test-timeouts-enabled YES`, and a
+fresh `-resultBundlePath`. Never add retry-on-failure to a sanitizer run.

--- a/.github/sanitizer-test-manifest.txt
+++ b/.github/sanitizer-test-manifest.txt
@@ -1,0 +1,24 @@
+# Terminal, PTY-adjacent subprocess ownership, SwiftTerm, AppKit, and Metal.
+PineTests/UserTaskRunnerTests
+PineTests/TerminalProcessConfirmationTests
+PineTests/TerminalMetalRendererTests
+
+# Agent detection, terminal ownership, and durable task persistence.
+PineTests/AgentDetectionCoordinatorTests
+PineTests/AgentProjectTerminalOwnershipTests
+PineTests/AgentTaskRegistryTests
+
+# File-system events and external-change races.
+PineTests/FileSystemWatcherTests
+PineTests/TabExternalChangeDetectorTests
+PineTests/ExternalChangeRefreshRegressionTests
+
+# Language-server process lifecycle and stream transport.
+PineTests/LSPProcessTransportTests
+
+# Tabs, panes, projects, windows, and termination-save coordination.
+PineTests/TabManagerTests
+PineTests/PaneManagerTests
+PineTests/ProjectRegistryTests
+PineTests/WindowLifecycleTests
+PineTests/TerminationSaveCoordinatorSecurityTests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Tests for xcodebuild CLI options
         run: bash scripts/tests/test-xcodebuild-cli-options.sh
 
+      - name: Tests for sanitizer workflow
+        run: bash scripts/tests/test-sanitizer-workflow.sh
+
       - name: Tests for DMG packaging scripts
         run: bash scripts/tests/test-dmg-packaging.sh
 

--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -1,0 +1,171 @@
+# NOTE: All third-party actions are pinned by full commit SHA for supply-chain safety.
+# To update an action: find the new version's commit SHA on GitHub (Tags -> verify commit),
+# replace the SHA, and keep the "# vX" comment in sync.
+name: Nightly Sanitizers
+
+on:
+  schedule:
+    # Run after nightly performance and fuzz jobs to reduce runner contention.
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-sanitizers
+  cancel-in-progress: false
+
+# These scheduled/manual jobs intentionally start outside blocking PR CI. A
+# sanitizer finding still fails its job. Promotion criteria live in
+# .github/SANITIZER_TESTING.md.
+jobs:
+  address-sanitizer:
+    name: AddressSanitizer
+    runs-on: macos-26
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Select Xcode
+        uses: ./.github/actions/select-xcode
+
+      - name: Ensure Metal Toolchain
+        run: bash scripts/ensure-metal-toolchain.sh
+
+      - name: Cache SPM Dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: DerivedData/SourcePackages
+          key: spm-${{ runner.os }}-${{ hashFiles('Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
+      - name: Run AddressSanitizer Manifest
+        shell: bash
+        env:
+          ASAN_OPTIONS: abort_on_error=1:halt_on_error=1:log_path=${{ github.workspace }}/SanitizerDiagnostics/asan
+        run: |
+          set -euo pipefail
+          mkdir -p SanitizerDiagnostics
+          test_selection=()
+          while IFS= read -r suite || [ -n "$suite" ]; do
+            if [[ "$suite" =~ ^[[:space:]]*($|#) ]]; then
+              continue
+            fi
+            test_selection+=("-only-testing:$suite")
+          done < .github/sanitizer-test-manifest.txt
+
+          result_bundle="AddressSanitizerResults.xcresult"
+          console_log="SanitizerDiagnostics/address-xcodebuild.log"
+          test_started_at="$(date +%s)"
+          set +e
+          xcodebuild test \
+            -project Pine.xcodeproj \
+            -scheme Pine \
+            -destination "platform=macOS" \
+            -derivedDataPath DerivedData \
+            "${test_selection[@]}" \
+            -enableAddressSanitizer YES \
+            -enableCodeCoverage NO \
+            -parallel-testing-enabled NO \
+            -test-timeouts-enabled YES \
+            -resultBundlePath "$result_bundle" \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            2>&1 | tee "$console_log"
+          test_exit=${PIPESTATUS[0]}
+          set -e
+
+          python3 .github/scripts/validate_test_results.py \
+            "$result_bundle" \
+            --xcodebuild-exit "$test_exit" \
+            --started-at "$test_started_at" \
+            --github-summary
+
+      - name: Upload AddressSanitizer Results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: AddressSanitizer-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            AddressSanitizerResults.xcresult
+            SanitizerDiagnostics
+          if-no-files-found: warn
+          retention-days: 14
+
+  thread-sanitizer:
+    name: ThreadSanitizer
+    runs-on: macos-26
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Select Xcode
+        uses: ./.github/actions/select-xcode
+
+      - name: Ensure Metal Toolchain
+        run: bash scripts/ensure-metal-toolchain.sh
+
+      - name: Cache SPM Dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: DerivedData/SourcePackages
+          key: spm-${{ runner.os }}-${{ hashFiles('Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
+      - name: Run ThreadSanitizer Manifest
+        shell: bash
+        env:
+          TSAN_OPTIONS: abort_on_error=1:halt_on_error=1:log_path=${{ github.workspace }}/SanitizerDiagnostics/tsan
+        run: |
+          set -euo pipefail
+          mkdir -p SanitizerDiagnostics
+          test_selection=()
+          while IFS= read -r suite || [ -n "$suite" ]; do
+            if [[ "$suite" =~ ^[[:space:]]*($|#) ]]; then
+              continue
+            fi
+            test_selection+=("-only-testing:$suite")
+          done < .github/sanitizer-test-manifest.txt
+
+          result_bundle="ThreadSanitizerResults.xcresult"
+          console_log="SanitizerDiagnostics/thread-xcodebuild.log"
+          test_started_at="$(date +%s)"
+          set +e
+          xcodebuild test \
+            -project Pine.xcodeproj \
+            -scheme Pine \
+            -destination "platform=macOS" \
+            -derivedDataPath DerivedData \
+            "${test_selection[@]}" \
+            -enableThreadSanitizer YES \
+            -enableCodeCoverage NO \
+            -parallel-testing-enabled NO \
+            -test-timeouts-enabled YES \
+            -resultBundlePath "$result_bundle" \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            2>&1 | tee "$console_log"
+          test_exit=${PIPESTATUS[0]}
+          set -e
+
+          python3 .github/scripts/validate_test_results.py \
+            "$result_bundle" \
+            --xcodebuild-exit "$test_exit" \
+            --started-at "$test_started_at" \
+            --github-summary
+
+      - name: Upload ThreadSanitizer Results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ThreadSanitizer-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ThreadSanitizerResults.xcresult
+            SanitizerDiagnostics
+          if-no-files-found: warn
+          retention-days: 14

--- a/scripts/tests/test-sanitizer-workflow.sh
+++ b/scripts/tests/test-sanitizer-workflow.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Guard the scheduled sanitizer manifest and its fail-closed workflow contract.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+WORKFLOW="$REPO_ROOT/.github/workflows/nightly-sanitizers.yml"
+MANIFEST="$REPO_ROOT/.github/sanitizer-test-manifest.txt"
+POLICY="$REPO_ROOT/.github/SANITIZER_TESTING.md"
+
+fail() {
+    echo "Error: $1" >&2
+    exit 1
+}
+
+require_count() {
+    local expected="$1"
+    local pattern="$2"
+    local file="$3"
+    local actual
+    actual="$(grep -cF -- "$pattern" "$file" || true)"
+    if [ "$actual" -ne "$expected" ]; then
+        fail "expected $expected occurrences of '$pattern' in ${file#$REPO_ROOT/}, found $actual"
+    fi
+}
+
+[ -f "$WORKFLOW" ] || fail "missing nightly sanitizer workflow"
+[ -f "$MANIFEST" ] || fail "missing sanitizer test manifest"
+[ -f "$POLICY" ] || fail "missing sanitizer policy"
+
+require_count 1 "  address-sanitizer:" "$WORKFLOW"
+require_count 1 "  thread-sanitizer:" "$WORKFLOW"
+require_count 1 "  schedule:" "$WORKFLOW"
+require_count 1 "  workflow_dispatch:" "$WORKFLOW"
+require_count 1 "-enableAddressSanitizer YES" "$WORKFLOW"
+require_count 1 "-enableThreadSanitizer YES" "$WORKFLOW"
+require_count 2 ".github/sanitizer-test-manifest.txt" "$WORKFLOW"
+require_count 2 ".github/scripts/validate_test_results.py" "$WORKFLOW"
+require_count 2 "-enableCodeCoverage NO" "$WORKFLOW"
+require_count 2 "-parallel-testing-enabled NO" "$WORKFLOW"
+require_count 2 "-test-timeouts-enabled YES" "$WORKFLOW"
+require_count 2 'test_exit=${PIPESTATUS[0]}' "$WORKFLOW"
+require_count 2 "        if: always()" "$WORKFLOW"
+require_count 2 "if-no-files-found: warn" "$WORKFLOW"
+require_count 2 "abort_on_error=1:halt_on_error=1:log_path=" "$WORKFLOW"
+
+if grep -q -- '-retry-tests-on-failure' "$WORKFLOW"; then
+    fail "sanitizer findings must never be retried"
+fi
+if grep -qE 'continue-on-error:[[:space:]]*true' "$WORKFLOW"; then
+    fail "sanitizer jobs must fail when their test command fails"
+fi
+
+suites="$(sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' "$MANIFEST")"
+suite_count="$(printf '%s\n' "$suites" | grep -c . || true)"
+if [ "$suite_count" -lt 10 ] || [ "$suite_count" -gt 20 ]; then
+    fail "manifest must contain 10-20 bounded representative suites (found $suite_count)"
+fi
+
+duplicates="$(printf '%s\n' "$suites" | sort | uniq -d)"
+[ -z "$duplicates" ] || fail "manifest contains duplicate suites: $duplicates"
+
+required_suites=(
+    PineTests/UserTaskRunnerTests
+    PineTests/TerminalMetalRendererTests
+    PineTests/AgentDetectionCoordinatorTests
+    PineTests/AgentTaskRegistryTests
+    PineTests/FileSystemWatcherTests
+    PineTests/LSPProcessTransportTests
+    PineTests/ProjectRegistryTests
+    PineTests/TerminationSaveCoordinatorSecurityTests
+)
+for required in "${required_suites[@]}"; do
+    if ! grep -qxF -- "$required" <<< "$suites"; then
+        fail "manifest is missing representative suite $required"
+    fi
+done
+
+while IFS= read -r suite; do
+    if ! grep -qE '^PineTests/[A-Za-z0-9_]+Tests$' <<< "$suite"; then
+        fail "invalid manifest entry: $suite"
+    fi
+    type_name="${suite#PineTests/}"
+    if ! rg -q "struct[[:space:]]+$type_name" "$REPO_ROOT/PineTests"; then
+        fail "manifest suite does not exist: $suite"
+    fi
+done <<< "$suites"
+
+grep -qF "30 consecutive scheduled runs" "$POLICY" \
+    || fail "policy must define the consecutive-run promotion threshold"
+grep -qF "95% infrastructure completion" "$POLICY" \
+    || fail "policy must define the infrastructure stability threshold"
+grep -qF "No suppressions are currently used" "$POLICY" \
+    || fail "policy must document the suppression baseline"
+
+echo "Sanitizer workflow and $suite_count-suite manifest satisfy the fail-closed contract."

--- a/scripts/tests/test-sanitizer-workflow.sh
+++ b/scripts/tests/test-sanitizer-workflow.sh
@@ -81,7 +81,8 @@ while IFS= read -r suite; do
         fail "invalid manifest entry: $suite"
     fi
     type_name="${suite#PineTests/}"
-    if ! rg -q "struct[[:space:]]+$type_name" "$REPO_ROOT/PineTests"; then
+    if ! grep -RqsE --include='*.swift' \
+        "struct[[:space:]]+$type_name" "$REPO_ROOT/PineTests"; then
         fail "manifest suite does not exist: $suite"
     fi
 done <<< "$suites"


### PR DESCRIPTION
## Summary
- add separate scheduled and manually dispatchable AddressSanitizer and ThreadSanitizer lanes on macOS 26
- cover 15 concurrency- and lifecycle-sensitive suites through a versioned 508-test manifest
- fail closed on test execution and sanitizer findings, retain diagnostic logs and result bundles, and document promotion criteria

## Validation
- AddressSanitizer: 508 tests across 15 suites passed locally with no findings
- ThreadSanitizer: 508 tests across 15 suites passed locally with no findings
- bash scripts/tests/test-sanitizer-workflow.sh
- workflow YAML parse and git diff check
- SwiftLint strict: 0 violations

Closes #1440