### PR TITLE
test(persistence): add versioned fixtures and fault injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,7 +537,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Shard 1 — Terminal (33 tests)
+          # Shard 1 — Terminal (34 tests)
           - shard-name: "Terminal"
             test-classes: >-
               -only-testing:PineUITests/TerminalTests

--- a/Pine/Agent/AgentTaskMetadataStore.swift
+++ b/Pine/Agent/AgentTaskMetadataStore.swift
@@ -108,6 +108,7 @@ nonisolated struct AgentTaskStoreHooks: Sendable {
 nonisolated struct AgentTaskStoreConfiguration: Sendable {
     let privateComponentCount: Int?
     let cleanup: AgentTaskCleanupConfiguration
+    let faultInjector: PersistenceFaultInjector
     #if DEBUG
     let hooks: AgentTaskStoreHooks
     #endif
@@ -116,19 +117,23 @@ nonisolated struct AgentTaskStoreConfiguration: Sendable {
     init(
         privateComponentCount: Int? = nil,
         cleanup: AgentTaskCleanupConfiguration = AgentTaskCleanupConfiguration(),
+        faultInjector: PersistenceFaultInjector = .processEnvironment,
         hooks: AgentTaskStoreHooks = AgentTaskStoreHooks()
     ) {
         self.privateComponentCount = privateComponentCount
         self.cleanup = cleanup
+        self.faultInjector = faultInjector
         self.hooks = hooks
     }
     #else
     init(
         privateComponentCount: Int? = nil,
-        cleanup: AgentTaskCleanupConfiguration = AgentTaskCleanupConfiguration()
+        cleanup: AgentTaskCleanupConfiguration = AgentTaskCleanupConfiguration(),
+        faultInjector: PersistenceFaultInjector = .processEnvironment
     ) {
         self.privateComponentCount = privateComponentCount
         self.cleanup = cleanup
+        self.faultInjector = faultInjector
     }
     #endif
 }
@@ -563,6 +568,10 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         } catch AgentTaskDirectoryError.lockContention {
             return .rejected(.lockContention)
         } catch AgentTaskDirectoryError.transient {
+            return .rejected(.transientIO)
+        } catch PersistenceFailureKind.noSpace {
+            return .rejected(.storageLimit)
+        } catch is PersistenceFailureKind {
             return .rejected(.transientIO)
         } catch {
             return .rejected(.transientIO)
@@ -1258,6 +1267,10 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         authorization: AgentTaskPublicationAuthorization?,
         verifyContext: @escaping () -> Bool
     ) throws {
+        try configuration.faultInjector.checkpoint(
+            store: .agentTask,
+            phase: .beforeWrite
+        )
         guard verifyContext() else { throw AgentTaskDirectoryError.unsafe }
         let initialFinalIdentity = try existingPrivateFileIdentity(
             fileName,
@@ -1316,10 +1329,22 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         }
         writerIdentity = opened
         try writeAll(data, descriptor: descriptor)
+        do {
+            try configuration.faultInjector.checkpoint(
+                store: .agentTask,
+                phase: .beforeSync
+            )
+        } catch {
+            throw AgentTaskDirectoryError.durabilityUnknown
+        }
         guard durableSync(descriptor, target: .metadataFile) else {
             throw AgentTaskDirectoryError.durabilityUnknown
         }
         reportPhase(.temporaryWritten)
+        try configuration.faultInjector.checkpoint(
+            store: .agentTask,
+            phase: .afterTemporaryWrite
+        )
         guard verifyContext(),
               fstat(descriptor, &opened) == 0,
               fstatat(
@@ -1405,6 +1430,10 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
                 fileName
             ) == 0
         }
+        try configuration.faultInjector.checkpoint(
+            store: .agentTask,
+            phase: .beforeAtomicReplace
+        )
         let decision = authorization?.publish(operation: publish)
             ?? (publish() ? .published : .failed)
         switch decision {
@@ -1416,6 +1445,14 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
             throw AgentTaskDirectoryError.superseded
         }
         published = true
+        do {
+            try configuration.faultInjector.checkpoint(
+                store: .agentTask,
+                phase: .afterAtomicReplace
+            )
+        } catch {
+            throw AgentTaskDirectoryError.durabilityUnknownAfterPublication
+        }
         guard verifyContext(),
               fstatat(
                   directoryDescriptor,

--- a/Pine/MigrationManager.swift
+++ b/Pine/MigrationManager.swift
@@ -41,10 +41,15 @@ struct MigrationManager {
     ]
 
     private let defaults: UserDefaults
+    private let faultInjector: PersistenceFaultInjector
     private var migrations: [(from: Int, to: Int, migrate: (UserDefaults) -> Void)] = []
 
-    init(defaults: UserDefaults = .standard) {
+    init(
+        defaults: UserDefaults = .standard,
+        faultInjector: PersistenceFaultInjector = .processEnvironment
+    ) {
         self.defaults = defaults
+        self.faultInjector = faultInjector
     }
 
     /// Registers a migration step from one version to the next.
@@ -58,7 +63,8 @@ struct MigrationManager {
     /// - Fresh install (no existing data, no version key): stamps latest version, skips migrations.
     /// - Existing install without version key: treats as version 0 and runs all migrations.
     /// - Existing install with version key: runs only migrations newer than the stored version.
-    func runMigrations() {
+    @discardableResult
+    func runMigrations() -> Bool {
         let hasVersionKey = defaults.object(forKey: Self.schemaVersionKey) != nil
         let storedVersion = defaults.integer(forKey: Self.schemaVersionKey)
         let registeredVersion = migrations.map(\.to).max() ?? Self.latestVersion
@@ -66,35 +72,81 @@ struct MigrationManager {
 
         if storedVersion == targetVersion {
             Logger.migration.info("Schema already at version \(targetVersion), no migrations needed")
-            return
+            return true
         }
 
         guard storedVersion < targetVersion else {
             Logger.migration.error(
                 "Refusing unknown future schema v\(storedVersion); supported through v\(targetVersion)"
             )
-            return
+            return false
         }
 
         if !hasVersionKey && !hasExistingData() {
             // Fresh install — no data to migrate, just stamp latest version
-            Logger.migration.info("Fresh install detected, setting schema version to \(targetVersion)")
-            defaults.set(targetVersion, forKey: Self.schemaVersionKey)
-            return
+            do {
+                try runPreReplacementCheckpoints()
+                Logger.migration.info(
+                    "Fresh install detected, setting schema version to \(targetVersion)"
+                )
+                defaults.set(targetVersion, forKey: Self.schemaVersionKey)
+                try faultInjector.checkpoint(
+                    store: .preferences,
+                    phase: .afterAtomicReplace
+                )
+                return true
+            } catch {
+                Logger.migration.error(
+                    "Failed to persist fresh-install schema v\(targetVersion): \(error)"
+                )
+                return false
+            }
         }
 
         // Run pending migrations
+        let original = defaults.dictionaryRepresentation()
         var currentVersion = storedVersion
         let sortedMigrations = migrations.sorted { $0.from < $1.from }
+        var didReplace = false
 
-        for migration in sortedMigrations where migration.from >= currentVersion {
-            Logger.migration.info("Running migration v\(migration.from) → v\(migration.to)")
-            migration.migrate(defaults)
-            currentVersion = migration.to
+        do {
+            try faultInjector.checkpoint(
+                store: .preferences,
+                phase: .beforeWrite
+            )
+            for migration in sortedMigrations where migration.from >= currentVersion {
+                Logger.migration.info("Running migration v\(migration.from) → v\(migration.to)")
+                migration.migrate(defaults)
+                currentVersion = migration.to
+            }
+            try faultInjector.checkpoint(
+                store: .preferences,
+                phase: .afterTemporaryWrite
+            )
+            try faultInjector.checkpoint(
+                store: .preferences,
+                phase: .beforeSync
+            )
+            try faultInjector.checkpoint(
+                store: .preferences,
+                phase: .beforeAtomicReplace
+            )
+
+            defaults.set(targetVersion, forKey: Self.schemaVersionKey)
+            didReplace = true
+            try faultInjector.checkpoint(
+                store: .preferences,
+                phase: .afterAtomicReplace
+            )
+            Logger.migration.info("Migration complete, schema now at version \(targetVersion)")
+            return true
+        } catch {
+            if !didReplace { restoreDefaults(original) }
+            Logger.migration.error(
+                "Migration to schema v\(targetVersion) failed safely: \(error)"
+            )
+            return false
         }
-
-        defaults.set(targetVersion, forKey: Self.schemaVersionKey)
-        Logger.migration.info("Migration complete, schema now at version \(targetVersion)")
     }
 
     // MARK: - Private
@@ -113,11 +165,38 @@ struct MigrationManager {
         return false
     }
 
+    private func runPreReplacementCheckpoints() throws {
+        for phase in [
+            PersistenceWritePhase.beforeWrite,
+            .afterTemporaryWrite,
+            .beforeSync,
+            .beforeAtomicReplace,
+        ] {
+            try faultInjector.checkpoint(store: .preferences, phase: phase)
+        }
+    }
+
+    private func restoreDefaults(_ snapshot: [String: Any]) {
+        for key in defaults.dictionaryRepresentation().keys
+            where snapshot[key] == nil {
+            defaults.removeObject(forKey: key)
+        }
+        for (key, value) in snapshot {
+            defaults.set(value, forKey: key)
+        }
+    }
+
     // MARK: - Default Migrations
 
     /// Creates a MigrationManager with all built-in migrations registered.
-    static func withDefaultMigrations(defaults: UserDefaults = .standard) -> MigrationManager {
-        var manager = MigrationManager(defaults: defaults)
+    static func withDefaultMigrations(
+        defaults: UserDefaults = .standard,
+        faultInjector: PersistenceFaultInjector = .processEnvironment
+    ) -> MigrationManager {
+        var manager = MigrationManager(
+            defaults: defaults,
+            faultInjector: faultInjector
+        )
 
         // Migration v0 → v1: Clean up stale recent projects that no longer exist on disk
         manager.registerMigration(from: 0, to: 1) { defs in

--- a/Pine/MigrationManager.swift
+++ b/Pine/MigrationManager.swift
@@ -61,16 +61,25 @@ struct MigrationManager {
     func runMigrations() {
         let hasVersionKey = defaults.object(forKey: Self.schemaVersionKey) != nil
         let storedVersion = defaults.integer(forKey: Self.schemaVersionKey)
+        let registeredVersion = migrations.map(\.to).max() ?? Self.latestVersion
+        let targetVersion = max(Self.latestVersion, registeredVersion)
 
-        if storedVersion == Self.latestVersion {
-            Logger.migration.info("Schema already at version \(Self.latestVersion), no migrations needed")
+        if storedVersion == targetVersion {
+            Logger.migration.info("Schema already at version \(targetVersion), no migrations needed")
+            return
+        }
+
+        guard storedVersion < targetVersion else {
+            Logger.migration.error(
+                "Refusing unknown future schema v\(storedVersion); supported through v\(targetVersion)"
+            )
             return
         }
 
         if !hasVersionKey && !hasExistingData() {
             // Fresh install — no data to migrate, just stamp latest version
-            Logger.migration.info("Fresh install detected, setting schema version to \(Self.latestVersion)")
-            defaults.set(Self.latestVersion, forKey: Self.schemaVersionKey)
+            Logger.migration.info("Fresh install detected, setting schema version to \(targetVersion)")
+            defaults.set(targetVersion, forKey: Self.schemaVersionKey)
             return
         }
 
@@ -84,8 +93,8 @@ struct MigrationManager {
             currentVersion = migration.to
         }
 
-        defaults.set(Self.latestVersion, forKey: Self.schemaVersionKey)
-        Logger.migration.info("Migration complete, schema now at version \(Self.latestVersion)")
+        defaults.set(targetVersion, forKey: Self.schemaVersionKey)
+        Logger.migration.info("Migration complete, schema now at version \(targetVersion)")
     }
 
     // MARK: - Private

--- a/Pine/PersistenceFaultInjection.swift
+++ b/Pine/PersistenceFaultInjection.swift
@@ -1,0 +1,144 @@
+//
+//  PersistenceFaultInjection.swift
+//  Pine
+//
+//  Deterministic persistence failures shared by unit and process tests.
+//
+
+import Foundation
+
+nonisolated enum PersistenceStoreKind: String, CaseIterable, Sendable {
+    case preferences
+    case session
+    case recovery
+    case agentTask = "agent-task"
+}
+
+nonisolated enum PersistenceWritePhase: String, CaseIterable, Sendable {
+    case beforeWrite = "before-write"
+    case afterTemporaryWrite = "after-temporary-write"
+    case beforeAtomicReplace = "before-atomic-replace"
+    case afterAtomicReplace = "after-atomic-replace"
+    case beforeSync = "before-sync"
+}
+
+nonisolated enum PersistenceFailureKind: String, CaseIterable, Error, Sendable {
+    case permissionDenied = "permission-denied"
+    case readOnly = "read-only"
+    case noSpace = "no-space"
+    case atomicRename = "atomic-rename"
+    case fsync
+    case concurrentWriter = "concurrent-writer"
+    case interrupted
+}
+
+nonisolated struct PersistenceFault: Equatable, Sendable {
+    let store: PersistenceStoreKind
+    let phase: PersistenceWritePhase
+    let failure: PersistenceFailureKind
+
+    init(
+        store: PersistenceStoreKind,
+        phase: PersistenceWritePhase,
+        failure: PersistenceFailureKind
+    ) {
+        self.store = store
+        self.phase = phase
+        self.failure = failure
+    }
+
+    init?(encoded: String) {
+        let fields = encoded.split(separator: ":", omittingEmptySubsequences: false)
+        guard fields.count == 3,
+              let store = PersistenceStoreKind(rawValue: String(fields[0])),
+              let phase = PersistenceWritePhase(rawValue: String(fields[1])),
+              let failure = PersistenceFailureKind(rawValue: String(fields[2])) else {
+            return nil
+        }
+        self.init(store: store, phase: phase, failure: failure)
+    }
+
+    var encoded: String {
+        "\(store.rawValue):\(phase.rawValue):\(failure.rawValue)"
+    }
+}
+
+nonisolated struct PersistenceFaultInjector: Sendable {
+    private let injection: @Sendable (
+        PersistenceStoreKind,
+        PersistenceWritePhase
+    ) throws -> Void
+
+    init(
+        injection: @escaping @Sendable (
+            PersistenceStoreKind,
+            PersistenceWritePhase
+        ) throws -> Void
+    ) {
+        self.injection = injection
+    }
+
+    func checkpoint(
+        store: PersistenceStoreKind,
+        phase: PersistenceWritePhase
+    ) throws {
+        try injection(store, phase)
+    }
+
+    static let none = PersistenceFaultInjector { _, _ in }
+
+    /// A repeatable deterministic fault shared by the launched app process.
+    /// Release builds deliberately ignore test-only process configuration.
+    static let processEnvironment: PersistenceFaultInjector = {
+        #if DEBUG
+        guard let encoded = ProcessInfo.processInfo.environment[
+            "PINE_PERSISTENCE_FAULT"
+        ],
+        let fault = PersistenceFault(encoded: encoded) else {
+            return .none
+        }
+        return PersistenceFaultInjector { store, phase in
+            guard store == fault.store,
+                  phase == fault.phase else { return }
+            throw fault.failure
+        }
+        #else
+        return .none
+        #endif
+    }()
+}
+
+/// Thread-safe, ordered, one-shot fault plan. Unrelated checkpoints cannot
+/// consume the next planned injection.
+nonisolated final class PersistenceFaultPlan: @unchecked Sendable {
+    private let lock = NSLock()
+    private var remaining: [PersistenceFault]
+
+    init(_ faults: [PersistenceFault]) {
+        remaining = faults
+    }
+
+    var injector: PersistenceFaultInjector {
+        PersistenceFaultInjector { [weak self] store, phase in
+            try self?.inject(store: store, phase: phase)
+        }
+    }
+
+    var remainingFaults: [PersistenceFault] {
+        lock.withLock { remaining }
+    }
+
+    private func inject(
+        store: PersistenceStoreKind,
+        phase: PersistenceWritePhase
+    ) throws {
+        let failure = lock.withLock { () -> PersistenceFailureKind? in
+            guard let first = remaining.first,
+                  first.store == store,
+                  first.phase == phase else { return nil }
+            remaining.removeFirst()
+            return first.failure
+        }
+        if let failure { throw failure }
+    }
+}

--- a/Pine/RecoveryEntry.swift
+++ b/Pine/RecoveryEntry.swift
@@ -7,6 +7,9 @@ import Foundation
 
 /// Represents a snapshot of unsaved editor content for crash recovery.
 struct RecoveryEntry: Codable, Sendable {
+    static let currentSchemaVersion = 1
+    /// Missing for snapshots written before persistence versioning.
+    let schemaVersion: Int?
     /// Path to the original file on disk (empty string for untitled tabs).
     let originalPath: String
     /// Display name retained for an untitled buffer. Optional keeps snapshots
@@ -23,13 +26,20 @@ struct RecoveryEntry: Codable, Sendable {
         String.Encoding(rawValue: encodingRawValue)
     }
 
+    var hasSupportedSchema: Bool {
+        guard let schemaVersion else { return true }
+        return (0...Self.currentSchemaVersion).contains(schemaVersion)
+    }
+
     init(
+        schemaVersion: Int? = Self.currentSchemaVersion,
         originalPath: String,
         untitledName: String? = nil,
         content: String,
         timestamp: Date = Date(),
         encoding: String.Encoding = .utf8
     ) {
+        self.schemaVersion = schemaVersion
         self.originalPath = originalPath
         self.untitledName = untitledName
         self.content = content

--- a/Pine/RecoveryManager.swift
+++ b/Pine/RecoveryManager.swift
@@ -37,6 +37,7 @@ final class RecoveryManager {
     nonisolated static let debounceDelay: TimeInterval = 5
 
     private let recoveryDirectory: URL
+    private let faultInjector: PersistenceFaultInjector
     private var periodicTimer: Timer?
     private var snapshotDebouncer: Debouncer?
     /// Old crash IDs whose recovered buffers now live under a runtime tab ID.
@@ -49,8 +50,12 @@ final class RecoveryManager {
     /// Tabs provider — set by ProjectManager so periodic snapshots can access current tabs.
     var tabsProvider: (() -> [EditorTab])?
 
-    init(recoveryDirectory: URL) {
+    init(
+        recoveryDirectory: URL,
+        faultInjector: PersistenceFaultInjector = .processEnvironment
+    ) {
         self.recoveryDirectory = recoveryDirectory
+        self.faultInjector = faultInjector
     }
 
     /// Convenience initializer for a specific project.
@@ -449,11 +454,39 @@ final class RecoveryManager {
         )
 
         do {
+            try faultInjector.checkpoint(
+                store: .recovery,
+                phase: .beforeWrite
+            )
             let data = try encoder.encode(entry)
+            try faultInjector.checkpoint(
+                store: .recovery,
+                phase: .afterTemporaryWrite
+            )
+            try faultInjector.checkpoint(
+                store: .recovery,
+                phase: .beforeSync
+            )
+            try faultInjector.checkpoint(
+                store: .recovery,
+                phase: .beforeAtomicReplace
+            )
             try data.write(
                 to: recoveryFileURL(for: tab.id),
                 options: .atomic
             )
+            do {
+                try faultInjector.checkpoint(
+                    store: .recovery,
+                    phase: .afterAtomicReplace
+                )
+            } catch {
+                let tabName = tab.fileName
+                Self.logger.error(
+                    "Recovery snapshot replaced but durability is unknown for tab \(tabName): \(error)"
+                )
+                return false
+            }
         } catch {
             Self.logger.error(
                 "Failed to write recovery file for tab \(tab.fileName): \(error)"

--- a/Pine/RecoveryManager.swift
+++ b/Pine/RecoveryManager.swift
@@ -138,6 +138,12 @@ final class RecoveryManager {
             do {
                 let data = try Data(contentsOf: file)
                 let entry = try decoder.decode(RecoveryEntry.self, from: data)
+                guard entry.hasSupportedSchema else {
+                    Self.logger.error(
+                        "Refusing unsupported recovery schema in \(name)"
+                    )
+                    continue
+                }
                 results.append((uuid, entry))
             } catch {
                 Self.logger.error("Failed to read recovery entry \(name): \(error)")
@@ -354,6 +360,12 @@ final class RecoveryManager {
             do {
                 let data = try Data(contentsOf: file)
                 let entry = try decoder.decode(RecoveryEntry.self, from: data)
+                guard entry.hasSupportedSchema else {
+                    Self.logger.error(
+                        "Refusing unsupported recovery schema during cleanup"
+                    )
+                    continue
+                }
                 if entry.timestamp < cutoff {
                     do {
                         try FileManager.default.removeItem(at: file)

--- a/Pine/SessionState.swift
+++ b/Pine/SessionState.swift
@@ -170,6 +170,7 @@ struct SessionState: Codable, Sendable {
 
     // MARK: - Save
 
+    @discardableResult
     static func save(
         projectURL: URL,
         openFileURLs: [URL],
@@ -187,8 +188,9 @@ struct SessionState: Codable, Sendable {
         panePinnedPaths: [String: [String]]? = nil,
         paneTransientPreviewPaths: [String: String]? = nil,
         globalTabSwitchOrder: [SessionTabReference]? = nil,
-        defaults: UserDefaults = .standard
-    ) {
+        defaults: UserDefaults = .standard,
+        faultInjector: PersistenceFaultInjector = .processEnvironment
+    ) -> Bool {
         let state = SessionState(
             projectPath: projectURL.path,
             openFilePaths: openFileURLs.map(\.path),
@@ -208,10 +210,45 @@ struct SessionState: Codable, Sendable {
             terminalPaneActiveIndices: terminalPaneActiveIndices
         )
         do {
-            let data = try JSONEncoder().encode(state)
+            try faultInjector.checkpoint(
+                store: .session,
+                phase: .beforeWrite
+            )
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            let data = try encoder.encode(state)
+            try faultInjector.checkpoint(
+                store: .session,
+                phase: .afterTemporaryWrite
+            )
+            try faultInjector.checkpoint(
+                store: .session,
+                phase: .beforeSync
+            )
+            try faultInjector.checkpoint(
+                store: .session,
+                phase: .beforeAtomicReplace
+            )
             defaults.set(data, forKey: key(for: projectURL))
+            do {
+                try faultInjector.checkpoint(
+                    store: .session,
+                    phase: .afterAtomicReplace
+                )
+            } catch {
+                let projectName = projectURL.lastPathComponent
+                logger.error(
+                    "Session state replaced but durability is unknown for \(projectName): \(error)"
+                )
+                return false
+            }
+            return true
         } catch {
-            logger.error("Failed to encode session state for \(projectURL.lastPathComponent): \(error)")
+            let projectName = projectURL.lastPathComponent
+            logger.error(
+                "Failed to persist session state for \(projectName): \(error)"
+            )
+            return false
         }
     }
 

--- a/Pine/SessionState.swift
+++ b/Pine/SessionState.swift
@@ -43,6 +43,8 @@ struct SessionTabReference: Codable, Equatable, Sendable {
 /// a project from Welcome or Open Recent restores its last workspace state.
 struct SessionState: Codable, Sendable {
     private static let logger = Logger.app
+    static let currentSchemaVersion = 1
+    var schemaVersion: Int?
     var projectPath: String
     var openFilePaths: [String]
     var activeFilePath: String?
@@ -87,6 +89,57 @@ struct SessionState: Codable, Sendable {
     var terminalPaneTabCounts: [String: Int]?
     /// Per-terminal-pane active tab indices. Key is pane UUID string.
     var terminalPaneActiveIndices: [String: Int]?
+
+    var hasSupportedSchema: Bool {
+        guard let schemaVersion else { return true }
+        return (0...Self.currentSchemaVersion).contains(schemaVersion)
+    }
+
+    init(
+        schemaVersion: Int? = Self.currentSchemaVersion,
+        projectPath: String,
+        openFilePaths: [String],
+        activeFilePath: String? = nil,
+        previewModes: [String: String]? = nil,
+        highlightingDisabledPaths: [String]? = nil,
+        editorStates: [String: PerTabEditorState]? = nil,
+        pinnedPaths: [String]? = nil,
+        paneLayoutData: Data? = nil,
+        paneTabAssignments: [String: [String]]? = nil,
+        activePaneID: String? = nil,
+        paneActiveEditorPaths: [String: String]? = nil,
+        panePinnedPaths: [String: [String]]? = nil,
+        paneTransientPreviewPaths: [String: String]? = nil,
+        globalTabSwitchOrder: [SessionTabReference]? = nil,
+        terminalTabCount: Int? = nil,
+        activeTerminalIndex: Int? = nil,
+        isTerminalVisible: Bool? = nil,
+        isTerminalMaximized: Bool? = nil,
+        terminalPaneTabCounts: [String: Int]? = nil,
+        terminalPaneActiveIndices: [String: Int]? = nil
+    ) {
+        self.schemaVersion = schemaVersion
+        self.projectPath = projectPath
+        self.openFilePaths = openFilePaths
+        self.activeFilePath = activeFilePath
+        self.previewModes = previewModes
+        self.highlightingDisabledPaths = highlightingDisabledPaths
+        self.editorStates = editorStates
+        self.pinnedPaths = pinnedPaths
+        self.paneLayoutData = paneLayoutData
+        self.paneTabAssignments = paneTabAssignments
+        self.activePaneID = activePaneID
+        self.paneActiveEditorPaths = paneActiveEditorPaths
+        self.panePinnedPaths = panePinnedPaths
+        self.paneTransientPreviewPaths = paneTransientPreviewPaths
+        self.globalTabSwitchOrder = globalTabSwitchOrder
+        self.terminalTabCount = terminalTabCount
+        self.activeTerminalIndex = activeTerminalIndex
+        self.isTerminalVisible = isTerminalVisible
+        self.isTerminalMaximized = isTerminalMaximized
+        self.terminalPaneTabCounts = terminalPaneTabCounts
+        self.terminalPaneActiveIndices = terminalPaneActiveIndices
+    }
 
     // MARK: - UserDefaults keys
 
@@ -177,6 +230,12 @@ struct SessionState: Codable, Sendable {
             // Try legacy key as fallback for migration
             return loadLegacy(for: projectURL, defaults: defaults)
         }
+        guard state.hasSupportedSchema else {
+            logger.error(
+                "Refusing unsupported session schema for \(projectURL.lastPathComponent)"
+            )
+            return nil
+        }
         guard directoryExists(at: state.projectPath) else { return nil }
         return state
     }
@@ -191,6 +250,10 @@ struct SessionState: Codable, Sendable {
             state = try JSONDecoder().decode(SessionState.self, from: data)
         } catch {
             logger.error("Failed to decode legacy session state: \(error)")
+            return nil
+        }
+        guard state.hasSupportedSchema else {
+            logger.error("Refusing unsupported legacy session schema")
             return nil
         }
         let canonical = projectURL.resolvingSymlinksInPath().path

--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -152,8 +152,14 @@ final class SidebarEditState {
 @MainActor
 @Observable
 final class SidebarKeyboardFocusController {
+    /// A disclosure change can rebuild the SwiftUI host after an AppKit focus
+    /// claim has already succeeded. Keep the retry window bounded, but cover
+    /// both the next run loop and the later reconciliation pass.
+    private static let focusRetryDelays: [TimeInterval] = [0, 0.1]
+
     private weak var responderView: SidebarKeyboardResponderView?
     private(set) var isFocused = false
+    private var focusRequestGeneration = 0
 
     func attach(_ responderView: SidebarKeyboardResponderView) {
         self.responderView = responderView
@@ -165,24 +171,39 @@ final class SidebarKeyboardFocusController {
 
     @discardableResult
     func requestFocus(retryOnNextRunLoop: Bool = false) -> Bool {
-        let focused: Bool
-        if let responderView, let window = responderView.window {
-            focused = window.makeFirstResponder(responderView)
-                && window.firstResponder === responderView
-        } else {
-            focused = false
-        }
+        focusRequestGeneration &+= 1
+        let generation = focusRequestGeneration
+        let focused = attemptFocus()
         if retryOnNextRunLoop {
             // A pointer action can arrive while SwiftUI is still attaching the
             // representable, or an editor preview can displace a successful
-            // claim later in the same layout transaction. Retry once after
-            // that transaction settles; never form an unbounded focus loop.
-            DispatchQueue.main.async { [weak self] in
-                guard let self, !self.isFocused else { return }
-                _ = self.requestFocus()
+            // claim during a later disclosure reconciliation pass. Retry at
+            // two bounded points; an explicit editor-focus action invalidates
+            // this generation before either retry can steal focus back.
+            for delay in Self.focusRetryDelays {
+                DispatchQueue.main.asyncAfter(
+                    deadline: .now() + delay
+                ) { [weak self] in
+                    guard let self,
+                          self.focusRequestGeneration == generation,
+                          !self.isFocused else { return }
+                    _ = self.attemptFocus()
+                }
             }
         }
         return focused
+    }
+
+    func cancelPendingFocusRetry() {
+        focusRequestGeneration &+= 1
+    }
+
+    private func attemptFocus() -> Bool {
+        guard let responderView, let window = responderView.window else {
+            return false
+        }
+        return window.makeFirstResponder(responderView)
+            && window.firstResponder === responderView
     }
 
     private func updateFocus(_ focused: Bool) {
@@ -639,7 +660,13 @@ struct SidebarView: View {
                                 nodes: workspace.rootNodes,
                                 treeRevision: workspace.rootNodesRevision,
                                 selection: $selectedFile,
-                                onFileOpen: onFileOpen,
+                                onFileOpen: { node, disposition in
+                                    if disposition.requestsEditorFocus {
+                                        keyboardFocusController
+                                            .cancelPendingFocusRetry()
+                                    }
+                                    onFileOpen(node, disposition)
+                                },
                                 isKeyboardFocused: keyboardFocusController.isFocused
                                     && controlActiveState == .key,
                                 onKeyboardFocusRequested: {

--- a/PineTests/Fixtures/Persistence/agent-task-future.json
+++ b/PineTests/Fixtures/Persistence/agent-task-future.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 999,
+  "revision": "00000000-0000-0000-0000-000000000999",
+  "canonicalProjectPath": "{{PROJECT_PATH}}",
+  "canonicalWorktreePath": "{{PROJECT_PATH}}",
+  "tasks": [],
+  "futureOnlyState": "preserve-verbatim"
+}

--- a/PineTests/Fixtures/Persistence/agent-task-v0.json
+++ b/PineTests/Fixtures/Persistence/agent-task-v0.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 0,
+  "canonicalProjectPath": "{{PROJECT_PATH}}",
+  "canonicalWorktreePath": "{{PROJECT_PATH}}",
+  "tasks": []
+}

--- a/PineTests/Fixtures/Persistence/agent-task-v1.json
+++ b/PineTests/Fixtures/Persistence/agent-task-v1.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "canonicalProjectPath": "{{PROJECT_PATH}}",
+  "canonicalWorktreePath": "{{PROJECT_PATH}}",
+  "tasks": []
+}

--- a/PineTests/Fixtures/Persistence/agent-task-v2.json
+++ b/PineTests/Fixtures/Persistence/agent-task-v2.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 2,
+  "revision": "00000000-0000-0000-0000-000000000002",
+  "canonicalProjectPath": "{{PROJECT_PATH}}",
+  "canonicalWorktreePath": "{{PROJECT_PATH}}",
+  "tasks": []
+}

--- a/PineTests/Fixtures/Persistence/manifest.json
+++ b/PineTests/Fixtures/Persistence/manifest.json
@@ -1,0 +1,18 @@
+{
+  "formatVersion": 1,
+  "fixtures": [
+    {"store":"preferences","file":"preferences-v0.json","schema":"N-1","outcome":"migrate"},
+    {"store":"preferences","file":"preferences-v1.json","schema":"current","outcome":"load"},
+    {"store":"preferences","file":"preferences-future.json","schema":"future","outcome":"reject"},
+    {"store":"session","file":"session-v0.json","schema":"N-1","outcome":"load"},
+    {"store":"session","file":"session-v1.json","schema":"current","outcome":"load"},
+    {"store":"session","file":"session-future.json","schema":"future","outcome":"reject"},
+    {"store":"recovery","file":"recovery-v0.json","schema":"N-1","outcome":"load"},
+    {"store":"recovery","file":"recovery-v1.json","schema":"current","outcome":"load"},
+    {"store":"recovery","file":"recovery-future.json","schema":"future","outcome":"reject"},
+    {"store":"agent-task","file":"agent-task-v0.json","schema":"N-2","outcome":"reject"},
+    {"store":"agent-task","file":"agent-task-v1.json","schema":"N-1","outcome":"migrate"},
+    {"store":"agent-task","file":"agent-task-v2.json","schema":"current","outcome":"load"},
+    {"store":"agent-task","file":"agent-task-future.json","schema":"future","outcome":"reject"}
+  ]
+}

--- a/PineTests/Fixtures/Persistence/preferences-future.json
+++ b/PineTests/Fixtures/Persistence/preferences-future.json
@@ -1,0 +1,5 @@
+{
+  "pineSchemaVersion": 999,
+  "futureOnlyPreference": "preserve-verbatim",
+  "recentProjectPaths": ["{{PROJECT_PATH}}"]
+}

--- a/PineTests/Fixtures/Persistence/preferences-v0.json
+++ b/PineTests/Fixtures/Persistence/preferences-v0.json
@@ -1,0 +1,3 @@
+{
+  "recentProjectPaths": ["{{PROJECT_PATH}}", "/sanitized/missing-project"]
+}

--- a/PineTests/Fixtures/Persistence/preferences-v1.json
+++ b/PineTests/Fixtures/Persistence/preferences-v1.json
@@ -1,0 +1,4 @@
+{
+  "pineSchemaVersion": 1,
+  "recentProjectPaths": ["{{PROJECT_PATH}}"]
+}

--- a/PineTests/Fixtures/Persistence/recovery-future.json
+++ b/PineTests/Fixtures/Persistence/recovery-future.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 999,
+  "originalPath": "{{PROJECT_PATH}}/Sources/App.swift",
+  "content": "future unsaved buffer\n",
+  "timestamp": "2026-01-03T00:00:00Z",
+  "encodingRawValue": 4,
+  "futureOnlyState": "preserve-verbatim"
+}

--- a/PineTests/Fixtures/Persistence/recovery-v0.json
+++ b/PineTests/Fixtures/Persistence/recovery-v0.json
@@ -1,0 +1,6 @@
+{
+  "originalPath": "{{PROJECT_PATH}}/Sources/App.swift",
+  "content": "legacy unsaved buffer\n",
+  "timestamp": "2026-01-01T00:00:00Z",
+  "encodingRawValue": 4
+}

--- a/PineTests/Fixtures/Persistence/recovery-v1.json
+++ b/PineTests/Fixtures/Persistence/recovery-v1.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "originalPath": "{{PROJECT_PATH}}/Sources/App.swift",
+  "content": "current unsaved buffer\n",
+  "timestamp": "2026-01-02T00:00:00Z",
+  "encodingRawValue": 4
+}

--- a/PineTests/Fixtures/Persistence/session-future.json
+++ b/PineTests/Fixtures/Persistence/session-future.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 999,
+  "projectPath": "{{PROJECT_PATH}}",
+  "openFilePaths": [],
+  "futureOnlyState": "preserve-verbatim"
+}

--- a/PineTests/Fixtures/Persistence/session-v0.json
+++ b/PineTests/Fixtures/Persistence/session-v0.json
@@ -1,0 +1,5 @@
+{
+  "projectPath": "{{PROJECT_PATH}}",
+  "openFilePaths": ["{{PROJECT_PATH}}/Sources/App.swift"],
+  "activeFilePath": "{{PROJECT_PATH}}/Sources/App.swift"
+}

--- a/PineTests/Fixtures/Persistence/session-v1.json
+++ b/PineTests/Fixtures/Persistence/session-v1.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "projectPath": "{{PROJECT_PATH}}",
+  "openFilePaths": ["{{PROJECT_PATH}}/Sources/App.swift"],
+  "activeFilePath": "{{PROJECT_PATH}}/Sources/App.swift",
+  "pinnedPaths": ["{{PROJECT_PATH}}/Sources/App.swift"]
+}

--- a/PineTests/MigrationManagerTests.swift
+++ b/PineTests/MigrationManagerTests.swift
@@ -87,7 +87,7 @@ struct MigrationManagerTests {
         manager.runMigrations()
 
         #expect(order == [1, 2, 3])
-        #expect(defaults.integer(forKey: MigrationManager.schemaVersionKey) == MigrationManager.latestVersion)
+        #expect(defaults.integer(forKey: MigrationManager.schemaVersionKey) == 3)
     }
 
     @Test func migration_skips_already_applied() {
@@ -105,6 +105,28 @@ struct MigrationManagerTests {
         manager.runMigrations()
 
         #expect(ranVersions == [3])
+    }
+
+    @Test func migration_unknownFutureSchemaFailsClosed() {
+        let (defaults, suiteName) = makeDefaults()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
+        let futureVersion = MigrationManager.latestVersion + 1
+        defaults.set(futureVersion, forKey: MigrationManager.schemaVersionKey)
+        defaults.set("future-data", forKey: "futureOnlyPreference")
+
+        var migrationRan = false
+        var manager = MigrationManager(defaults: defaults)
+        manager.registerMigration(from: 0, to: 1) { defs in
+            migrationRan = true
+            defs.removeObject(forKey: "futureOnlyPreference")
+        }
+
+        manager.runMigrations()
+
+        #expect(!migrationRan)
+        #expect(defaults.integer(forKey: MigrationManager.schemaVersionKey) == futureVersion)
+        #expect(defaults.string(forKey: "futureOnlyPreference") == "future-data")
     }
 
     // MARK: - Idempotency

--- a/PineTests/MultiProjectAgentLifecycleIntegrationTests.swift
+++ b/PineTests/MultiProjectAgentLifecycleIntegrationTests.swift
@@ -789,7 +789,13 @@ private final class MultiProjectAgentLifecycleFixture {
         phase: String
     ) async throws {
         let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(2))
+        // The controlled Python process has already published an exact child
+        // identity before this wait. A loaded macOS runner can still take
+        // more than two seconds to schedule it after the release-file rename;
+        // keep the wait bounded but align it with the fixture's own 5-second
+        // release deadline so a safe cleanup test does not become a scheduler
+        // lottery.
+        let deadline = clock.now.advanced(by: .seconds(5))
         while clock.now < deadline {
             try Task.checkCancellation()
             if FileManager.default.fileExists(atPath: url.path) { return }

--- a/PineTests/PersistenceFaultInjectionTests.swift
+++ b/PineTests/PersistenceFaultInjectionTests.swift
@@ -1,0 +1,458 @@
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Persistence fault injection", .serialized)
+@MainActor
+struct PersistenceFaultInjectionTests {
+    @Test("fault encoding is stable and plans consume only matching checkpoints")
+    func faultEncodingAndOrdering() throws {
+        for store in PersistenceStoreKind.allCases {
+            for phase in PersistenceWritePhase.allCases {
+                for failure in PersistenceFailureKind.allCases {
+                    let fault = PersistenceFault(
+                        store: store,
+                        phase: phase,
+                        failure: failure
+                    )
+                    #expect(PersistenceFault(encoded: fault.encoded) == fault)
+                }
+            }
+        }
+        #expect(PersistenceFault(encoded: "session:unknown:interrupted") == nil)
+
+        let first = PersistenceFault(
+            store: .session,
+            phase: .beforeWrite,
+            failure: .permissionDenied
+        )
+        let second = PersistenceFault(
+            store: .recovery,
+            phase: .beforeAtomicReplace,
+            failure: .atomicRename
+        )
+        let plan = PersistenceFaultPlan([first, second])
+        let injector = plan.injector
+
+        try injector.checkpoint(store: .recovery, phase: .beforeAtomicReplace)
+        #expect(plan.remainingFaults == [first, second])
+        #expect(throws: PersistenceFailureKind.permissionDenied) {
+            try injector.checkpoint(store: .session, phase: .beforeWrite)
+        }
+        #expect(throws: PersistenceFailureKind.atomicRename) {
+            try injector.checkpoint(
+                store: .recovery,
+                phase: .beforeAtomicReplace
+            )
+        }
+        #expect(plan.remainingFaults.isEmpty)
+    }
+
+    @Test("session failures before replacement preserve last-known-good data")
+    func sessionFailureMatrix() throws {
+        let project = try makeProject(named: "session")
+        defer { try? FileManager.default.removeItem(at: project) }
+        let oldFile = project.appendingPathComponent("old.swift")
+        let newFile = project.appendingPathComponent("new.swift")
+        try Data("old\n".utf8).write(to: oldFile)
+        try Data("new\n".utf8).write(to: newFile)
+        let (defaults, suite) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        #expect(SessionState.save(
+            projectURL: project,
+            openFileURLs: [oldFile],
+            defaults: defaults,
+            faultInjector: .none
+        ))
+        let (key, baseline) = try sessionRecord(in: defaults)
+
+        for scenario in preReplacementFailures() {
+            defaults.set(baseline, forKey: key)
+            let plan = PersistenceFaultPlan([
+                PersistenceFault(
+                    store: .session,
+                    phase: scenario.phase,
+                    failure: scenario.failure
+                ),
+            ])
+            #expect(!SessionState.save(
+                projectURL: project,
+                openFileURLs: [newFile],
+                defaults: defaults,
+                faultInjector: plan.injector
+            ))
+            #expect(defaults.data(forKey: key) == baseline)
+            #expect(plan.remainingFaults.isEmpty)
+        }
+
+        let postReplace = PersistenceFaultPlan([
+            PersistenceFault(
+                store: .session,
+                phase: .afterAtomicReplace,
+                failure: .interrupted
+            ),
+        ])
+        #expect(!SessionState.save(
+            projectURL: project,
+            openFileURLs: [newFile],
+            defaults: defaults,
+            faultInjector: postReplace.injector
+        ))
+        let restored = try #require(
+            SessionState.load(for: project, defaults: defaults)
+        )
+        #expect(restored.openFilePaths == [newFile.path])
+        #expect(postReplace.remainingFaults.isEmpty)
+    }
+
+    @Test("preference migration failures roll back the complete domain")
+    func preferenceFailureMatrix() throws {
+        let (defaults, suite) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(0, forKey: MigrationManager.schemaVersionKey)
+        defaults.set("known-good", forKey: "fixtureValue")
+        let baseline = defaults.dictionaryRepresentation()
+
+        for scenario in preReplacementFailures() {
+            restore(defaults: defaults, snapshot: baseline)
+            let plan = PersistenceFaultPlan([
+                PersistenceFault(
+                    store: .preferences,
+                    phase: scenario.phase,
+                    failure: scenario.failure
+                ),
+            ])
+            var manager = MigrationManager(
+                defaults: defaults,
+                faultInjector: plan.injector
+            )
+            manager.registerMigration(from: 0, to: 1) { migrationDefaults in
+                migrationDefaults.set("migrated", forKey: "fixtureValue")
+                migrationDefaults.set("new", forKey: "migrationSideEffect")
+            }
+            #expect(!manager.runMigrations())
+            #expect(
+                defaults.dictionaryRepresentation() as NSDictionary
+                    == baseline as NSDictionary
+            )
+            #expect(plan.remainingFaults.isEmpty)
+        }
+
+        restore(defaults: defaults, snapshot: baseline)
+        let postReplace = PersistenceFaultPlan([
+            PersistenceFault(
+                store: .preferences,
+                phase: .afterAtomicReplace,
+                failure: .interrupted
+            ),
+        ])
+        var manager = MigrationManager(
+            defaults: defaults,
+            faultInjector: postReplace.injector
+        )
+        manager.registerMigration(from: 0, to: 1) { migrationDefaults in
+            migrationDefaults.set("migrated", forKey: "fixtureValue")
+        }
+        #expect(!manager.runMigrations())
+        #expect(
+            defaults.integer(forKey: MigrationManager.schemaVersionKey)
+                == MigrationManager.latestVersion
+        )
+        #expect(defaults.string(forKey: "fixtureValue") == "migrated")
+        #expect(postReplace.remainingFaults.isEmpty)
+    }
+
+    @Test("recovery failures never expose torn JSON")
+    func recoveryFailureMatrix() throws {
+        let root = try makeProject(named: "recovery")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let recovery = root.appendingPathComponent("Recovery")
+        try FileManager.default.createDirectory(
+            at: recovery,
+            withIntermediateDirectories: true
+        )
+        var tab = EditorTab(
+            url: root.appendingPathComponent("document.swift"),
+            content: "known-good",
+            savedContent: "disk"
+        )
+        RecoveryManager(
+            recoveryDirectory: recovery,
+            faultInjector: .none
+        ).snapshotDirtyTabs([tab])
+        let snapshotURL = recovery.appendingPathComponent(
+            "\(tab.id.uuidString).json"
+        )
+        let baseline = try Data(contentsOf: snapshotURL)
+        tab.content = "replacement"
+
+        for scenario in preReplacementFailures() {
+            try baseline.write(to: snapshotURL, options: .atomic)
+            let plan = PersistenceFaultPlan([
+                PersistenceFault(
+                    store: .recovery,
+                    phase: scenario.phase,
+                    failure: scenario.failure
+                ),
+            ])
+            RecoveryManager(
+                recoveryDirectory: recovery,
+                faultInjector: plan.injector
+            ).snapshotDirtyTabs([tab])
+            #expect(try Data(contentsOf: snapshotURL) == baseline)
+            #expect(plan.remainingFaults.isEmpty)
+        }
+
+        let postReplace = PersistenceFaultPlan([
+            PersistenceFault(
+                store: .recovery,
+                phase: .afterAtomicReplace,
+                failure: .interrupted
+            ),
+        ])
+        let manager = RecoveryManager(
+            recoveryDirectory: recovery,
+            faultInjector: postReplace.injector
+        )
+        manager.snapshotDirtyTabs([tab])
+        #expect(manager.pendingRecoveryEntries().first?.1.content == "replacement")
+        #expect(postReplace.remainingFaults.isEmpty)
+    }
+
+    @Test("agent metadata failures preserve a loadable revision")
+    func agentTaskFailureMatrix() async throws {
+        let fixture = try makeAgentFixture(projectNames: ["project"])
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let identity = agentIdentity(fixture.projects[0])
+        let baselineStore = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(
+            await baselineStore.save(
+                tasks: [],
+                project: identity,
+                authorization: nil
+            ) == .saved(taskCount: 0)
+        )
+        let metadataURL = AgentTaskMetadataStore.metadataURL(
+            for: identity,
+            storageRoot: fixture.storage
+        )
+        let baseline = try Data(contentsOf: metadataURL)
+
+        for scenario in preReplacementFailures() {
+            try installPrivate(baseline, at: metadataURL)
+            let plan = PersistenceFaultPlan([
+                PersistenceFault(
+                    store: .agentTask,
+                    phase: scenario.phase,
+                    failure: scenario.failure
+                ),
+            ])
+            let store = AgentTaskMetadataStore(
+                storageRoot: fixture.storage,
+                configuration: AgentTaskStoreConfiguration(
+                    faultInjector: plan.injector
+                )
+            )
+            let result = await store.save(
+                tasks: [],
+                project: identity,
+                authorization: nil
+            )
+            #expect(!result.isDurablySaved)
+            #expect(try Data(contentsOf: metadataURL) == baseline)
+            #expect(plan.remainingFaults.isEmpty)
+        }
+
+        let postReplace = PersistenceFaultPlan([
+            PersistenceFault(
+                store: .agentTask,
+                phase: .afterAtomicReplace,
+                failure: .interrupted
+            ),
+        ])
+        let uncertainStore = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                faultInjector: postReplace.injector
+            )
+        )
+        let uncertain = await uncertainStore.save(
+            tasks: [],
+            project: identity,
+            authorization: nil
+        )
+        if case .publishedButDurabilityUnknown(let count, _) = uncertain {
+            #expect(count == 0)
+        } else {
+            Issue.record("Expected a complete publication with unknown durability")
+        }
+        #expect(await uncertainStore.load(project: identity).status == .loaded)
+        #expect(postReplace.remainingFaults.isEmpty)
+    }
+
+    @Test("concurrent project stores cannot cross-contaminate metadata")
+    func concurrentAgentProjectsRemainIsolated() async throws {
+        let fixture = try makeAgentFixture(projectNames: ["alpha", "beta"])
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let alpha = agentIdentity(fixture.projects[0])
+        let beta = agentIdentity(fixture.projects[1])
+        let firstStore = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        let secondStore = AgentTaskMetadataStore(storageRoot: fixture.storage)
+
+        async let first = firstStore.save(
+            tasks: [],
+            project: alpha,
+            authorization: nil
+        )
+        async let second = secondStore.save(
+            tasks: [],
+            project: beta,
+            authorization: nil
+        )
+        let (firstResult, secondResult) = await (first, second)
+        if firstResult != .saved(taskCount: 0) {
+            #expect([
+                .rejected(.lockContention),
+                .rejected(.transientIO),
+            ].contains(firstResult))
+            #expect(
+                await firstStore.save(
+                    tasks: [],
+                    project: alpha,
+                    authorization: nil
+                ) == .saved(taskCount: 0)
+            )
+        }
+        if secondResult != .saved(taskCount: 0) {
+            #expect([
+                .rejected(.lockContention),
+                .rejected(.transientIO),
+            ].contains(secondResult))
+            #expect(
+                await secondStore.save(
+                    tasks: [],
+                    project: beta,
+                    authorization: nil
+                ) == .saved(taskCount: 0)
+            )
+        }
+        #expect(await firstStore.load(project: alpha).status == .loaded)
+        #expect(await secondStore.load(project: beta).status == .loaded)
+        #expect(await firstStore.load(project: beta).status == .loaded)
+        #expect(await secondStore.load(project: alpha).status == .loaded)
+        #expect(
+            AgentTaskMetadataStore.metadataURL(
+                for: alpha,
+                storageRoot: fixture.storage
+            ) != AgentTaskMetadataStore.metadataURL(
+                for: beta,
+                storageRoot: fixture.storage
+            )
+        )
+    }
+
+    private func preReplacementFailures() -> [(
+        phase: PersistenceWritePhase,
+        failure: PersistenceFailureKind
+    )] {
+        [
+            (.beforeWrite, .permissionDenied),
+            (.beforeWrite, .readOnly),
+            (.beforeWrite, .noSpace),
+            (.afterTemporaryWrite, .interrupted),
+            (.beforeSync, .fsync),
+            (.beforeAtomicReplace, .atomicRename),
+            (.beforeAtomicReplace, .concurrentWriter),
+        ]
+    }
+
+    private func makeProject(named name: String) throws -> URL {
+        let project = FileManager.default.temporaryDirectory
+            .resolvingSymlinksInPath()
+            .appendingPathComponent("PinePersistence-\(name)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: project,
+            withIntermediateDirectories: true
+        )
+        return project
+    }
+
+    private func makeDefaults() throws -> (UserDefaults, String) {
+        let suite = "PinePersistenceFaults-\(UUID().uuidString)"
+        return (try #require(UserDefaults(suiteName: suite)), suite)
+    }
+
+    private func sessionRecord(
+        in defaults: UserDefaults
+    ) throws -> (String, Data) {
+        let key = try #require(
+            defaults.dictionaryRepresentation().keys.first {
+                $0.hasPrefix("sessionState:")
+            }
+        )
+        return (key, try #require(defaults.data(forKey: key)))
+    }
+
+    private func restore(
+        defaults: UserDefaults,
+        snapshot: [String: Any]
+    ) {
+        for key in defaults.dictionaryRepresentation().keys
+            where snapshot[key] == nil {
+            defaults.removeObject(forKey: key)
+        }
+        for (key, value) in snapshot {
+            defaults.set(value, forKey: key)
+        }
+    }
+
+    private func makeAgentFixture(
+        projectNames: [String]
+    ) throws -> (root: URL, storage: URL, projects: [URL]) {
+        let root = try makeProject(named: "agents")
+        try removeExtendedACL(from: root)
+        let storage = root.appendingPathComponent("storage", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: storage,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let projects = try projectNames.map { name -> URL in
+            let project = root.appendingPathComponent(name, isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: project,
+                withIntermediateDirectories: true
+            )
+            return project.resolvingSymlinksInPath()
+        }
+        return (root, storage, projects)
+    }
+
+    private func agentIdentity(_ project: URL) -> AgentTaskProjectIdentity {
+        AgentTaskProjectIdentity(
+            canonicalProjectPath: project.path,
+            canonicalWorktreePath: project.path
+        )
+    }
+
+    private func installPrivate(_ data: Data, at url: URL) throws {
+        try data.write(to: url, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: url.path
+        )
+    }
+
+    private func removeExtendedACL(from url: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/chmod")
+        process.arguments = ["-N", url.path]
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw CocoaError(.fileWriteNoPermission)
+        }
+    }
+}

--- a/PineTests/PersistenceFixtureCorpusTests.swift
+++ b/PineTests/PersistenceFixtureCorpusTests.swift
@@ -1,0 +1,268 @@
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Versioned persistence fixture corpus", .serialized)
+@MainActor
+struct PersistenceFixtureCorpusTests {
+    private struct Manifest: Decodable {
+        let formatVersion: Int
+        let fixtures: [Fixture]
+    }
+
+    private struct Fixture: Decodable {
+        let store: String
+        let file: String
+        let schema: String
+        let outcome: String
+    }
+
+    @Test("manifest covers every durable store and schema tier")
+    func manifestCoverageAndSanitization() throws {
+        let manifest: Manifest = try decode("manifest.json")
+        #expect(manifest.formatVersion == 1)
+        #expect(Set(manifest.fixtures.map(\.store)) == [
+            "preferences", "session", "recovery", "agent-task",
+        ])
+        #expect(Set(manifest.fixtures.map(\.schema)).isSuperset(of: [
+            "N-2", "N-1", "current", "future",
+        ]))
+        #expect(Set(manifest.fixtures.map(\.outcome)) == [
+            "load", "migrate", "reject",
+        ])
+
+        let forbidden = [
+            "/Users/", "/home/", "terminalOutput", "credentials",
+            "accessToken", "refreshToken", "\"prompt\"",
+        ]
+        for fixture in manifest.fixtures {
+            let contents = try String(
+                contentsOf: fixtureURL(fixture.file),
+                encoding: .utf8
+            )
+            for pattern in forbidden {
+                #expect(!contents.localizedCaseInsensitiveContains(pattern))
+            }
+        }
+    }
+
+    @Test("preference fixtures migrate idempotently and future data is untouched")
+    func preferenceFixtures() throws {
+        let project = try makeProject()
+        defer { try? FileManager.default.removeItem(at: project) }
+
+        let (legacy, legacyName) = try makeDefaults()
+        defer { legacy.removePersistentDomain(forName: legacyName) }
+        try installPreferences("preferences-v0.json", in: legacy, project: project)
+        let manager = MigrationManager.withDefaultMigrations(defaults: legacy)
+        manager.runMigrations()
+        #expect(
+            legacy.integer(forKey: MigrationManager.schemaVersionKey)
+                == MigrationManager.latestVersion
+        )
+        #expect(legacy.stringArray(forKey: "recentProjectPaths") == [project.path])
+        let migrated = legacy.dictionaryRepresentation() as NSDictionary
+        manager.runMigrations()
+        #expect(legacy.dictionaryRepresentation() as NSDictionary == migrated)
+
+        let (future, futureName) = try makeDefaults()
+        defer { future.removePersistentDomain(forName: futureName) }
+        try installPreferences(
+            "preferences-future.json",
+            in: future,
+            project: project
+        )
+        let original = future.dictionaryRepresentation() as NSDictionary
+        MigrationManager.withDefaultMigrations(defaults: future).runMigrations()
+        #expect(future.dictionaryRepresentation() as NSDictionary == original)
+    }
+
+    @Test("session fixtures load legacy/current and preserve future data")
+    func sessionFixtures() throws {
+        let project = try makeProject()
+        defer { try? FileManager.default.removeItem(at: project) }
+        let (defaults, defaultsName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+
+        let fixtures: [(String, Int?)] = [
+            ("session-v0.json", nil),
+            ("session-v1.json", SessionState.currentSchemaVersion),
+        ]
+        for (file, expectedVersion) in fixtures {
+            let data = try fixtureData(file, project: project)
+            defaults.set(data, forKey: "lastSessionState")
+            let state = try #require(
+                SessionState.load(for: project, defaults: defaults)
+            )
+            #expect(state.schemaVersion == expectedVersion)
+            #expect(state.activeFileURL?.lastPathComponent == "App.swift")
+        }
+
+        let future = try fixtureData("session-future.json", project: project)
+        defaults.set(future, forKey: "lastSessionState")
+        #expect(SessionState.load(for: project, defaults: defaults) == nil)
+        #expect(defaults.data(forKey: "lastSessionState") == future)
+    }
+
+    @Test("recovery fixtures load legacy/current and preserve future data")
+    func recoveryFixtures() throws {
+        let project = try makeProject()
+        defer { try? FileManager.default.removeItem(at: project) }
+        let recovery = project.appendingPathComponent("Recovery")
+        try FileManager.default.createDirectory(
+            at: recovery,
+            withIntermediateDirectories: true
+        )
+        let manager = RecoveryManager(recoveryDirectory: recovery)
+
+        let fixtures: [(String, Int?)] = [
+            ("recovery-v0.json", nil),
+            ("recovery-v1.json", RecoveryEntry.currentSchemaVersion),
+        ]
+        for (file, expectedVersion) in fixtures {
+            let id = UUID()
+            let url = recovery.appendingPathComponent("\(id.uuidString).json")
+            try fixtureData(file, project: project).write(to: url)
+            let entries = manager.pendingRecoveryEntries()
+            let entry = try #require(entries.first(where: { $0.0 == id })?.1)
+            #expect(entry.schemaVersion == expectedVersion)
+            try FileManager.default.removeItem(at: url)
+        }
+
+        let id = UUID()
+        let url = recovery.appendingPathComponent("\(id.uuidString).json")
+        let future = try fixtureData("recovery-future.json", project: project)
+        try future.write(to: url)
+        #expect(manager.pendingRecoveryEntries().isEmpty)
+        #expect(try Data(contentsOf: url) == future)
+    }
+
+    @Test("agent-task fixtures enforce N-2 through future compatibility")
+    func agentTaskFixtures() async throws {
+        let root = try makePrivateRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let project = root.appendingPathComponent("project", isDirectory: true)
+        let storage = root.appendingPathComponent("storage", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: project,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: storage,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let identity = AgentTaskProjectIdentity(
+            canonicalProjectPath: project.path,
+            canonicalWorktreePath: project.path
+        )
+        let url = AgentTaskMetadataStore.metadataURL(
+            for: identity,
+            storageRoot: storage
+        )
+        let store = AgentTaskMetadataStore(storageRoot: storage)
+
+        try installAgentFixture("agent-task-v0.json", at: url, project: project)
+        #expect(await store.load(project: identity).status == .rejected(.unknownSchema))
+
+        try installAgentFixture("agent-task-v1.json", at: url, project: project)
+        let legacy = await store.load(project: identity)
+        #expect(legacy.status == .loaded)
+        #expect(legacy.requiresMigration)
+
+        try installAgentFixture("agent-task-v2.json", at: url, project: project)
+        let current = await store.load(project: identity)
+        #expect(current.status == .loaded)
+        #expect(!current.requiresMigration)
+
+        try installAgentFixture("agent-task-future.json", at: url, project: project)
+        let future = try Data(contentsOf: url)
+        #expect(await store.load(project: identity).status == .rejected(.unknownSchema))
+        #expect(try Data(contentsOf: url) == future)
+    }
+
+    private func installAgentFixture(
+        _ name: String,
+        at url: URL,
+        project: URL
+    ) throws {
+        try fixtureData(name, project: project).write(to: url)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: url.path
+        )
+    }
+
+    private func installPreferences(
+        _ name: String,
+        in defaults: UserDefaults,
+        project: URL
+    ) throws {
+        let object = try #require(
+            JSONSerialization.jsonObject(
+                with: fixtureData(name, project: project)
+            ) as? [String: Any]
+        )
+        for (key, value) in object { defaults.set(value, forKey: key) }
+    }
+
+    private func decode<Value: Decodable>(_ name: String) throws -> Value {
+        try JSONDecoder().decode(Value.self, from: Data(contentsOf: fixtureURL(name)))
+    }
+
+    private func fixtureData(_ name: String, project: URL) throws -> Data {
+        let contents = try String(
+            contentsOf: fixtureURL(name),
+            encoding: .utf8
+        ).replacingOccurrences(of: "{{PROJECT_PATH}}", with: project.path)
+        return Data(contents.utf8)
+    }
+
+    private func fixtureURL(_ name: String) -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/Persistence")
+            .appendingPathComponent(name)
+    }
+
+    private func makeProject() throws -> URL {
+        let project = FileManager.default.temporaryDirectory
+            .resolvingSymlinksInPath()
+            .appendingPathComponent("PinePersistence-\(UUID().uuidString)")
+        let sources = project.appendingPathComponent("Sources")
+        try FileManager.default.createDirectory(
+            at: sources,
+            withIntermediateDirectories: true
+        )
+        try Data("let fixture = true\n".utf8).write(
+            to: sources.appendingPathComponent("App.swift")
+        )
+        return project
+    }
+
+    private func makePrivateRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .resolvingSymlinksInPath()
+            .appendingPathComponent("PinePersistencePrivate-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/chmod")
+        process.arguments = ["-N", root.path]
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw CocoaError(.fileWriteNoPermission)
+        }
+        return root
+    }
+
+    private func makeDefaults() throws -> (UserDefaults, String) {
+        let name = "PinePersistenceCorpus-\(UUID().uuidString)"
+        return (try #require(UserDefaults(suiteName: name)), name)
+    }
+}

--- a/PineTests/PersistenceFixtureCorpusTests.swift
+++ b/PineTests/PersistenceFixtureCorpusTests.swift
@@ -78,7 +78,7 @@ struct PersistenceFixtureCorpusTests {
         #expect(future.dictionaryRepresentation() as NSDictionary == original)
     }
 
-    @Test("session fixtures load legacy/current and preserve future data")
+    @Test("session fixtures normalize idempotently and preserve future data")
     func sessionFixtures() throws {
         let project = try makeProject()
         defer { try? FileManager.default.removeItem(at: project) }
@@ -97,6 +97,22 @@ struct PersistenceFixtureCorpusTests {
             )
             #expect(state.schemaVersion == expectedVersion)
             #expect(state.activeFileURL?.lastPathComponent == "App.swift")
+
+            #expect(saveNormalizedSession(state, for: project, in: defaults))
+            let normalized = try #require(
+                SessionState.load(for: project, defaults: defaults)
+            )
+            #expect(
+                normalized.schemaVersion == SessionState.currentSchemaVersion
+            )
+            let first = try sessionRecord(in: defaults)
+            #expect(
+                saveNormalizedSession(normalized, for: project, in: defaults)
+            )
+            #expect(try sessionRecord(in: defaults) == first)
+
+            SessionState.clear(for: project, defaults: defaults)
+            defaults.removeObject(forKey: "lastSessionState")
         }
 
         let future = try fixtureData("session-future.json", project: project)
