### PR TITLE
test(a11y): audit critical localization contracts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,11 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
   -destination 'platform=macOS' -only-testing:PineUITests
 ```
 
+Release candidates also use the focused manual
+[accessibility and localization checklist](docs/accessibility-release-checklist.md)
+for VoiceOver, physical-keyboard, pseudolanguage, and appearance checks that
+XCUITest cannot assert reliably.
+
 ### Linting
 
 Run SwiftLint before every commit and fix all warnings and errors:

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -351,6 +351,7 @@ struct TerminalPaneTabBar: View {
                 .buttonStyle(.plain)
                 .help(Strings.newTerminal)
                 .accessibilityIdentifier(AccessibilityID.newTerminalButton)
+                .accessibilityLabel(Strings.newTerminal)
                 .accessibilityAddTraits(.isButton)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -379,6 +380,11 @@ struct TerminalPaneTabBar: View {
             .help(paneManager.maximizedPaneID == paneID
                   ? Strings.restoreTerminal : Strings.maximizeTerminal)
             .accessibilityIdentifier(AccessibilityID.maximizeTerminalButton)
+            .accessibilityLabel(
+                paneManager.maximizedPaneID == paneID
+                    ? Strings.restoreTerminal
+                    : Strings.maximizeTerminal
+            )
 
             // Close terminal pane
             Button {

--- a/PineTests/AccessibilityLocalizationMatrixTests.swift
+++ b/PineTests/AccessibilityLocalizationMatrixTests.swift
@@ -1,0 +1,156 @@
+//
+//  AccessibilityLocalizationMatrixTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@Suite("Accessibility localization matrix")
+struct AccessibilityLocalizationMatrixTests {
+    private static let supportedLocales: Set<String> = [
+        "de",
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "pt-BR",
+        "ru",
+        "zh-Hans",
+    ]
+
+    /// One or more stable labels from every release-critical surface in the
+    /// focused UI smoke. Keeping the list here makes missing translations fail
+    /// in the fast unit lane before XCUITest needs to launch the app.
+    private static let criticalKeys = [
+        // Welcome and project entry.
+        "welcome.title",
+        "welcome.subtitle",
+        "welcome.recentProjects",
+        "sidebar.openFolderButton",
+        // Settings.
+        "settings.tab.general",
+        "settings.tab.terminal",
+        "settings.tab.languageServers",
+        "settings.tab.agentHandoff",
+        "settings.tab.keyBindings",
+        "settings.general.autoSave",
+        "settings.terminal.cursor.shape",
+        // Terminal and command surfaces.
+        "terminal.new",
+        "terminal.maximize",
+        "terminal.restore",
+        "menu.commandPalette",
+        "commandPalette.placeholder",
+        // Agent Inbox, save/Quit decisions, and updates.
+        "menu.agentInbox",
+        "agentInbox.empty",
+        "dialog.unsavedChanges.title",
+        "dialog.unsavedChanges.cancel",
+        "dialog.unsavedChanges.dontSave",
+        "dialog.unsavedChanges.save",
+        "quit.summary.title",
+        "quit.summary.quitAnyway",
+        "quit.summary.review",
+        "menu.checkForUpdates",
+    ]
+
+    @Test("Critical surfaces have explicit translations in every locale")
+    func criticalSurfaceTranslations() throws {
+        let catalog = try Self.loadCatalog()
+        #expect(catalog.sourceLanguage == "en")
+
+        for key in Self.criticalKeys {
+            let entry = try #require(
+                catalog.strings[key],
+                "Missing localization key: \(key)"
+            )
+            let localizations = try #require(
+                entry.localizations,
+                "Missing localizations for: \(key)"
+            )
+            #expect(
+                Set(localizations.keys) == Self.supportedLocales,
+                "\(key) must cover the complete supported-locale matrix"
+            )
+
+            for locale in Self.supportedLocales {
+                let unit = try #require(
+                    localizations[locale]?.stringUnit,
+                    "\(key) has no static string for \(locale)"
+                )
+                #expect(
+                    unit.state == "translated",
+                    "\(key) is not translated for \(locale)"
+                )
+                #expect(
+                    !unit.value.trimmingCharacters(
+                        in: .whitespacesAndNewlines
+                    ).isEmpty,
+                    "\(key) is empty for \(locale)"
+                )
+                #expect(
+                    unit.value != key,
+                    "\(key) exposes its raw key for \(locale)"
+                )
+            }
+        }
+    }
+
+    @Test("Project and catalog declare the same supported locales")
+    func projectLocaleContract() throws {
+        let catalog = try Self.loadCatalog()
+        let declared = catalog.strings.values.reduce(into: Set<String>()) { locales, entry in
+            if let localizations = entry.localizations {
+                locales.formUnion(localizations.keys)
+            }
+        }
+        #expect(declared == Self.supportedLocales)
+
+        let project = try String(
+            contentsOf: Self.repositoryRoot
+                .appending(path: "Pine.xcodeproj/project.pbxproj"),
+            encoding: .utf8
+        )
+        for locale in Self.supportedLocales {
+            let quoted = locale.contains("-") ? "\"\(locale)\"" : locale
+            #expect(
+                project.contains("\n\t\t\t\t\(quoted),"),
+                "Xcode knownRegions omits \(locale)"
+            )
+        }
+    }
+
+    private static var repositoryRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private static func loadCatalog() throws -> Catalog {
+        let data = try Data(
+            contentsOf: repositoryRoot
+                .appending(path: "Pine/Localizable.xcstrings")
+        )
+        return try JSONDecoder().decode(Catalog.self, from: data)
+    }
+}
+
+private struct Catalog: Decodable {
+    let sourceLanguage: String
+    let strings: [String: CatalogEntry]
+}
+
+private struct CatalogEntry: Decodable {
+    let localizations: [String: CatalogLocalization]?
+}
+
+private struct CatalogLocalization: Decodable {
+    let stringUnit: CatalogStringUnit?
+}
+
+private struct CatalogStringUnit: Decodable {
+    let state: String
+    let value: String
+}

--- a/docs/accessibility-release-checklist.md
+++ b/docs/accessibility-release-checklist.md
@@ -1,0 +1,40 @@
+# Accessibility and Localization Release Check
+
+Run this short manual pass for release candidates after automated unit and UI
+checks are green. Record the exact macOS and Xcode/SDK versions described in
+`AGENTS.md`, plus the language, appearance, and accessibility settings used.
+
+## Representative configurations
+
+- English, light appearance, default accessibility settings.
+- German, dark appearance, Reduce Motion enabled.
+- Japanese, light appearance, Differentiate Without Color enabled.
+- Russian, dark appearance, both settings enabled.
+- One pass with Xcode's Double Length Pseudolanguage.
+
+## VoiceOver and layout
+
+1. On Welcome, verify the Open Folder and Agent Inbox buttons have localized
+   names, expose the button role, and are reachable in a sensible order.
+2. In a project window, open each Settings pane and check long labels, rows,
+   buttons, and sliders for clipping. Confirm controls announce their current
+   value and enabled state.
+3. Create a terminal and verify New Tab, maximize/restore, close, and terminal
+   tabs expose localized names and their default action.
+4. Open Quick Open, Symbol Navigator, Command Palette, and Agent Inbox. Check
+   the search field, selected result, empty state, and actionable rows.
+5. Trigger unsaved-changes, application-Quit, and update surfaces. Check the
+   title, explanation, default button, cancel path, and keyboard focus order.
+6. Repeat the visual pass in light and dark appearance. With Differentiate
+   Without Color enabled, confirm status and selection do not rely on color
+   alone; with Reduce Motion enabled, confirm transitions are immediate.
+
+## Physical-keyboard journey
+
+Without using the pointer, open a file, create a second tab, switch tabs and
+panes, save, create/focus a terminal, operate its controls, and open Agent
+Inbox. This remains manual because macOS XCUITest accessibility events bypass
+Pine's local `NSEvent` monitors for several production shortcuts.
+
+Fail the release check for raw localization keys, unexpected English fallback,
+empty required labels, clipped controls, missing actions, or focus traps.


### PR DESCRIPTION
## Summary
- validate release-critical accessibility strings across all nine supported locales
- give terminal controls explicit localized accessibility labels
- document a focused manual VoiceOver and localization release checklist

## Validation
- `PineTests/AccessibilityLocalizationMatrixTests` (2 tests)
- SwiftLint
- `git diff --check`

No UI tests were added or run locally in this change. This is the locale/string contract and manual-audit portion of the broader matrix; keyboard/AX automation remains follow-up work.

Refs #1442