### PR TITLE
test(lifecycle): gate real quit, crash, and relaunch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,13 +551,14 @@ jobs:
               -only-testing:PineUITests/AgentInboxToolbarButtonTests
               -only-testing:PineUITests/SidebarFolderClickTests
               -only-testing:PineUITests/NativeFileWindowMenuUITests
-          # Shard 3 — Navigation (31 tests)
+          # Shard 3 — Navigation + lifecycle (34 tests)
           - shard-name: "Navigation"
             test-classes: >-
               -only-testing:PineUITests/GoToLineTabOverflowExternalChangesUITests
               -only-testing:PineUITests/QuickOpenUITests
               -only-testing:PineUITests/EditorTabNavigationTests
               -only-testing:PineUITests/DiffNavigationUITests
+              -only-testing:PineUITests/ApplicationLifecycleProcessTests
           # Shard 4 — Editor Chrome (31 tests)
           - shard-name: "Editor Chrome"
             test-classes: >-
@@ -643,6 +644,14 @@ jobs:
           python3 .github/scripts/detect_flaky_tests.py \
             UITestResults.xcresult --github-summary \
             --output-file flaky-shard-${{ strategy.job-index }}.json
+
+      - name: Upload Lifecycle Process Results
+        if: always() && matrix.shard-name == 'Navigation'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: lifecycle-process-results
+          path: UITestResults.xcresult
+          retention-days: 7
 
       - name: Upload Flaky Report
         if: success() || failure()

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -152,6 +152,9 @@ struct ContentView: View {
             await registry.seedLiveAgentUITestFixture(
                 afterWindowBindingFor: projectManager
             )
+            LifecycleProcessTestDriver.shared.startIfRequested(
+                projectManager: projectManager
+            )
             #endif
         }
         .sheet(isPresented: $showRecoveryDialog) {

--- a/Pine/LifecycleProcessTestDriver.swift
+++ b/Pine/LifecycleProcessTestDriver.swift
@@ -7,6 +7,7 @@
 
 #if DEBUG
 import Foundation
+import SwiftTerm
 
 /// Installs deterministic dirty-editor and live-PTY state in the real Pine
 /// process. The process test can request a second terminal generation with
@@ -38,6 +39,7 @@ final class LifecycleProcessTestDriver {
         }
         self.projectManager = projectManager
         self.diagnosticsDirectory = diagnosticsDirectory
+        writeProcessIdentifier()
 
         if ProcessInfo.processInfo.environment[
             "PINE_LIFECYCLE_FIXTURE_DIRTY"
@@ -57,8 +59,12 @@ final class LifecycleProcessTestDriver {
             }
         }
 
-        spawnTerminalGeneration()
-        installGenerationControl()
+        if ProcessInfo.processInfo.environment[
+            "PINE_LIFECYCLE_FIXTURE_TERMINAL"
+        ] != "0" {
+            spawnTerminalGeneration()
+            installGenerationControl()
+        }
         record("fixture-ready")
     }
 