@@ -105,7 +121,7 @@ struct PersistenceFixtureCorpusTests {
         #expect(defaults.data(forKey: "lastSessionState") == future)
     }
 
-    @Test("recovery fixtures load legacy/current and preserve future data")
+    @Test("recovery fixtures normalize idempotently and preserve future data")
     func recoveryFixtures() throws {
         let project = try makeProject()
         defer { try? FileManager.default.removeItem(at: project) }
@@ -127,7 +143,37 @@ struct PersistenceFixtureCorpusTests {
             let entries = manager.pendingRecoveryEntries()
             let entry = try #require(entries.first(where: { $0.0 == id })?.1)
             #expect(entry.schemaVersion == expectedVersion)
-            try FileManager.default.removeItem(at: url)
+
+            var tab = EditorTab(
+                url: URL(fileURLWithPath: entry.originalPath),
+                content: entry.content,
+                savedContent: ""
+            )
+            tab.encoding = entry.encoding
+            #expect(manager.migrateRecoverySnapshot(from: id, to: tab))
+            let normalized = try #require(
+                manager.pendingRecoveryEntries().first {
+                    $0.0 == tab.id
+                }?.1
+            )
+            #expect(
+                normalized.schemaVersion == RecoveryEntry.currentSchemaVersion
+            )
+            #expect(normalized.originalPath == entry.originalPath)
+            #expect(normalized.content == entry.content)
+
+            #expect(manager.migrateRecoverySnapshot(from: tab.id, to: tab))
+            let repeated = try #require(
+                manager.pendingRecoveryEntries().first {
+                    $0.0 == tab.id
+                }?.1
+            )
+            #expect(
+                repeated.schemaVersion == RecoveryEntry.currentSchemaVersion
+            )
+            #expect(repeated.originalPath == normalized.originalPath)
+            #expect(repeated.content == normalized.content)
+            manager.deleteRecoveryFile(for: tab.id)
         }
 
         let id = UUID()
