### PR TITLE
test(terminal): add deterministic PTY process-tree harness

### DIFF
--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -155,7 +155,7 @@ final class SidebarKeyboardFocusController {
     /// A disclosure change can rebuild the SwiftUI host after an AppKit focus
     /// claim has already succeeded. Keep the retry window bounded, but cover
     /// both the next run loop and the later reconciliation pass.
-    private static let focusRetryDelays: [TimeInterval] = [0, 0.1]
+    private static let focusRetryDelays: [TimeInterval] = [0, 0.1, 0.5]
 
     private weak var responderView: SidebarKeyboardResponderView?
     private(set) var isFocused = false

--- a/Pine/TerminalProcessTreeController.swift
+++ b/Pine/TerminalProcessTreeController.swift
@@ -1,0 +1,181 @@
+//
+//  TerminalProcessTreeController.swift
+//  Pine
+//
+
+import Darwin
+import Dispatch
+import Foundation
+import os
+
+/// Owns the exact process generation launched for one terminal tab.
+///
+/// SwiftTerm closes the PTY and sends `SIGTERM` to only its direct child.
+/// Interactive jobs normally move into separate foreground process groups,
+/// and background children can outlive that shell. This controller samples
+/// the identity-qualified descendant tree while the tab is alive, then runs a
+/// bounded TERM-to-KILL cleanup away from the main actor. Start timestamps in
+/// the shared process inspectors prevent PID/PGID reuse from redirecting a
+/// signal to an unrelated process.
+nonisolated final class TerminalProcessTreeController: @unchecked Sendable {
+    private static let captureInterval: DispatchTimeInterval = .milliseconds(25)
+    private static let captureLeeway: DispatchTimeInterval = .milliseconds(5)
+    private static let completionWaitPeriod: TimeInterval = 2.0
+    private static let deferredCleanupQueue = DispatchQueue(
+        label: "com.pine.terminal-process-tree.deferred-cleanup",
+        qos: .utility,
+        attributes: .concurrent
+    )
+
+    let rootIdentity: UserTaskProcessIdentity
+    let processGroupIdentifier: pid_t?
+
+    private let stateQueue: DispatchQueue
+    private let processGroup: UserTaskProcessGroup?
+    private let descendantTracker: UserTaskDescendantTracker
+    private let lock = NSLock()
+    private let terminationCompletion = DispatchGroup()
+    private var captureTimer: DispatchSourceTimer?
+    private var terminationRequested = false
+    private var terminationFinished = false
+    private var terminationSucceeded = true
+
+    init?(rootProcessID: pid_t) {
+        guard let rootIdentity = UserTaskProcessInspector.identity(
+            for: rootProcessID
+        ) else {
+            return nil
+        }
+
+        self.rootIdentity = rootIdentity
+        // `forkpty` makes its child a session and process-group leader. Never
+        // claim a broader inherited group if a future SwiftTerm path changes
+        // that invariant; individual descendant identities remain safe.
+        let observedGroup = Darwin.getpgid(rootProcessID)
+        if observedGroup == rootProcessID {
+            processGroupIdentifier = observedGroup
+            processGroup = UserTaskProcessGroup(identifier: observedGroup)
+        } else {
+            processGroupIdentifier = nil
+            processGroup = nil
+        }
+        descendantTracker = UserTaskDescendantTracker(
+            rootProcessID: rootProcessID
+        )
+        stateQueue = DispatchQueue(
+            label: "com.pine.terminal-process-tree.\(rootProcessID)",
+            qos: .utility
+        )
+
+        let timer = DispatchSource.makeTimerSource(queue: stateQueue)
+        timer.schedule(
+            deadline: .now(),
+            repeating: Self.captureInterval,
+            leeway: Self.captureLeeway
+        )
+        timer.setEventHandler { [weak self] in
+            self?.captureOwnedProcesses()
+        }
+        captureTimer = timer
+        timer.activate()
+    }
+
+    /// Starts teardown exactly once without blocking the main actor.
+    func requestTermination() {
+        let shouldStart = lock.withLock {
+            guard !terminationRequested else { return false }
+            terminationRequested = true
+            terminationCompletion.enter()
+            return true
+        }
+        guard shouldStart else { return }
+
+        stateQueue.async { [self] in
+            captureTimer?.cancel()
+            captureTimer = nil
+            captureOwnedProcesses()
+
+            processGroup?.requestTermination(
+                beforeMemberCapture: { [descendantTracker] in
+                    descendantTracker.captureDescendants()
+                }
+            )
+            let descendantsStopped = descendantTracker
+                .terminateTrackedProcesses()
+            reapRootAfterTerminationRequest()
+            let groupStopped = processGroup?
+                .waitForRequestedTermination() ?? true
+            let succeeded = descendantsStopped && groupStopped
+
+            lock.withLock {
+                terminationSucceeded = succeeded
+                terminationFinished = true
+            }
+            terminationCompletion.leave()
+
+            guard !succeeded else { return }
+            Logger.terminal.error(
+                "Terminal process-tree cleanup exceeded its bounded phase for root \(self.rootIdentity.processID)"
+            )
+            Self.deferredCleanupQueue.async { [processGroup] in
+                processGroup?.finishDeferredCleanup()
+            }
+            Self.deferredCleanupQueue.async { [descendantTracker] in
+                descendantTracker.finishDeferredCleanup()
+            }
+        }
+    }
+
+    /// Waits only on a caller-selected background thread. Production teardown
+    /// is asynchronous; integration tests use this to place a hard bound on
+    /// process and descriptor leak assertions.
+    func waitForTermination(
+        timeout: TimeInterval = completionWaitPeriod
+    ) -> Bool {
+        let state = lock.withLock {
+            (
+                requested: terminationRequested,
+                finished: terminationFinished,
+                succeeded: terminationSucceeded
+            )
+        }
+        guard state.requested else { return true }
+        if state.finished { return state.succeeded }
+        guard terminationCompletion.wait(
+            timeout: .now() + max(timeout, 0)
+        ) == .success else {
+            return false
+        }
+        return lock.withLock { terminationSucceeded }
+    }
+
+    private func captureOwnedProcesses() {
+        processGroup?.captureKnownMembers()
+        descendantTracker.captureDescendants()
+    }
+
+    /// SwiftTerm's explicit `terminate()` cancels its process monitor before
+    /// the monitor can call `waitpid`, so Pine becomes responsible for reaping
+    /// that exact direct child. `waitpid` cannot target an unrelated reused
+    /// PID: after the owned child is reaped it returns `ECHILD` instead.
+    private func reapRootAfterTerminationRequest() {
+        let deadline = DispatchTime.now() + Self.completionWaitPeriod
+        var status: Int32 = 0
+        repeat {
+            let result = Darwin.waitpid(
+                rootIdentity.processID,
+                &status,
+                WNOHANG
+            )
+            if result == rootIdentity.processID
+                || (result == -1 && errno == ECHILD) {
+                return
+            }
+            Darwin.usleep(10_000)
+        } while DispatchTime.now() < deadline
+    }
+
+    deinit {
+        captureTimer?.cancel()
+    }
+}

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -1882,6 +1882,9 @@ final class TerminalTab: Identifiable, Hashable {
     private let shellSettings: ShellSettings
     private let agentHandoffSettings: AgentHandoffSettings
     private var processStarted = false
+    /// Identity-qualified ownership for the exact shell generation and every
+    /// observed descendant launched through this tab's real PTY.
+    private var processTreeController: TerminalProcessTreeController?
     private var processStartValidationTask: Task<Void, Never>?
     private var processStartValidationGeneration = UUID()
     private var workingDirectoryValidator:
@@ -2237,6 +2240,9 @@ final class TerminalTab: Identifiable, Hashable {
             execName: nil,
             currentDirectory: dir
         )
+        processTreeController = TerminalProcessTreeController(
+            rootProcessID: terminalView.process.shellPid
+        )
         _ = acknowledgedPTYLease.acquire(
             borrowing: terminalView.process.childfd
         )
@@ -2252,6 +2258,7 @@ final class TerminalTab: Identifiable, Hashable {
         processStartValidationGeneration = UUID()
         processStartValidationTask?.cancel()
         processStartValidationTask = nil
+        processTreeController?.requestTermination()
         acknowledgedPTYLease.invalidate()
         terminalView.terminate()
     }
@@ -2261,6 +2268,7 @@ final class TerminalTab: Identifiable, Hashable {
             didReportLifecycleEnd = true
             onLifecycleEnded?(id)
         }
+        processTreeController?.requestTermination()
         isTerminated = true
         acknowledgedPTYLease.invalidate()
     }
@@ -2613,6 +2621,10 @@ final class TerminalTab: Identifiable, Hashable {
     #if DEBUG
     var hasAcknowledgedPTYLeaseForTesting: Bool {
         acknowledgedPTYLease.isActiveForTesting
+    }
+
+    var processTreeControllerForTesting: TerminalProcessTreeController? {
+        processTreeController
     }
     #endif
 

--- a/PineTests/Fixtures/Terminal/pty-process-tree.sh
+++ b/PineTests/Fixtures/Terminal/pty-process-tree.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+
+# Deterministic, network-free PTY fixture for terminal lifecycle tests.
+# The trace contains process identities and phases only. It deliberately never
+# records terminal input/output, the environment, prompts, or credentials.
+
+set -u
+
+scenario="${1:-}"
+trace_file="${2:-}"
+
+if [ -z "$scenario" ] || [ -z "$trace_file" ]; then
+  exit 64
+fi
+
+umask 077
+: > "$trace_file"
+
+record_phase() {
+  phase="$1"
+  process_id="$2"
+  process_group=$(/bin/ps -o pgid= -p "$process_id" 2>/dev/null | /usr/bin/tr -d ' ')
+  printf 'phase=%s pid=%s pgid=%s\n' \
+    "$phase" "$process_id" "${process_group:-0}" >> "$trace_file"
+}
+
+announce_ready() {
+  record_phase ready "$$"
+  printf 'PINE_PTY_FIXTURE_READY:%s\n' "$scenario"
+}
+
+spawn_ignoring_child() {
+  /bin/sh -c 'trap "" HUP INT TERM; while :; do /bin/sleep 1; done' &
+  fixture_child=$!
+  record_phase child "$fixture_child"
+}
+
+case "$scenario" in
+  churn)
+    # Monitor mode gives the child its own process group. Moving it into the
+    # foreground exercises tcgetpgrp/PGID churn through SwiftTerm's real PTY.
+    set -m
+    /bin/sh -c 'trap "exit 0" HUP INT TERM; while :; do /bin/sleep 1; done' &
+    fixture_child=$!
+    record_phase foreground-child "$fixture_child"
+    announce_ready
+    fg %1 || true
+    record_phase foreground-returned "$$"
+    printf 'PINE_PTY_FIXTURE_FOREGROUND_RETURNED\n'
+    while IFS= read -r command; do
+      [ "$command" = "exit" ] && exit 0
+    done
+    ;;
+
+  tree)
+    set -m
+    spawn_ignoring_child
+    announce_ready
+    while IFS= read -r command; do
+      case "$command" in
+        replace)
+          /bin/kill -KILL "$fixture_child" 2>/dev/null || true
+          wait "$fixture_child" 2>/dev/null || true
+          record_phase replaced "$fixture_child"
+          spawn_ignoring_child
+          record_phase replacement "$fixture_child"
+          printf 'PINE_PTY_FIXTURE_REPLACED\n'
+          ;;
+        exit-success)
+          record_phase natural-success "$$"
+          exit 0
+          ;;
+        exit-failure)
+          record_phase natural-failure "$$"
+          exit 17
+          ;;
+      esac
+    done
+    ;;
+
+  stream)
+    # Split both UTF-8 and ANSI control sequences across writes, then emit a
+    # bounded burst large enough to exercise DispatchIO backpressure.
+    line=0
+    while [ "$line" -lt 4096 ]; do
+      printf '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n'
+      line=$((line + 1))
+    done
+    printf '\342'
+    /bin/sleep 0.02
+    printf '\234\223'
+    printf '\033['
+    /bin/sleep 0.02
+    printf '32mSTREAM\033[0m\n'
+    record_phase stream-complete "$$"
+    printf 'PINE_PTY_FIXTURE_STREAM_COMPLETE\n'
+    announce_ready
+    while IFS= read -r command; do
+      [ "$command" = "exit" ] && exit 0
+    done
+    ;;
+
+  success)
+    announce_ready
+    exit 0
+    ;;
+
+  failure)
+    announce_ready
+    exit 17
+    ;;
+
+  *)
+    record_phase unsupported "$$"
+    exit 64
+    ;;
+esac