@@ -85,8 +91,7 @@ final class LifecycleProcessTestDriver {
             executablePath: "/bin/sh",
             arguments: [
                 "-c",
-                "echo $$ > \"$1/owned-$2.pid\"; "
-                    + "child=0; "
+                "child=0; "
                     + "trap 'test \"$child\" -le 0 || kill \"$child\" "
                     + "2>/dev/null; exit 0' HUP INT TERM; "
                     + "while :; do /bin/sleep 60 & child=$!; "
@@ -97,8 +102,9 @@ final class LifecycleProcessTestDriver {
                 String(generation),
             ]
         )
+        let tab: TerminalTab?
         if let terminalPaneID {
-            _ = projectManager.paneManager.addTerminalTab(
+            tab = projectManager.paneManager.addTerminalTab(
                 in: terminalPaneID,
                 workingDirectory: rootURL,
                 initialProcess: process
@@ -109,8 +115,63 @@ final class LifecycleProcessTestDriver {
                     workingDirectory: rootURL,
                     initialProcess: process
                 )
+            tab = terminalPaneID.flatMap {
+                projectManager.paneManager.terminalState(for: $0)?.activeTab
+            }
         }
         record("terminal-generation-\(generation)-requested")
+        guard let tab else {
+            record("terminal-generation-\(generation)-missing-tab")
+            return
+        }
+        // Production starts PTYs lazily from TerminalContainerView.layout().
+        // The process-level gate must not depend on CI window-layout timing:
+        // drive the same production start path once the real tab is owned.
+        tab.startIfNeeded()
+        recordStartedProcess(for: tab, generation: generation)
+    }
+
+    private func recordStartedProcess(
+        for tab: TerminalTab,
+        generation: Int
+    ) {
+        guard let diagnosticsDirectory else { return }
+        Task { @MainActor [weak tab] in
+            for _ in 0..<200 {
+                guard let tab else { return }
+                let processIdentifier = tab.terminalView.process.shellPid
+                if tab.isProcessRunning, processIdentifier > 1 {
+                    let url = diagnosticsDirectory.appendingPathComponent(
+                        "owned-\(generation).pid"
+                    )
+                    try? Data("\(processIdentifier)\n".utf8).write(
+                        to: url,
+                        options: .atomic
+                    )
+                    LifecycleProcessDiagnostics.record(
+                        "terminal-generation-\(generation)-started-"
+                            + "pid-\(processIdentifier)",
+                        in: diagnosticsDirectory
+                    )
+                    return
+                }
+                try? await Task.sleep(for: .milliseconds(50))
+            }
+            LifecycleProcessDiagnostics.record(
+                "terminal-generation-\(generation)-start-timeout",
+                in: diagnosticsDirectory
+            )
+        }
+    }
+
+    private func writeProcessIdentifier() {
+        guard let diagnosticsDirectory else { return }
+        let processIdentifier = ProcessInfo.processInfo.processIdentifier
+        let url = diagnosticsDirectory.appendingPathComponent("pine.pid")
+        try? Data("\(processIdentifier)\n".utf8).write(
+            to: url,
+            options: .atomic
+        )
     }
 
     private func record(_ phase: String) {

--- a/Pine/LifecycleProcessTestDriver.swift
+++ b/Pine/LifecycleProcessTestDriver.swift
@@ -91,12 +91,12 @@ final class LifecycleProcessTestDriver {
             executablePath: "/bin/sh",
             arguments: [
                 "-c",
-                "child=0; "
+                "set -m; child=0; "
                     + "trap 'test \"$child\" -le 0 || kill \"$child\" "
                     + "2>/dev/null; exit 0' HUP INT TERM; "
                     + "while :; do /bin/sleep 60 & child=$!; "
                     + "echo $child > \"$1/owned-$2-child.pid\"; "
-                    + "wait \"$child\"; done",
+                    + "fg %1; done",
                 "pine-lifecycle-fixture",
                 diagnosticsDirectory.path,
                 String(generation),

--- a/Pine/LifecycleProcessTestDriver.swift
+++ b/Pine/LifecycleProcessTestDriver.swift
@@ -1,0 +1,182 @@
+//
+//  LifecycleProcessTestDriver.swift
+//  Pine
+//
+//  Debug-only process fixture for the full application lifecycle release gate.
+//
+
+#if DEBUG
+import Foundation
+
+/// Installs deterministic dirty-editor and live-PTY state in the real Pine
+/// process. The process test can request a second terminal generation with
+/// a one-shot control file while AppKit's Quit sheet is visible, without
+/// reaching through a
+/// model-only test seam.
+@MainActor
+final class LifecycleProcessTestDriver {
+    static let shared = LifecycleProcessTestDriver()
+
+    private weak var projectManager: ProjectManager?
+    private var terminalPaneID: PaneID?
+    private var generationControl: DispatchSourceTimer?
+    private var diagnosticsDirectory: URL?
+    private var generation = 0
+
+    private init() {}
+
+    func startIfRequested(projectManager: ProjectManager) {
+        guard CommandLine.arguments.contains(
+            "--ui-test-lifecycle-process"
+        ) else { return }
+        guard generationControl == nil else { return }
+        guard let diagnosticsDirectory = Self.diagnosticsDirectory() else {
+            assertionFailure(
+                "Lifecycle process fixture requires a diagnostics directory"
+            )
+            return
+        }
+        self.projectManager = projectManager
+        self.diagnosticsDirectory = diagnosticsDirectory
+
+        if ProcessInfo.processInfo.environment[
+            "PINE_LIFECYCLE_FIXTURE_DIRTY"
+        ] != "0" {
+            let dirtyFile = projectManager.rootURL?
+                .appendingPathComponent("dirty.swift")
+            if let dirtyFile,
+               case .opened = projectManager.activeTabManager.openTab(
+                   url: dirtyFile
+               ) {
+                projectManager.activeTabManager.updateContent(
+                    "let lifecycleFixtureIsDirty = true\n"
+                )
+                record("dirty-buffer-ready")
+            } else {
+                record("dirty-buffer-failed")
+            }
+        }
+
+        spawnTerminalGeneration()
+        installGenerationControl()
+        record("fixture-ready")
+    }
+
+    private func installGenerationControl() {
+        guard let diagnosticsDirectory else { return }
+        let request = diagnosticsDirectory.appendingPathComponent(
+            "request-next-generation"
+        )
+        let source = DispatchSource.makeTimerSource(
+            queue: DispatchQueue.global(qos: .utility)
+        )
+        source.schedule(
+            deadline: .now(),
+            repeating: .milliseconds(50)
+        )
+        source.setEventHandler { [weak self] in
+            guard FileManager.default.fileExists(atPath: request.path),
+                  (try? FileManager.default.removeItem(at: request)) != nil
+            else { return }
+            Task { @MainActor [weak self] in
+                self?.spawnTerminalGeneration()
+            }
+        }
+        source.resume()
+        generationControl = source
+    }
+
+    private func spawnTerminalGeneration() {
+        guard let projectManager,
+              let rootURL = projectManager.rootURL,
+              let diagnosticsDirectory else { return }
+        generation += 1
+        let process = TerminalInitialProcess(
+            executablePath: "/bin/sh",
+            arguments: [
+                "-c",
+                "echo $$ > \"$1/owned-$2.pid\"; "
+                    + "child=0; "
+                    + "trap 'test \"$child\" -le 0 || kill \"$child\" "
+                    + "2>/dev/null; exit 0' HUP INT TERM; "
+                    + "while :; do /bin/sleep 60 & child=$!; "
+                    + "echo $child > \"$1/owned-$2-child.pid\"; "
+                    + "wait \"$child\"; done",
+                "pine-lifecycle-fixture",
+                diagnosticsDirectory.path,
+                String(generation),
+            ]
+        )
+        if let terminalPaneID {
+            _ = projectManager.paneManager.addTerminalTab(
+                in: terminalPaneID,
+                workingDirectory: rootURL,
+                initialProcess: process
+            )
+        } else {
+            terminalPaneID = projectManager.paneManager
+                .createTerminalPaneAtBottom(
+                    workingDirectory: rootURL,
+                    initialProcess: process
+                )
+        }
+        record("terminal-generation-\(generation)-requested")
+    }
+
+    private func record(_ phase: String) {
+        guard let diagnosticsDirectory else { return }
+        LifecycleProcessDiagnostics.record(
+            phase,
+            in: diagnosticsDirectory
+        )
+    }
+
+    private static func diagnosticsDirectory() -> URL? {
+        guard let path = ProcessInfo.processInfo.environment[
+            "PINE_LIFECYCLE_DIAGNOSTICS_DIRECTORY"
+        ], path.hasPrefix("/") else { return nil }
+        let url = URL(fileURLWithPath: path, isDirectory: true)
+            .standardizedFileURL
+        do {
+            try FileManager.default.createDirectory(
+                at: url,
+                withIntermediateDirectories: true
+            )
+            return url
+        } catch {
+            return nil
+        }
+    }
+}
+
+nonisolated enum LifecycleProcessDiagnostics {
+    private static let queue = DispatchQueue(
+        label: "com.pine.lifecycle-process-diagnostics",
+        qos: .utility
+    )
+
+    static func record(_ phase: String, in directory: URL) {
+        queue.async {
+            let url = directory.appendingPathComponent("phases.log")
+            let line = Data("\(phase)\n".utf8)
+            if !FileManager.default.fileExists(atPath: url.path) {
+                FileManager.default.createFile(
+                    atPath: url.path,
+                    contents: nil
+                )
+            }
+            guard let handle = try? FileHandle(forWritingTo: url) else {
+                return
+            }
+            defer { try? handle.close() }
+            do {
+                try handle.seekToEnd()
+                try handle.write(contentsOf: line)
+                try handle.synchronize()
+            } catch {
+                return
+            }
+        }
+    }
+}
+#endif

--- a/Pine/LifecycleProcessTestDriver.swift
+++ b/Pine/LifecycleProcessTestDriver.swift
@@ -67,23 +67,13 @@ final class LifecycleProcessTestDriver {
         let request = diagnosticsDirectory.appendingPathComponent(
             "request-next-generation"
         )
-        let source = DispatchSource.makeTimerSource(
-            queue: DispatchQueue.global(qos: .utility)
-        )
-        source.schedule(
-            deadline: .now(),
-            repeating: .milliseconds(50)
-        )
-        source.setEventHandler { [weak self] in
-            guard FileManager.default.fileExists(atPath: request.path),
-                  (try? FileManager.default.removeItem(at: request)) != nil
-            else { return }
+        generationControl = LifecycleProcessGenerationControl.make(
+            request: request
+        ) { [weak self] in
             Task { @MainActor [weak self] in
                 self?.spawnTerminalGeneration()
             }
         }
-        source.resume()
-        generationControl = source
     }
 
     private func spawnTerminalGeneration() {
@@ -146,6 +136,29 @@ final class LifecycleProcessTestDriver {
         } catch {
             return nil
         }
+    }
+}
+
+nonisolated enum LifecycleProcessGenerationControl {
+    static func make(
+        request: URL,
+        onRequest: @escaping @Sendable () -> Void
+    ) -> DispatchSourceTimer {
+        let source = DispatchSource.makeTimerSource(
+            queue: DispatchQueue.global(qos: .utility)
+        )
+        source.schedule(
+            deadline: .now(),
+            repeating: .milliseconds(50)
+        )
+        source.setEventHandler {
+            guard FileManager.default.fileExists(atPath: request.path),
+                  (try? FileManager.default.removeItem(at: request)) != nil
+            else { return }
+            onRequest()
+        }
+        source.resume()
+        return source
     }
 }
 

--- a/Pine/PersistenceFaultInjection.swift
+++ b/Pine/PersistenceFaultInjection.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if DEBUG
+import Darwin
+#endif
 
 nonisolated enum PersistenceStoreKind: String, CaseIterable, Sendable {
     case preferences
@@ -100,6 +103,9 @@ nonisolated struct PersistenceFaultInjector: Sendable {
         return PersistenceFaultInjector { store, phase in
             guard store == fault.store,
                   phase == fault.phase else { return }
+            if fault.failure == .interrupted {
+                PersistenceProcessInterruption.terminate(at: fault)
+            }
             throw fault.failure
         }
         #else
@@ -107,6 +113,42 @@ nonisolated struct PersistenceFaultInjector: Sendable {
         #endif
     }()
 }
+
+#if DEBUG
+/// Turns the explicit process-level `interrupted` fault into the crash that
+/// the release gate needs to exercise. Unit fault plans still throw
+/// `.interrupted` normally; only the launched app's opt-in environment path
+/// can terminate the process.
+nonisolated private enum PersistenceProcessInterruption {
+    static func terminate(at fault: PersistenceFault) -> Never {
+        writeDurableDiagnostic(fault.encoded)
+        _ = Darwin.kill(Darwin.getpid(), SIGKILL)
+        fatalError("SIGKILL failed for persistence interruption fixture")
+    }
+
+    private static func writeDurableDiagnostic(_ diagnostic: String) {
+        guard let directory = ProcessInfo.processInfo.environment[
+            "PINE_LIFECYCLE_DIAGNOSTICS_DIRECTORY"
+        ], directory.hasPrefix("/") else { return }
+        let path = URL(fileURLWithPath: directory, isDirectory: true)
+            .appendingPathComponent("persistence-interruption.log")
+            .path
+        let descriptor = Darwin.open(
+            path,
+            O_WRONLY | O_CREAT | O_APPEND,
+            S_IRUSR | S_IWUSR
+        )
+        guard descriptor >= 0 else { return }
+        defer { _ = Darwin.close(descriptor) }
+        let bytes = Array("\(diagnostic)\n".utf8)
+        bytes.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else { return }
+            _ = Darwin.write(descriptor, baseAddress, buffer.count)
+        }
+        _ = Darwin.fsync(descriptor)
+    }
+}
+#endif
 
 /// Thread-safe, ordered, one-shot fault plan. Unrelated checkpoints cannot
 /// consume the next planned injection.

--- a/Pine/PersistenceFaultInjection.swift
+++ b/Pine/PersistenceFaultInjection.swift
@@ -100,9 +100,15 @@ nonisolated struct PersistenceFaultInjector: Sendable {
         let fault = PersistenceFault(encoded: encoded) else {
             return .none
         }
+        let armFile = ProcessInfo.processInfo.environment[
+            "PINE_PERSISTENCE_FAULT_ARM_FILE"
+        ].map { URL(fileURLWithPath: $0).standardizedFileURL }
         return PersistenceFaultInjector { store, phase in
             guard store == fault.store,
-                  phase == fault.phase else { return }
+                  phase == fault.phase,
+                  armFile.map({
+                      FileManager.default.fileExists(atPath: $0.path)
+                  }) ?? true else { return }
             if fault.failure == .interrupted {
                 PersistenceProcessInterruption.terminate(at: fault)
             }

--- a/PineUITests/ApplicationLifecycleProcessTests.swift
+++ b/PineUITests/ApplicationLifecycleProcessTests.swift
@@ -207,9 +207,12 @@ final class ApplicationLifecycleProcessTests: PineUITestCase {
             timeout: 5
         )
         let generation = try captureOwnedGeneration(1)
-        try Data().write(to: faultArmURL, options: .atomic)
         requestQuit()
-        clickButton("Quit Anyway")
+        let quitAnywayButton = waitForSheetButton("Quit Anyway")
+        // Arm only after the human decision is visible. Session autosaves
+        // before this point must not consume the controlled crash checkpoint.
+        try Data().write(to: faultArmURL, options: .atomic)
+        quitAnywayButton.click()
 
         XCTAssertTrue(
             waitForProcessToStop(pineProcessIdentifier, timeout: 15),
@@ -300,12 +303,27 @@ final class ApplicationLifecycleProcessTests: PineUITestCase {
         _ title: String,
         timeout: TimeInterval = 10
     ) {
-        let button = app.buttons[title].firstMatch
+        waitForSheetButton(title, timeout: timeout).click()
+    }
+
+    private func waitForSheetButton(
+        _ title: String,
+        timeout: TimeInterval = 10
+    ) -> XCUIElement {
+        // Scope the query to the visible sheet. A process-wide button query
+        // can resolve macOS's mirrored Touch Bar item before the real alert
+        // button, and XCUITest cannot click that synthetic element.
+        let sheet = app.sheets.firstMatch
+        XCTAssertTrue(
+            sheet.waitForExistence(timeout: timeout),
+            "Expected a sheet containing the \(title) button"
+        )
+        let button = sheet.buttons[title].firstMatch
         XCTAssertTrue(
             button.waitForExistence(timeout: timeout),
             "Expected \(title) button"
         )
-        button.click()
+        return button
     }
 
     private func terminalTab(_ name: String) -> XCUIElement {

--- a/PineUITests/ApplicationLifecycleProcessTests.swift
+++ b/PineUITests/ApplicationLifecycleProcessTests.swift
@@ -1,0 +1,442 @@
+//
+//  ApplicationLifecycleProcessTests.swift
+//  PineUITests
+//
+//  Real-process release gate for Quit, failure recovery, crash, and relaunch.
+//
+
+import Darwin
+import XCTest
+
+final class ApplicationLifecycleProcessTests: PineUITestCase {
+    private let bundleID = "io.github.batonogov.pine"
+    private var projectURL: URL!
+    private var diagnosticsURL: URL!
+    private var seededSessionKey: String?
+    private var ownedProcessIdentifiers: [pid_t] = []
+    private var unrelatedProcess: Process?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        projectURL = try createTempProject(
+            files: [
+                "Sources/App.swift": "let committed = true\n",
+                "dirty.swift": "let lifecycleFixtureIsDirty = false\n",
+            ],
+            projectName: "Pine Lifecycle Fixture"
+        )
+        diagnosticsURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "PineLifecycleDiagnostics-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: diagnosticsURL,
+            withIntermediateDirectories: true
+        )
+    }
+
+    override func tearDownWithError() throws {
+        attachDiagnostics()
+        if app.state != .notRunning {
+            app.terminate()
+            _ = waitForApplicationToStop(timeout: 5)
+        }
+        for processIdentifier in ownedProcessIdentifiers {
+            let stopped = waitForProcessToStop(
+                processIdentifier,
+                timeout: 3
+            )
+            if !stopped {
+                _ = Darwin.kill(processIdentifier, SIGKILL)
+            }
+            XCTAssertTrue(
+                stopped,
+                "Pine-owned child \(processIdentifier) survived teardown"
+            )
+        }
+        if let unrelatedProcess, unrelatedProcess.isRunning {
+            unrelatedProcess.terminate()
+            unrelatedProcess.waitUntilExit()
+        }
+        if let seededSessionKey {
+            try? runDefaults(["delete", bundleID, seededSessionKey])
+        }
+        if let projectURL {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: projectURL.path
+            )
+            cleanupProject(projectURL)
+        }
+        if let diagnosticsURL {
+            try? FileManager.default.removeItem(at: diagnosticsURL)
+        }
+        try super.tearDownWithError()
+    }
+
+    func testCleanQuitStopsTheRealApplicationProcess() throws {
+        launchWithProject(projectURL)
+        requestQuit()
+
+        XCTAssertTrue(
+            waitForApplicationToStop(timeout: 10),
+            "A clean project should quit without a confirmation sheet"
+        )
+        recordPhase("clean-quit-completed")
+    }
+
+    func testCancelGenerationFailureAndRetryPreserveOwnership() throws {
+        try launchLifecycleFixture()
+        let firstGeneration = try captureOwnedGeneration(1)
+        let unrelated = try launchUnrelatedProcess()
+
+        requestQuit()
+        clickButton("Cancel")
+        recordPhase("quit-cancelled")
+        XCTAssertNotEqual(app.state, .notRunning)
+        XCTAssertTrue(isProcessAlive(firstGeneration.parent))
+        XCTAssertTrue(isProcessAlive(firstGeneration.child))
+        XCTAssertTrue(isProcessAlive(unrelated.processIdentifier))
+        let dirtyTab = editorTab("dirty.swift")
+        dirtyTab.click()
+        XCTAssertTrue(
+            dirtyTab.isSelected,
+            "Cancelled Quit should return the editor to usable input"
+        )
+
+        requestQuit()
+        XCTAssertTrue(
+            app.buttons["Quit Anyway"].firstMatch.waitForExistence(
+                timeout: 10
+            )
+        )
+        try Data().write(
+            to: diagnosticsURL.appendingPathComponent(
+                "request-next-generation"
+            ),
+            options: .atomic
+        )
+        let secondGeneration = try captureOwnedGeneration(2)
+        clickButton("Quit Anyway")
+        XCTAssertTrue(
+            app.staticTexts["Pine Couldn’t Quit"].firstMatch
+                .waitForExistence(timeout: 15),
+            "A process generation born under the sheet must invalidate Quit"
+        )
+        recordPhase("new-generation-rejected")
+        clickButton("OK")
+        XCTAssertNotEqual(app.state, .notRunning)
+
+        try setProjectPermissions(0o555)
+        requestReviewedSaveAndTerminalShutdown()
+        XCTAssertTrue(
+            app.staticTexts["Error"].firstMatch
+                .waitForExistence(timeout: 15),
+            "A denied save should fail closed and return control to Pine"
+        )
+        recordPhase("save-failure-returned")
+        clickButton("OK")
+        XCTAssertNotEqual(app.state, .notRunning)
+
+        try setProjectPermissions(0o755)
+        requestReviewedSaveAndTerminalShutdown()
+        XCTAssertTrue(
+            waitForApplicationToStop(timeout: 15),
+            "Retrying after the save failure should complete Quit"
+        )
+        recordPhase("quit-retry-completed")
+        XCTAssertEqual(
+            try String(
+                contentsOf: projectURL.appendingPathComponent("dirty.swift"),
+                encoding: .utf8
+            ),
+            "let lifecycleFixtureIsDirty = true\n"
+        )
+        for processIdentifier in [
+            firstGeneration.parent,
+            firstGeneration.child,
+            secondGeneration.parent,
+            secondGeneration.child,
+        ] {
+            XCTAssertTrue(
+                waitForProcessToStop(processIdentifier, timeout: 5),
+                "Confirmed Quit should stop owned process \(processIdentifier)"
+            )
+        }
+        XCTAssertTrue(
+            isProcessAlive(unrelated.processIdentifier),
+            "Confirmed Quit must leave an unrelated process untouched"
+        )
+    }
+
+    func testInterruptedSessionWriteRelaunchesLastCommittedState() throws {
+        app.launchArguments.removeAll { $0 == "--reset-state" }
+        try seedVersionedSessionFixture()
+        app.launchArguments.append("--ui-test-lifecycle-process")
+        app.launchEnvironment[
+            "PINE_LIFECYCLE_DIAGNOSTICS_DIRECTORY"
+        ] = diagnosticsURL.path
+        app.launchEnvironment["PINE_LIFECYCLE_FIXTURE_DIRTY"] = "0"
+        app.launchEnvironment["PINE_PERSISTENCE_FAULT"] = [
+            "session",
+            "before-atomic-replace",
+            "interrupted",
+        ].joined(separator: ":")
+
+        launchWithProject(projectURL)
+        XCTAssertTrue(
+            editorTab("App.swift").waitForExistence(timeout: 15),
+            "The last committed fixture should restore before interruption"
+        )
+        let generation = try captureOwnedGeneration(1)
+        requestQuit()
+        clickButton("Quit Anyway")
+
+        XCTAssertTrue(
+            waitForApplicationToStop(timeout: 15),
+            "The controlled checkpoint should kill the real Pine process"
+        )
+        XCTAssertTrue(
+            waitForDiagnostic(
+                named: "persistence-interruption.log",
+                containing: "session:before-atomic-replace:interrupted",
+                timeout: 5
+            ),
+            "The crash artifact should identify only the controlled phase"
+        )
+        recordPhase("process-interrupted")
+        XCTAssertTrue(waitForProcessToStop(generation.parent, timeout: 5))
+        XCTAssertTrue(waitForProcessToStop(generation.child, timeout: 5))
+
+        app.launchArguments.removeAll {
+            $0 == "--ui-test-lifecycle-process"
+        }
+        app.launchEnvironment.removeValue(forKey: "PINE_PERSISTENCE_FAULT")
+        app.launchEnvironment.removeValue(
+            forKey: "PINE_LIFECYCLE_FIXTURE_DIRTY"
+        )
+        launchWithProject(projectURL)
+
+        XCTAssertTrue(
+            editorTab("App.swift").waitForExistence(timeout: 15),
+            "Relaunch should restore the last fully committed session"
+        )
+        XCTAssertFalse(
+            editorTab("dirty.swift").exists,
+            "A partial replacement must never become authoritative"
+        )
+        XCTAssertFalse(
+            terminalTab("Terminal 1").exists,
+            "Relaunch must not revive stale process ownership"
+        )
+        recordPhase("relaunch-restored-last-commit")
+    }
+
+    private func launchLifecycleFixture() throws {
+        app.launchArguments.removeAll { $0 == "--reset-state" }
+        app.launchArguments.append("--ui-test-lifecycle-process")
+        app.launchEnvironment[
+            "PINE_LIFECYCLE_DIAGNOSTICS_DIRECTORY"
+        ] = diagnosticsURL.path
+        launchWithProject(projectURL)
+        XCTAssertTrue(editorTab("dirty.swift").waitForExistence(timeout: 15))
+        XCTAssertTrue(terminalTab("Terminal 1").waitForExistence(timeout: 15))
+    }
+
+    private func requestQuit() {
+        let appMenu = app.menuBars.menuBarItems["Pine"]
+        XCTAssertTrue(appMenu.waitForExistence(timeout: 10))
+        appMenu.click()
+        let quit = app.menuItems["Quit Pine"].firstMatch
+        XCTAssertTrue(quit.waitForExistence(timeout: 5))
+        quit.click()
+    }
+
+    private func requestReviewedSaveAndTerminalShutdown() {
+        requestQuit()
+        clickButton("Review…")
+        clickButton("Save All")
+        clickButton("Quit")
+    }
+
+    private func clickButton(
+        _ title: String,
+        timeout: TimeInterval = 10
+    ) {
+        let button = app.buttons[title].firstMatch
+        XCTAssertTrue(
+            button.waitForExistence(timeout: timeout),
+            "Expected \(title) button"
+        )
+        button.click()
+    }
+
+    private func terminalTab(_ name: String) -> XCUIElement {
+        app.descendants(matching: .any)["terminalTab_\(name)"].firstMatch
+    }
+
+    private func captureOwnedGeneration(
+        _ generation: Int
+    ) throws -> (parent: pid_t, child: pid_t) {
+        let parent = try waitForPID(
+            named: "owned-\(generation).pid",
+            timeout: 15
+        )
+        let child = try waitForPID(
+            named: "owned-\(generation)-child.pid",
+            timeout: 15
+        )
+        ownedProcessIdentifiers.append(contentsOf: [parent, child])
+        XCTAssertTrue(isProcessAlive(parent))
+        XCTAssertTrue(isProcessAlive(child))
+        return (parent, child)
+    }
+
+    private func waitForPID(
+        named name: String,
+        timeout: TimeInterval
+    ) throws -> pid_t {
+        let url = diagnosticsURL.appendingPathComponent(name)
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if let value = try? String(contentsOf: url, encoding: .utf8),
+               let processIdentifier = pid_t(value.trimmingCharacters(
+                   in: .whitespacesAndNewlines
+               )), processIdentifier > 0 {
+                return processIdentifier
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        } while Date() < deadline
+        throw CocoaError(.fileReadNoSuchFile)
+    }
+
+    private func launchUnrelatedProcess() throws -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            "trap 'exit 0' HUP INT TERM; while :; do /bin/sleep 60; done",
+        ]
+        try process.run()
+        unrelatedProcess = process
+        return process
+    }
+
+    private func setProjectPermissions(_ permissions: Int) throws {
+        try FileManager.default.setAttributes(
+            [.posixPermissions: permissions],
+            ofItemAtPath: projectURL.path
+        )
+    }
+
+    private func isProcessAlive(_ processIdentifier: pid_t) -> Bool {
+        errno = 0
+        return Darwin.kill(processIdentifier, 0) == 0 || errno == EPERM
+    }
+
+    private func waitForProcessToStop(
+        _ processIdentifier: pid_t,
+        timeout: TimeInterval
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while isProcessAlive(processIdentifier), Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        return !isProcessAlive(processIdentifier)
+    }
+
+    private func waitForApplicationToStop(
+        timeout: TimeInterval
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while app.state != .notRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        return app.state == .notRunning
+    }
+
+    private func waitForDiagnostic(
+        named name: String,
+        containing expected: String,
+        timeout: TimeInterval
+    ) -> Bool {
+        let url = diagnosticsURL.appendingPathComponent(name)
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if let text = try? String(contentsOf: url, encoding: .utf8),
+               text.contains(expected) {
+                return true
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        } while Date() < deadline
+        return false
+    }
+
+    private func seedVersionedSessionFixture() throws {
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent(
+                "PineTests/Fixtures/Persistence/session-v0.json"
+            )
+        let fixture = try String(
+            contentsOf: fixtureURL,
+            encoding: .utf8
+        ).replacingOccurrences(
+            of: "{{PROJECT_PATH}}",
+            with: projectURL.resolvingSymlinksInPath().path
+        )
+        let hex = Data(fixture.utf8).map {
+            String(format: "%02x", $0)
+        }.joined()
+        let key = "sessionState:\(projectURL.resolvingSymlinksInPath().path)"
+        try runDefaults(["write", bundleID, key, "-data", hex])
+        seededSessionKey = key
+    }
+
+    private func runDefaults(_ arguments: [String]) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        process.arguments = arguments
+        var environment = ProcessInfo.processInfo.environment
+        environment["DEVELOPER_DIR"] = environment["DEVELOPER_DIR"]
+            ?? "/Applications/Xcode.app/Contents/Developer"
+        process.environment = environment
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+    }
+
+    private func attachDiagnostics() {
+        for name in ["phases.log", "persistence-interruption.log"] {
+            let url = diagnosticsURL?.appendingPathComponent(name)
+            guard let url,
+                  let text = try? String(contentsOf: url, encoding: .utf8)
+            else { continue }
+            let attachment = XCTAttachment(string: text)
+            attachment.name = name
+            attachment.lifetime = .keepAlways
+            add(attachment)
+        }
+    }
+
+    private func recordPhase(_ phase: String) {
+        let path = diagnosticsURL.appendingPathComponent("phases.log").path
+        let descriptor = Darwin.open(
+            path,
+            O_WRONLY | O_CREAT | O_APPEND,
+            S_IRUSR | S_IWUSR
+        )
+        guard descriptor >= 0 else { return }
+        defer { _ = Darwin.close(descriptor) }
+        let bytes = Array("\(phase)\n".utf8)
+        bytes.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else { return }
+            _ = Darwin.write(descriptor, baseAddress, buffer.count)
+        }
+        _ = Darwin.fsync(descriptor)
+    }
+}

--- a/PineUITests/ApplicationLifecycleProcessTests.swift
+++ b/PineUITests/ApplicationLifecycleProcessTests.swift
@@ -76,11 +76,15 @@ final class ApplicationLifecycleProcessTests: PineUITestCase {
     }
 
     func testCleanQuitStopsTheRealApplicationProcess() throws {
-        launchWithProject(projectURL)
+        try launchLifecycleFixture(dirty: false, terminal: false)
+        let pineProcessIdentifier = try waitForPID(
+            named: "pine.pid",
+            timeout: 5
+        )
         requestQuit()
 
         XCTAssertTrue(
-            waitForApplicationToStop(timeout: 10),
+            waitForProcessToStop(pineProcessIdentifier, timeout: 35),
             "A clean project should quit without a confirmation sheet"
         )
         recordPhase("clean-quit-completed")
@@ -88,6 +92,10 @@ final class ApplicationLifecycleProcessTests: PineUITestCase {
 
     func testCancelGenerationFailureAndRetryPreserveOwnership() throws {
         try launchLifecycleFixture()
+        let pineProcessIdentifier = try waitForPID(
+            named: "pine.pid",
+            timeout: 5
+        )
         let firstGeneration = try captureOwnedGeneration(1)
         let unrelated = try launchUnrelatedProcess()
 
@@ -142,7 +150,7 @@ final class ApplicationLifecycleProcessTests: PineUITestCase {
         try setProjectPermissions(0o755)
         requestReviewedSaveAndTerminalShutdown()
         XCTAssertTrue(
-            waitForApplicationToStop(timeout: 15),
+            waitForProcessToStop(pineProcessIdentifier, timeout: 35),
             "Retrying after the save failure should complete Quit"
         )
         recordPhase("quit-retry-completed")
@@ -183,18 +191,28 @@ final class ApplicationLifecycleProcessTests: PineUITestCase {
             "before-atomic-replace",
             "interrupted",
         ].joined(separator: ":")
+        let faultArmURL = diagnosticsURL.appendingPathComponent(
+            "arm-persistence-fault"
+        )
+        app.launchEnvironment["PINE_PERSISTENCE_FAULT_ARM_FILE"] =
+            faultArmURL.path
 
         launchWithProject(projectURL)
         XCTAssertTrue(
             editorTab("App.swift").waitForExistence(timeout: 15),
             "The last committed fixture should restore before interruption"
         )
+        let pineProcessIdentifier = try waitForPID(
+            named: "pine.pid",
+            timeout: 5
+        )
         let generation = try captureOwnedGeneration(1)
+        try Data().write(to: faultArmURL, options: .atomic)
         requestQuit()
         clickButton("Quit Anyway")
 
         XCTAssertTrue(
-            waitForApplicationToStop(timeout: 15),
+            waitForProcessToStop(pineProcessIdentifier, timeout: 15),
             "The controlled checkpoint should kill the real Pine process"
         )
         XCTAssertTrue(
@@ -213,6 +231,9 @@ final class ApplicationLifecycleProcessTests: PineUITestCase {
             $0 == "--ui-test-lifecycle-process"
         }
         app.launchEnvironment.removeValue(forKey: "PINE_PERSISTENCE_FAULT")
+        app.launchEnvironment.removeValue(
+            forKey: "PINE_PERSISTENCE_FAULT_ARM_FILE"
+        )
         app.launchEnvironment.removeValue(
             forKey: "PINE_LIFECYCLE_FIXTURE_DIRTY"
         )
@@ -233,15 +254,30 @@ final class ApplicationLifecycleProcessTests: PineUITestCase {
         recordPhase("relaunch-restored-last-commit")
     }
 
-    private func launchLifecycleFixture() throws {
+    private func launchLifecycleFixture(
+        dirty: Bool = true,
+        terminal: Bool = true
+    ) throws {
         app.launchArguments.removeAll { $0 == "--reset-state" }
         app.launchArguments.append("--ui-test-lifecycle-process")
         app.launchEnvironment[
             "PINE_LIFECYCLE_DIAGNOSTICS_DIRECTORY"
         ] = diagnosticsURL.path
+        app.launchEnvironment["PINE_LIFECYCLE_FIXTURE_DIRTY"] =
+            dirty ? "1" : "0"
+        app.launchEnvironment["PINE_LIFECYCLE_FIXTURE_TERMINAL"] =
+            terminal ? "1" : "0"
         launchWithProject(projectURL)
-        XCTAssertTrue(editorTab("dirty.swift").waitForExistence(timeout: 15))
-        XCTAssertTrue(terminalTab("Terminal 1").waitForExistence(timeout: 15))
+        if dirty {
+            XCTAssertTrue(
+                editorTab("dirty.swift").waitForExistence(timeout: 15)
+            )
+        }
+        if terminal {
+            XCTAssertTrue(
+                terminalTab("Terminal 1").waitForExistence(timeout: 15)
+            )
+        }
     }
 
     private func requestQuit() {


### PR DESCRIPTION
Closes #1437

## Summary
- add a DEBUG-only lifecycle driver that prepares real dirty editor state and terminal PTY generations
- add deterministic durable persistence crash injection before SIGKILL
- cover quit, crash recovery, and relaunch with real application processes
- retain lifecycle diagnostics from the Navigation CI shard

## Validation
- SwiftLint
- UI shard validator unit tests
- UI shard membership and balance check (39 classes / 230 tests, delta 3)
- build-for-testing and relevant unit suites passed before the clean rebase onto current main
- UI tests not run locally per request; required CI shards will provide UI coverage