@@ -171,6 +217,55 @@ struct PersistenceFixtureCorpusTests {
         #expect(legacy.status == .loaded)
         #expect(legacy.requiresMigration)
 
+        let generation = UUID()
+        let revision = try #require(
+            UUID(uuidString: "11111111-1111-4111-8111-111111111111")
+        )
+        let fence = AgentTaskPublicationFence(generation: generation)
+        let firstTicket = AgentTaskPersistenceTicket(
+            generation: generation,
+            sequence: 1,
+            projectKey: identity.persistenceKey,
+            expectedDiskRevision: legacy.revision,
+            nextDiskRevision: revision
+        )
+        fence.authorize(firstTicket)
+        #expect(
+            await store.save(
+                tasks: legacy.tasks,
+                project: identity,
+                authorization: AgentTaskPublicationAuthorization(
+                    ticket: firstTicket,
+                    fence: fence
+                )
+            ) == .saved(taskCount: legacy.tasks.count)
+        )
+        let normalized = await store.load(project: identity)
+        #expect(normalized.status == .loaded)
+        #expect(!normalized.requiresMigration)
+        #expect(normalized.revision == .versioned(revision))
+        let firstNormalizedData = try Data(contentsOf: url)
+
+        let secondTicket = AgentTaskPersistenceTicket(
+            generation: generation,
+            sequence: 2,
+            projectKey: identity.persistenceKey,
+            expectedDiskRevision: .versioned(revision),
+            nextDiskRevision: revision
+        )
+        fence.authorize(secondTicket)
+        #expect(
+            await store.save(
+                tasks: normalized.tasks,
+                project: identity,
+                authorization: AgentTaskPublicationAuthorization(
+                    ticket: secondTicket,
+                    fence: fence
+                )
+            ) == .saved(taskCount: normalized.tasks.count)
+        )
+        #expect(try Data(contentsOf: url) == firstNormalizedData)
+
         try installAgentFixture("agent-task-v2.json", at: url, project: project)
         let current = await store.load(project: identity)
         #expect(current.status == .loaded)