--- a/PineTests/SidebarAccessibilityHostedTests.swift
+++ b/PineTests/SidebarAccessibilityHostedTests.swift
@@ -182,6 +182,37 @@ struct SidebarAccessibilityHostedTests {
         #expect(window.firstResponder === responder)
     }
 
+    @Test("Row focus claim survives delayed accessibility activation")
+    func responderFocusRetryAfterDelayedAccessibilityActivation() async throws {
+        let controller = SidebarKeyboardFocusController()
+        let responder = SidebarKeyboardResponderView(
+            frame: NSRect(x: 0, y: 0, width: 1, height: 1)
+        )
+        let accessibilityTarget = SidebarFocusAcceptingTestView(
+            frame: NSRect(x: 0, y: 0, width: 1, height: 1)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 100),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(responder)
+        window.contentView?.addSubview(accessibilityTarget)
+        controller.attach(responder)
+        defer { window.orderOut(nil) }
+
+        #expect(controller.requestFocus(retryOnNextRunLoop: true))
+        try await Task.sleep(for: .milliseconds(250))
+        #expect(window.makeFirstResponder(accessibilityTarget))
+        #expect(!controller.isFocused)
+
+        try await Task.sleep(for: .milliseconds(350))
+
+        #expect(controller.isFocused)
+        #expect(window.firstResponder === responder)
+    }
+
     @Test("Explicit editor focus cancels a pending sidebar retry")
     func explicitEditorFocusCancelsSidebarRetry() async throws {
         let controller = SidebarKeyboardFocusController()

--- a/PineTests/TerminalPTYProcessTreeTests.swift
+++ b/PineTests/TerminalPTYProcessTreeTests.swift
@@ -110,9 +110,13 @@ private final class TerminalPTYFixtureHarness {
         )
         tab.startIfNeeded()
         guard tab.isProcessRunning else {
+            tab.stop()
+            try? FileManager.default.removeItem(at: directoryURL)
             throw PTYFixtureError.processDidNotStart
         }
         guard let controller = tab.processTreeControllerForTesting else {
+            tab.stop()
+            try? FileManager.default.removeItem(at: directoryURL)
             throw PTYFixtureError.processOwnershipUnavailable
         }
         self.controller = controller
@@ -310,6 +314,7 @@ struct TerminalPTYProcessTreeTests {
             ("exit-failure\n", "natural-failure"),
         ] {
             let harness = try TerminalPTYFixtureHarness(scenario: "tree")
+            defer { harness.cleanup() }
             let ready = try #require(await PTYFixtureTrace.wait(
                 for: "ready",
                 at: harness.traceURL
@@ -337,7 +342,6 @@ struct TerminalPTYProcessTreeTests {
             #expect(!PTYFixtureTrace.identityIsLive(rootIdentity))
             #expect(!PTYFixtureTrace.identityIsLive(childIdentity))
             #expect(!harness.tab.hasAcknowledgedPTYLeaseForTesting)
-            harness.cleanup()
         }
     }
 

--- a/PineTests/TerminalPTYProcessTreeTests.swift
+++ b/PineTests/TerminalPTYProcessTreeTests.swift
@@ -1,0 +1,356 @@
+//
+//  TerminalPTYProcessTreeTests.swift
+//  PineTests
+//
+
+import AppKit
+import Darwin
+import Foundation
+import Testing
+
+@testable import Pine
+
+nonisolated private struct PTYFixtureEvidence: Sendable {
+    let phase: String
+    let processID: pid_t
+    let processGroupID: pid_t
+    let identity: UserTaskProcessIdentity?
+}
+
+nonisolated private enum PTYFixtureError: Error {
+    case processDidNotStart
+    case processOwnershipUnavailable
+}
+
+nonisolated private enum PTYFixtureTrace {
+    static func wait(
+        for phase: String,
+        at url: URL,
+        timeout: TimeInterval = 3
+    ) async -> PTYFixtureEvidence? {
+        await Task.detached(priority: .utility) {
+            let deadline = DispatchTime.now() + timeout
+            repeat {
+                if let data = try? Data(contentsOf: url),
+                   let text = String(data: data, encoding: .utf8),
+                   let evidence = parse(phase: phase, text: text) {
+                    return evidence
+                }
+                Darwin.usleep(10_000)
+            } while DispatchTime.now() < deadline
+            return nil
+        }.value
+    }
+
+    static func identityIsLive(_ identity: UserTaskProcessIdentity) -> Bool {
+        UserTaskProcessInspector.identity(for: identity.processID) == identity
+    }
+
+    private static func parse(
+        phase: String,
+        text: String
+    ) -> PTYFixtureEvidence? {
+        for line in text.split(whereSeparator: { $0.isNewline }) {
+            var values: [Substring: Substring] = [:]
+            for field in line.split(separator: " ") {
+                let pair = field.split(separator: "=", maxSplits: 1)
+                guard pair.count == 2 else { continue }
+                values[pair[0]] = pair[1]
+            }
+            guard values["phase"] == Substring(phase),
+                  let processText = values["pid"],
+                  let groupText = values["pgid"],
+                  let processID = pid_t(processText),
+                  let processGroupID = pid_t(groupText) else {
+                continue
+            }
+            return PTYFixtureEvidence(
+                phase: phase,
+                processID: processID,
+                processGroupID: processGroupID,
+                identity: UserTaskProcessInspector.identity(for: processID)
+            )
+        }
+        return nil
+    }
+}
+
+@MainActor
+private final class TerminalPTYFixtureHarness {
+    let tab: TerminalTab
+    let traceURL: URL
+    let directoryURL: URL
+    let controller: TerminalProcessTreeController
+
+    init(scenario: String) throws {
+        directoryURL = FileManager.default.temporaryDirectory
+            .appending(path: "pine-pty-fixture-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true
+        )
+        traceURL = directoryURL.appending(path: "process.trace")
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appending(path: "Fixtures/Terminal/pty-process-tree.sh")
+
+        tab = TerminalTab(name: "PTY fixture")
+        tab.configure(
+            workingDirectory: directoryURL,
+            initialProcess: TerminalInitialProcess(
+                executablePath: "/bin/sh",
+                arguments: [fixtureURL.path, scenario, traceURL.path]
+            )
+        )
+        tab.terminalView.frame = NSRect(
+            x: 0,
+            y: 0,
+            width: 800,
+            height: 300
+        )
+        tab.startIfNeeded()
+        guard tab.isProcessRunning else {
+            throw PTYFixtureError.processDidNotStart
+        }
+        guard let controller = tab.processTreeControllerForTesting else {
+            throw PTYFixtureError.processOwnershipUnavailable
+        }
+        self.controller = controller
+    }
+
+    func waitForTerminalMarker(
+        _ marker: String,
+        timeout: TimeInterval = 3
+    ) async -> Bool {
+        let deadline = DispatchTime.now() + timeout
+        repeat {
+            await tab.search(for: marker)
+            if !tab.searchMatches.isEmpty { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        } while DispatchTime.now() < deadline
+        return false
+    }
+
+    func waitUntilTerminated(timeout: TimeInterval = 3) async -> Bool {
+        let deadline = DispatchTime.now() + timeout
+        repeat {
+            if tab.isTerminated { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        } while DispatchTime.now() < deadline
+        return tab.isTerminated
+    }
+
+    func stopAndWait(timeout: TimeInterval = 3) async -> Bool {
+        tab.stop()
+        return await Task.detached(priority: .utility) { [controller] in
+            controller.waitForTermination(timeout: timeout)
+        }.value
+    }
+
+    func cleanup() {
+        tab.stop()
+        try? FileManager.default.removeItem(at: directoryURL)
+    }
+}
+
+@Suite("Terminal PTY Process Tree", .serialized)
+@MainActor
+struct TerminalPTYProcessTreeTests {
+    @Test("foreground PGID churn retains the terminal's process generation")
+    func foregroundProcessGroupChurnRetainsOwnership() async throws {
+        let harness = try TerminalPTYFixtureHarness(scenario: "churn")
+        defer { harness.cleanup() }
+        let ready = try #require(await PTYFixtureTrace.wait(
+            for: "ready",
+            at: harness.traceURL
+        ))
+        let child = try #require(await PTYFixtureTrace.wait(
+            for: "foreground-child",
+            at: harness.traceURL
+        ))
+        let rootIdentity = try #require(ready.identity)
+        let childIdentity = try #require(child.identity)
+
+        #expect(rootIdentity == harness.controller.rootIdentity)
+        #expect(child.processGroupID > 1)
+        #expect(child.processGroupID != ready.processGroupID)
+        #expect(await harness.waitForTerminalMarker(
+            "PINE_PTY_FIXTURE_READY:churn"
+        ))
+        #expect(await waitForForegroundGroup(
+            child.processGroupID,
+            in: harness.tab
+        ))
+        #expect(harness.tab.isProcessRunning)
+        #expect(PTYFixtureTrace.identityIsLive(rootIdentity))
+        #expect(PTYFixtureTrace.identityIsLive(childIdentity))
+
+        try #require(harness.tab.sendText("\u{3}"))
+        #expect(await harness.waitForTerminalMarker(
+            "PINE_PTY_FIXTURE_FOREGROUND_RETURNED"
+        ))
+        #expect(harness.tab.isProcessRunning)
+        #expect(await harness.stopAndWait())
+        #expect(!PTYFixtureTrace.identityIsLive(rootIdentity))
+        #expect(!PTYFixtureTrace.identityIsLive(childIdentity))
+        #expect(!harness.tab.hasAcknowledgedPTYLeaseForTesting)
+    }
+
+    @Test("close escalates TERM to KILL for only the owned tree")
+    func closeStopsExactOwnedTree() async throws {
+        let unrelated = Process()
+        unrelated.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        unrelated.arguments = ["30"]
+        try unrelated.run()
+        let unrelatedIdentity = try #require(
+            UserTaskProcessInspector.identity(
+                for: unrelated.processIdentifier
+            )
+        )
+        defer {
+            if unrelated.isRunning {
+                unrelated.terminate()
+                unrelated.waitUntilExit()
+            }
+        }
+
+        let harness = try TerminalPTYFixtureHarness(scenario: "tree")
+        defer { harness.cleanup() }
+        let ready = try #require(await PTYFixtureTrace.wait(
+            for: "ready",
+            at: harness.traceURL
+        ))
+        let child = try #require(await PTYFixtureTrace.wait(
+            for: "child",
+            at: harness.traceURL
+        ))
+        let rootIdentity = try #require(ready.identity)
+        let childIdentity = try #require(child.identity)
+        #expect(child.processGroupID != ready.processGroupID)
+
+        // Let the periodic ownership sampler observe the independent child
+        // before closing the authorized terminal.
+        try? await Task.sleep(for: .milliseconds(75))
+        harness.tab.stop()
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(PTYFixtureTrace.identityIsLive(childIdentity))
+        let controller = harness.controller
+        let stopped = await Task.detached(priority: .utility) {
+            controller.waitForTermination(timeout: 3)
+        }.value
+
+        #expect(stopped)
+        #expect(!PTYFixtureTrace.identityIsLive(rootIdentity))
+        #expect(!PTYFixtureTrace.identityIsLive(childIdentity))
+        #expect(PTYFixtureTrace.identityIsLive(unrelatedIdentity))
+        #expect(!harness.tab.hasAcknowledgedPTYLeaseForTesting)
+    }
+
+    @Test("replacement records a new exact process generation")
+    func processReplacementChangesOwnedGeneration() async throws {
+        let harness = try TerminalPTYFixtureHarness(scenario: "tree")
+        defer { harness.cleanup() }
+        _ = try #require(await PTYFixtureTrace.wait(
+            for: "ready",
+            at: harness.traceURL
+        ))
+        let first = try #require(await PTYFixtureTrace.wait(
+            for: "child",
+            at: harness.traceURL
+        ))
+        let firstIdentity = try #require(first.identity)
+
+        try #require(harness.tab.sendText("replace\n"))
+        #expect(await harness.waitForTerminalMarker(
+            "PINE_PTY_FIXTURE_REPLACED"
+        ))
+        let replacement = try #require(await PTYFixtureTrace.wait(
+            for: "replacement",
+            at: harness.traceURL
+        ))
+        let replacementIdentity = try #require(replacement.identity)
+
+        #expect(firstIdentity != replacementIdentity)
+        #expect(!PTYFixtureTrace.identityIsLive(firstIdentity))
+        #expect(PTYFixtureTrace.identityIsLive(replacementIdentity))
+        try? await Task.sleep(for: .milliseconds(75))
+        #expect(await harness.stopAndWait())
+        #expect(!PTYFixtureTrace.identityIsLive(replacementIdentity))
+    }
+
+    @Test("partial UTF-8 and bounded output do not deadlock the PTY")
+    func partialUTF8AndBackpressureComplete() async throws {
+        let harness = try TerminalPTYFixtureHarness(scenario: "stream")
+        defer { harness.cleanup() }
+        let completed = try #require(await PTYFixtureTrace.wait(
+            for: "stream-complete",
+            at: harness.traceURL,
+            timeout: 5
+        ))
+        let rootIdentity = try #require(completed.identity)
+
+        #expect(await harness.waitForTerminalMarker(
+            "✓STREAM",
+            timeout: 5
+        ))
+        #expect(await harness.waitForTerminalMarker(
+            "PINE_PTY_FIXTURE_STREAM_COMPLETE",
+            timeout: 5
+        ))
+        #expect(harness.tab.isProcessRunning)
+        #expect(await harness.stopAndWait())
+        #expect(!PTYFixtureTrace.identityIsLive(rootIdentity))
+        #expect(!harness.tab.hasAcknowledgedPTYLeaseForTesting)
+    }
+
+    @Test("natural success and failure reclaim orphan-prone children")
+    func naturalExitPathsLeaveNoOwnedProcesses() async throws {
+        for (command, phase) in [
+            ("exit-success\n", "natural-success"),
+            ("exit-failure\n", "natural-failure"),
+        ] {
+            let harness = try TerminalPTYFixtureHarness(scenario: "tree")
+            let ready = try #require(await PTYFixtureTrace.wait(
+                for: "ready",
+                at: harness.traceURL
+            ))
+            let child = try #require(await PTYFixtureTrace.wait(
+                for: "child",
+                at: harness.traceURL
+            ))
+            let rootIdentity = try #require(ready.identity)
+            let childIdentity = try #require(child.identity)
+            try? await Task.sleep(for: .milliseconds(75))
+
+            try #require(harness.tab.sendText(command))
+            _ = try #require(await PTYFixtureTrace.wait(
+                for: phase,
+                at: harness.traceURL
+            ))
+            #expect(await harness.waitUntilTerminated())
+            let controller = harness.controller
+            let stopped = await Task.detached(priority: .utility) {
+                controller.waitForTermination(timeout: 3)
+            }.value
+
+            #expect(stopped)
+            #expect(!PTYFixtureTrace.identityIsLive(rootIdentity))
+            #expect(!PTYFixtureTrace.identityIsLive(childIdentity))
+            #expect(!harness.tab.hasAcknowledgedPTYLeaseForTesting)
+            harness.cleanup()
+        }
+    }
+
+    private func waitForForegroundGroup(
+        _ expectedGroup: pid_t,
+        in tab: TerminalTab,
+        timeout: TimeInterval = 3
+    ) async -> Bool {
+        let deadline = DispatchTime.now() + timeout
+        repeat {
+            if tab.foregroundProcessID == expectedGroup { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        } while DispatchTime.now() < deadline
+        return tab.foregroundProcessID == expectedGroup
+    }
+}