@@ -180,6 +275,75 @@ struct PersistenceFixtureCorpusTests {
         let future = try Data(contentsOf: url)
         #expect(await store.load(project: identity).status == .rejected(.unknownSchema))
         #expect(try Data(contentsOf: url) == future)
+    }
+
+    @Test("corrupt, oversized, and invalid inputs are rejected untouched")
+    func invalidInputsFailClosed() async throws {
+        let project = try makeProject()
+        defer { try? FileManager.default.removeItem(at: project) }
+        let (defaults, defaultsName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+
+        let truncatedSession = Data("{\"schemaVersion\":1".utf8)
+        defaults.set(truncatedSession, forKey: "lastSessionState")
+        #expect(SessionState.load(for: project, defaults: defaults) == nil)
+        #expect(defaults.data(forKey: "lastSessionState") == truncatedSession)
+
+        let recovery = project.appendingPathComponent("Recovery")
+        try FileManager.default.createDirectory(
+            at: recovery,
+            withIntermediateDirectories: true
+        )
+        let recoveryURL = recovery.appendingPathComponent("\(UUID()).json")
+        let truncatedRecovery = Data("{\"schemaVersion\":1".utf8)
+        try truncatedRecovery.write(to: recoveryURL)
+        #expect(
+            RecoveryManager(recoveryDirectory: recovery)
+                .pendingRecoveryEntries().isEmpty
+        )
+        #expect(try Data(contentsOf: recoveryURL) == truncatedRecovery)
+
+        let storage = project.appendingPathComponent("storage")
+        try FileManager.default.createDirectory(
+            at: storage,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let identity = AgentTaskProjectIdentity(
+            canonicalProjectPath: project.path,
+            canonicalWorktreePath: project.path
+        )
+        let metadataURL = AgentTaskMetadataStore.metadataURL(
+            for: identity,
+            storageRoot: storage
+        )
+        let store = AgentTaskMetadataStore(storageRoot: storage)
+
+        let oversized = Data(repeating: 0x41, count: 1_048_577)
+        try installPrivate(oversized, at: metadataURL)
+        #expect(
+            await store.load(project: identity).status
+                == .rejected(.storageLimit)
+        )
+        #expect(try Data(contentsOf: metadataURL) == oversized)
+
+        let invalid = Data(
+            """
+            {
+              "schemaVersion": 2,
+              "revision": "22222222-2222-4222-8222-222222222222",
+              "canonicalProjectPath": "/different/project",
+              "canonicalWorktreePath": "/different/project",
+              "tasks": []
+            }
+            """.utf8
+        )
+        try installPrivate(invalid, at: metadataURL)
+        #expect(
+            await store.load(project: identity).status
+                == .rejected(.invalidMetadata)
+        )
+        #expect(try Data(contentsOf: metadataURL) == invalid)
     }
 
     private func installAgentFixture(
@@ -192,6 +356,50 @@ struct PersistenceFixtureCorpusTests {
             [.posixPermissions: 0o600],
             ofItemAtPath: url.path
         )
+    }
+
+    private func installPrivate(_ data: Data, at url: URL) throws {
+        try data.write(to: url, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: url.path
+        )
+    }
+
+    private func saveNormalizedSession(
+        _ state: SessionState,
+        for project: URL,
+        in defaults: UserDefaults
+    ) -> Bool {
+        SessionState.save(
+            projectURL: project,
+            openFileURLs: state.existingFileURLs,
+            activeFileURL: state.activeFileURL,
+            previewModes: state.previewModes,
+            highlightingDisabledPaths: state.highlightingDisabledPaths,
+            editorStates: state.editorStates,
+            pinnedPaths: state.pinnedPaths,
+            terminalPaneTabCounts: state.terminalPaneTabCounts,
+            terminalPaneActiveIndices: state.terminalPaneActiveIndices,
+            paneLayoutData: state.paneLayoutData,
+            paneTabAssignments: state.paneTabAssignments,
+            activePaneID: state.activePaneID,
+            paneActiveEditorPaths: state.paneActiveEditorPaths,
+            panePinnedPaths: state.panePinnedPaths,
+            paneTransientPreviewPaths: state.paneTransientPreviewPaths,
+            globalTabSwitchOrder: state.globalTabSwitchOrder,
+            defaults: defaults,
+            faultInjector: .none
+        )
+    }
+
+    private func sessionRecord(in defaults: UserDefaults) throws -> Data {
+        let key = try #require(
+            defaults.dictionaryRepresentation().keys.first {
+                $0.hasPrefix("sessionState:")
+            }
+        )
+        return try #require(defaults.data(forKey: key))
     }
 
     private func installPreferences(

--- a/PineTests/RecoveryManagerTests.swift
+++ b/PineTests/RecoveryManagerTests.swift
@@ -87,6 +87,51 @@ struct RecoveryManagerTests {
         #expect(entry.originalPath == "/Users/test/file.swift")
         #expect(entry.content == "modified code")
         #expect(entry.encoding == .utf16)
+        #expect(entry.schemaVersion == RecoveryEntry.currentSchemaVersion)
+    }
+
+    @Test func futureSchemaFailsClosedWithoutOverwrite() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let manager = RecoveryManager(recoveryDirectory: dir)
+        let id = UUID()
+        let file = dir.appendingPathComponent("\(id.uuidString).json")
+        let entry = RecoveryEntry(
+            schemaVersion: RecoveryEntry.currentSchemaVersion + 1,
+            originalPath: "/sanitized/project/file.swift",
+            content: "future contents"
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(entry)
+        try data.write(to: file)
+
+        #expect(manager.pendingRecoveryEntries().isEmpty)
+        #expect(try Data(contentsOf: file) == data)
+    }
+
+    @Test func legacySnapshotWithoutSchemaRemainsReadable() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let manager = RecoveryManager(recoveryDirectory: dir)
+        let id = UUID()
+        let legacy = """
+        {
+          "originalPath": "/sanitized/project/file.swift",
+          "content": "legacy contents",
+          "timestamp": "2026-01-01T00:00:00Z",
+          "encodingRawValue": 4
+        }
+        """
+        try Data(legacy.utf8).write(
+            to: dir.appendingPathComponent("\(id.uuidString).json")
+        )
+
+        let entries = manager.pendingRecoveryEntries()
+        #expect(entries.count == 1)
+        #expect(entries.first?.0 == id)
+        #expect(entries.first?.1.schemaVersion == nil)
+        #expect(entries.first?.1.content == "legacy contents")
     }
 
     @Test func snapshotSkipsCleanTabs() throws {

--- a/PineTests/SessionStateTests.swift
+++ b/PineTests/SessionStateTests.swift
@@ -54,6 +54,25 @@ struct SessionStateTests {
         #expect(loaded?.existingFileURLs.count == 2)
         #expect(loaded?.existingFileURLs[0].path == file1.path)
         #expect(loaded?.existingFileURLs[1].path == file2.path)
+        #expect(loaded?.schemaVersion == SessionState.currentSchemaVersion)
+    }
+
+    @Test func futureSchemaFailsClosedWithoutOverwrite() throws {
+        let tempDir = try makeTempDirectory()
+        defer { cleanup(tempDir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let futureState = SessionState(
+            schemaVersion: SessionState.currentSchemaVersion + 1,
+            projectPath: tempDir.path,
+            openFilePaths: []
+        )
+        let data = try JSONEncoder().encode(futureState)
+        defaults.set(data, forKey: "lastSessionState")
+
+        #expect(SessionState.load(for: tempDir, defaults: defaults) == nil)
+        #expect(defaults.data(forKey: "lastSessionState") == data)
     }
 
     // MARK: - Missing project folder

--- a/PineTests/SidebarAccessibilityHostedTests.swift
+++ b/PineTests/SidebarAccessibilityHostedTests.swift
@@ -152,6 +152,66 @@ struct SidebarAccessibilityHostedTests {
         #expect(window.firstResponder === responder)
     }
 
+    @Test("Row focus claim survives a later disclosure reconciliation")
+    func responderFocusRetryAfterDisclosureReconciliation() async throws {
+        let controller = SidebarKeyboardFocusController()
+        let responder = SidebarKeyboardResponderView(
+            frame: NSRect(x: 0, y: 0, width: 1, height: 1)
+        )
+        let replacement = SidebarFocusAcceptingTestView(
+            frame: NSRect(x: 0, y: 0, width: 1, height: 1)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 100),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(responder)
+        window.contentView?.addSubview(replacement)
+        controller.attach(responder)
+        defer { window.orderOut(nil) }
+
+        #expect(controller.requestFocus(retryOnNextRunLoop: true))
+        #expect(window.makeFirstResponder(replacement))
+        #expect(!controller.isFocused)
+
+        try await Task.sleep(for: .milliseconds(150))
+
+        #expect(controller.isFocused)
+        #expect(window.firstResponder === responder)
+    }
+
+    @Test("Explicit editor focus cancels a pending sidebar retry")
+    func explicitEditorFocusCancelsSidebarRetry() async throws {
+        let controller = SidebarKeyboardFocusController()
+        let responder = SidebarKeyboardResponderView(
+            frame: NSRect(x: 0, y: 0, width: 1, height: 1)
+        )
+        let editor = SidebarFocusAcceptingTestView(
+            frame: NSRect(x: 0, y: 0, width: 100, height: 100)
+        )
+        let window = NSWindow(
+            contentRect: editor.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(editor)
+        window.contentView?.addSubview(responder)
+        controller.attach(responder)
+        defer { window.orderOut(nil) }
+
+        #expect(controller.requestFocus(retryOnNextRunLoop: true))
+        controller.cancelPendingFocusRetry()
+        #expect(window.makeFirstResponder(editor))
+
+        try await Task.sleep(for: .milliseconds(150))
+
+        #expect(!controller.isFocused)
+        #expect(window.firstResponder === editor)
+    }
+
     @Test("Physical and interpreted printable input share one callback")
     func responderInputClassification() throws {
         let responder = SidebarKeyboardResponderView(frame: .zero)
@@ -465,4 +525,8 @@ private struct SidebarAccessibilityHostedHarness: View {
         )
         .frame(width: 220, height: 24)
     }
+}
+
+private final class SidebarFocusAcceptingTestView: NSView {
+    override var acceptsFirstResponder: Bool { true }
 }

--- a/PineUITests/SessionRestoreTests.swift
+++ b/PineUITests/SessionRestoreTests.swift
@@ -12,6 +12,8 @@ import XCTest
 final class SessionRestoreTests: PineUITestCase {
 
     private var projectURL: URL!
+    private var seededSessionKey: String?
+    private let bundleID = "io.github.batonogov.pine"
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -23,6 +25,9 @@ final class SessionRestoreTests: PineUITestCase {
     }
 
     override func tearDownWithError() throws {
+        if let seededSessionKey {
+            try? runDefaults(["delete", bundleID, seededSessionKey])
+        }
         if let url = projectURL { cleanupProject(url) }
         try super.tearDownWithError()
     }
@@ -149,4 +154,84 @@ final class SessionRestoreTests: PineUITestCase {
             "Status bar should be visible after session restore"
         )
     }
+
+    func testFixtureSurvivesInjectedWriteFailureAndProcessRelaunch() throws {
+        cleanupProject(projectURL)
+        projectURL = try createTempProject(files: [
+            "Sources/App.swift": "let fixture = true\n",
+            "helper.swift": "let replacement = true\n",
+        ])
+        app.launchArguments.removeAll { $0 == "--reset-state" }
+        try seedVersionedSessionFixture()
+        app.launchEnvironment["PINE_PERSISTENCE_FAULT"] = [
+            "session",
+            "before-atomic-replace",
+            "atomic-rename",
+        ].joined(separator: ":")
+
+        launchWithProject(projectURL)
+        XCTAssertTrue(
+            waitForExistence(editorTab("App.swift"), timeout: 15),
+            "The shared versioned fixture should restore App.swift"
+        )
+        openFile("helper.swift")
+
+        let closeButton = app.windows.firstMatch
+            .buttons["_XCUI:CloseWindow"].firstMatch
+        XCTAssertTrue(closeButton.exists)
+        closeButton.click()
+        XCTAssertTrue(
+            waitForExistence(app.windows["welcome"], timeout: 10),
+            "Closing the project should attempt the injected session save"
+        )
+        app.terminate()
+
+        app.launchEnvironment.removeValue(forKey: "PINE_PERSISTENCE_FAULT")
+        launchWithProject(projectURL)
+        XCTAssertTrue(
+            waitForExistence(editorTab("App.swift"), timeout: 15),
+            "Relaunch should consume the original last-known-good fixture"
+        )
+        XCTAssertFalse(
+            editorTab("helper.swift").exists,
+            "The failed replacement must not become the restored session"
+        )
+    }
+
+    private func seedVersionedSessionFixture() throws {
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent(
+                "PineTests/Fixtures/Persistence/session-v0.json"
+            )
+        let fixture = try String(
+            contentsOf: fixtureURL,
+            encoding: .utf8
+        ).replacingOccurrences(
+            of: "{{PROJECT_PATH}}",
+            with: projectURL.resolvingSymlinksInPath().path
+        )
+        let data = Data(fixture.utf8)
+        let hex = data.map { String(format: "%02x", $0) }.joined()
+        let key = "sessionState:\(projectURL.resolvingSymlinksInPath().path)"
+        try runDefaults(["write", bundleID, key, "-data", hex])
+        seededSessionKey = key
+    }
+
+    private func runDefaults(_ arguments: [String]) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        process.arguments = arguments
+        var environment = ProcessInfo.processInfo.environment
+        environment["DEVELOPER_DIR"] = environment["DEVELOPER_DIR"]
+            ?? "/Applications/Xcode.app/Contents/Developer"
+        process.environment = environment
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary
- version preferences, project sessions, recovery snapshots, and agent-task metadata with N-2/N-1/current/future fixture coverage
- add deterministic permission, read-only, no-space, fsync, interrupted-write, atomic-rename, and concurrent-writer injection at persistence checkpoints
- preserve last-known-good bytes before publication and distinguish complete publication with unknown durability
- exercise migration idempotence, corrupt/oversized/future fail-closed behavior, concurrent project isolation, and process relaunch against the shared fixture corpus

## Validation
- targeted persistence unit suites: 86 tests across fixture, fault, migration, session, and recovery suites
- focused reruns: 6 fixture tests and 31 fault/session tests
- full `swiftlint lint --no-cache` (0 violations)
- UI shard membership/balance validator: 38 classes, 227 tests, delta 3
- `git diff --check`

Closes #1441