--- a/PineUITests/SidebarFolderClickTests.swift
+++ b/PineUITests/SidebarFolderClickTests.swift
@@ -26,6 +26,20 @@ final class SidebarFolderClickTests: PineUITestCase {
         ) == .completed
     }
 
+    private func waitForKeyboardFocus(
+        _ element: XCUIElement,
+        timeout: TimeInterval = 3
+    ) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "hasFocus == true"),
+            object: element
+        )
+        return XCTWaiter.wait(
+            for: [expectation],
+            timeout: timeout
+        ) == .completed
+    }
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         projectURL = try createTempProject(
@@ -167,6 +181,10 @@ final class SidebarFolderClickTests: PineUITestCase {
         XCTAssertTrue(child.waitForExistence(timeout: 3))
         XCTAssertTrue(alpha.isSelected)
         XCTAssertEqual(alpha.value as? String, "expanded")
+        XCTAssertTrue(
+            waitForKeyboardFocus(alpha),
+            "Folder activation should restore sidebar keyboard focus"
+        )
 
         app.typeKey(.leftArrow, modifierFlags: [])
         XCTAssertTrue(child.waitForNonExistence(timeout: 3))

--- a/PineUITests/SidebarFolderClickTests.swift
+++ b/PineUITests/SidebarFolderClickTests.swift
@@ -26,20 +26,6 @@ final class SidebarFolderClickTests: PineUITestCase {
         ) == .completed
     }
 
-    private func waitForKeyboardFocus(
-        _ element: XCUIElement,
-        timeout: TimeInterval = 3
-    ) -> Bool {
-        let expectation = XCTNSPredicateExpectation(
-            predicate: NSPredicate(format: "hasFocus == true"),
-            object: element
-        )
-        return XCTWaiter.wait(
-            for: [expectation],
-            timeout: timeout
-        ) == .completed
-    }
-
     override func setUpWithError() throws {
         try super.setUpWithError()
         projectURL = try createTempProject(
@@ -181,11 +167,6 @@ final class SidebarFolderClickTests: PineUITestCase {
         XCTAssertTrue(child.waitForExistence(timeout: 3))
         XCTAssertTrue(alpha.isSelected)
         XCTAssertEqual(alpha.value as? String, "expanded")
-        XCTAssertTrue(
-            waitForKeyboardFocus(alpha),
-            "Folder activation should restore sidebar keyboard focus"
-        )
-
         app.typeKey(.leftArrow, modifierFlags: [])
         XCTAssertTrue(child.waitForNonExistence(timeout: 3))
         XCTAssertTrue(alpha.isSelected)


### PR DESCRIPTION
## Summary
- drive controlled local process trees through the real SwiftTerm PTY path
- retain identity-qualified shell, process-group, and descendant ownership across foreground PGID churn
- perform bounded asynchronous TERM-to-KILL cleanup for terminal trees without signaling unrelated processes
- cover process replacement, partial UTF-8/ANSI output, backpressure, natural success/failure, cancellation, PTY release, and sanitized diagnostics

## Validation
- `swiftlint --strict`
- `python3 .github/scripts/check_nonisolated.py Pine`
- `xcodebuild test ... -only-testing:PineTests/TerminalPTYProcessTreeTests` (5 integration tests)
- `xcodebuild test ... -only-testing:PineTests/TerminalTabTests -only-testing:PineTests/UserTaskRunnerTests` (119 unit tests)
- no local UI tests were run

Closes #1436