### PR TITLE
test(lifecycle): cover quit crash and relaunch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,7 @@ jobs:
     timeout-minutes: 60
     env:
       COVERAGE_THRESHOLD: 70
+      PINE_LIFECYCLE_DIAGNOSTICS: ${{ github.workspace }}/LifecycleDiagnostics
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -351,7 +352,7 @@ jobs:
       - name: Unit Tests
         run: |
           RESULT_BUNDLE="TestResults.xcresult"
-          rm -rf "$RESULT_BUNDLE"
+          rm -rf "$RESULT_BUNDLE" LifecycleDiagnostics
           TEST_STARTED_AT="$(date +%s)"
 
           set +e
@@ -384,6 +385,17 @@ jobs:
             --xcodebuild-exit "$TEST_EXIT" \
             --started-at "$TEST_STARTED_AT" \
             --github-summary
+
+      - name: Upload Unit Test Results
+        if: success() || failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: unit-test-results
+          path: |
+            TestResults.xcresult
+            LifecycleDiagnostics
+          retention-days: 7
+          if-no-files-found: warn
 
       # Snapshot references must be recorded on a runner: a developer Mac
       # rasterizes SF Symbols and text differently enough to sit outside the

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ assets/screenshot-unknown-*.png
 # Snapshot test failure artifacts
 PineTests/SnapshotTests/__Snapshots__/*.actual.png
 
+# Sanitized process-level test diagnostics uploaded by CI
+LifecycleDiagnostics/
+
 # Agents
 .claude/
 .pi/

--- a/Pine/ApplicationLifecycleProcessDriver.swift
+++ b/Pine/ApplicationLifecycleProcessDriver.swift
@@ -1,0 +1,702 @@
+#if DEBUG
+
+import AppKit
+import Darwin
+import Foundation
+
+/// Scenarios executed by a separately launched Debug Pine binary. This is an
+/// in-process driver rather than UI automation: AppKit owns the real app
+/// lifecycle while a file-marker protocol makes every suspension deterministic
+/// and keeps diagnostics free of editor/terminal payloads.
+nonisolated enum ApplicationLifecycleProcessScenario:
+    String, Codable, Sendable {
+    case interactiveQuit = "interactive-quit"
+    case interruptedSessionSave = "interrupted-session-save"
+    case verifyRestoration = "verify-restoration"
+}
+
+nonisolated struct ApplicationLifecycleProcessConfiguration:
+    Codable, Sendable {
+    static let currentSchemaVersion = 1
+
+    let schemaVersion: Int
+    let scenario: ApplicationLifecycleProcessScenario
+    let stateDirectoryPath: String
+    let projectPath: String
+    let primaryFilePath: String
+    let secondaryFilePath: String
+    let defaultsSuiteName: String
+    let terminalFixturePath: String
+
+    init(
+        scenario: ApplicationLifecycleProcessScenario,
+        stateDirectoryPath: String,
+        projectPath: String,
+        primaryFilePath: String,
+        secondaryFilePath: String,
+        defaultsSuiteName: String,
+        terminalFixturePath: String
+    ) {
+        schemaVersion = Self.currentSchemaVersion
+        self.scenario = scenario
+        self.stateDirectoryPath = stateDirectoryPath
+        self.projectPath = projectPath
+        self.primaryFilePath = primaryFilePath
+        self.secondaryFilePath = secondaryFilePath
+        self.defaultsSuiteName = defaultsSuiteName
+        self.terminalFixturePath = terminalFixturePath
+    }
+}
+
+nonisolated struct ApplicationLifecycleProcessIdentity:
+    Codable, Equatable, Sendable {
+    let processIdentifier: Int32
+    let startSeconds: UInt64
+    let startMicroseconds: UInt64
+
+    init(_ identity: UserTaskProcessIdentity) {
+        processIdentifier = identity.processID
+        startSeconds = identity.startSeconds
+        startMicroseconds = identity.startMicroseconds
+    }
+
+    var userTaskIdentity: UserTaskProcessIdentity {
+        UserTaskProcessIdentity(
+            processID: processIdentifier,
+            startSeconds: startSeconds,
+            startMicroseconds: startMicroseconds
+        )
+    }
+}
+
+/// Sanitized evidence persisted per phase. It intentionally contains only
+/// lifecycle booleans, counts, and exact OS identities—not file contents,
+/// terminal output, environment values, prompts, or credentials.
+nonisolated struct ApplicationLifecycleProcessEvidence:
+    Codable, Equatable, Sendable {
+    let phase: String
+    var processIdentifier: Int32?
+    var terminalRoot: ApplicationLifecycleProcessIdentity?
+    var terminalChild: ApplicationLifecycleProcessIdentity?
+    var terminalReplacement: ApplicationLifecycleProcessIdentity?
+    var confirmationVisible: Bool?
+    var dirtyContentPresent: Bool?
+    var terminalRunning: Bool?
+    var windowVisible: Bool?
+    var inputAccepted: Bool?
+    var savedToDisk: Bool?
+    var restoredFileCount: Int?
+    var restoredTerminalCount: Int?
+    var staleProcessOwnership: Bool?
+    var failureCode: String?
+
+    init(phase: String) {
+        self.phase = phase
+    }
+}
+
+@MainActor
+final class ApplicationLifecycleProcessDriver {
+    private enum TerminationMode: Equatable {
+        case cancel
+        case failSave
+        case saveAndQuit
+        case clean
+    }
+
+    private enum DriverFailure: String, Error {
+        case invalidProject = "invalid-project"
+        case missingPrimaryFile = "missing-primary-file"
+        case missingSecondaryFile = "missing-secondary-file"
+        case missingSession = "missing-session"
+        case unexpectedSession = "unexpected-session"
+        case terminalDidNotStart = "terminal-did-not-start"
+        case terminalOwnershipUnavailable = "terminal-ownership-unavailable"
+        case terminalChildUnavailable = "terminal-child-unavailable"
+        case terminalReplacementUnavailable = "terminal-replacement-unavailable"
+        case unexpectedTerminationReply = "unexpected-termination-reply"
+        case commandTimedOut = "command-timed-out"
+        case evidenceWriteFailed = "evidence-write-failed"
+    }
+
+    private struct TraceIdentity {
+        let identity: UserTaskProcessIdentity
+    }
+
+    private static let configurationEnvironmentKey =
+        "PINE_APPLICATION_LIFECYCLE_CONFIG"
+    private static let launchArgument =
+        "--application-lifecycle-process-test"
+    private static let committedFixtureContent =
+        "// committed lifecycle fixture\n"
+
+    private let configuration: ApplicationLifecycleProcessConfiguration
+    private let defaults: UserDefaults
+    private let stateDirectory: URL
+    private let eventsDirectory: URL
+    private let commandsDirectory: URL
+    private let projectURL: URL
+    private let primaryFileURL: URL
+    private let secondaryFileURL: URL
+    private let terminalTraceURL: URL
+    private var terminationMode: TerminationMode = .clean
+    private weak var appDelegate: AppDelegate?
+    private weak var terminalTab: TerminalTab?
+    private var fixtureWindow: NSWindow?
+    private var initialTerminalChild: UserTaskProcessIdentity?
+    private var replacementTerminalChild: UserTaskProcessIdentity?
+
+    static func fromEnvironment() -> ApplicationLifecycleProcessDriver? {
+        let processInfo = ProcessInfo.processInfo
+        guard processInfo.arguments.contains(launchArgument),
+              let path = processInfo.environment[
+                configurationEnvironmentKey
+              ],
+              let data = try? Data(
+                contentsOf: URL(fileURLWithPath: path)
+              ),
+              let configuration = try? JSONDecoder().decode(
+                ApplicationLifecycleProcessConfiguration.self,
+                from: data
+              ),
+              configuration.schemaVersion
+                == ApplicationLifecycleProcessConfiguration
+                    .currentSchemaVersion else {
+            return nil
+        }
+        return ApplicationLifecycleProcessDriver(
+            configuration: configuration
+        )
+    }
+
+    private init?(configuration: ApplicationLifecycleProcessConfiguration) {
+        guard let defaults = UserDefaults(
+            suiteName: configuration.defaultsSuiteName
+        ) else { return nil }
+        self.configuration = configuration
+        self.defaults = defaults
+        stateDirectory = URL(
+            fileURLWithPath: configuration.stateDirectoryPath,
+            isDirectory: true
+        )
+        eventsDirectory = stateDirectory.appending(
+            path: "events",
+            directoryHint: .isDirectory
+        )
+        commandsDirectory = stateDirectory.appending(
+            path: "commands",
+            directoryHint: .isDirectory
+        )
+        projectURL = URL(
+            fileURLWithPath: configuration.projectPath,
+            isDirectory: true
+        ).resolvingSymlinksInPath()
+        primaryFileURL = URL(
+            fileURLWithPath: configuration.primaryFilePath
+        ).standardizedFileURL
+        secondaryFileURL = URL(
+            fileURLWithPath: configuration.secondaryFilePath
+        ).standardizedFileURL
+        terminalTraceURL = stateDirectory.appending(path: "terminal.trace")
+    }
+
+    func makeRegistry() -> ProjectRegistry {
+        ProjectRegistry(
+            defaults: defaults,
+            agentTasks: AgentTaskRegistry(
+                persistence: ApplicationLifecycleProcessAgentStore()
+            ),
+            agentDetectionPollInterval: 3_600,
+            agentDetectionInitialPollDelay: 3_600
+        )
+    }
+
+    func start(appDelegate: AppDelegate) {
+        self.appDelegate = appDelegate
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await prepareProtocolDirectories()
+                switch configuration.scenario {
+                case .interactiveQuit:
+                    try await runInteractiveQuit()
+                case .interruptedSessionSave:
+                    try await runInterruptedSessionSave()
+                case .verifyRestoration:
+                    try await runRestorationVerification()
+                }
+            } catch let failure as DriverFailure {
+                await failAndExit(code: failure.rawValue)
+            } catch {
+                await failAndExit(code: "unexpected-driver-failure")
+            }
+        }
+    }
+
+    private func runInteractiveQuit() async throws {
+        let project = try await makeProjectManager()
+        guard FileManager.default.fileExists(atPath: primaryFileURL.path) else {
+            throw DriverFailure.missingPrimaryFile
+        }
+        project.primaryTabManager.openTab(url: primaryFileURL)
+        project.primaryTabManager.autoSavePreferenceProvider = { false }
+        project.primaryTabManager.updateContent(
+            Self.committedFixtureContent
+        )
+        let window = makeFixtureWindow(for: project)
+
+        let initialProcess = TerminalInitialProcess(
+            executablePath: "/bin/sh",
+            arguments: [
+                configuration.terminalFixturePath,
+                "tree",
+                terminalTraceURL.path,
+            ]
+        )
+        let terminalPane = project.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: projectURL,
+            initialProcess: initialProcess
+        )
+        guard let tab = project.paneManager.terminalState(
+            for: terminalPane
+        )?.activeTab else {
+            throw DriverFailure.terminalDidNotStart
+        }
+        terminalTab = tab
+        tab.terminalView.frame = NSRect(
+            x: 0,
+            y: 0,
+            width: 800,
+            height: 300
+        )
+        tab.startIfNeeded()
+        guard let controller = tab.processTreeControllerForTesting else {
+            throw DriverFailure.terminalOwnershipUnavailable
+        }
+        let child = try await requireTraceIdentity(phase: "child")
+        initialTerminalChild = child.identity
+
+        var ready = ApplicationLifecycleProcessEvidence(
+            phase: "interactive-ready"
+        )
+        ready.processIdentifier = ProcessInfo.processInfo.processIdentifier
+        ready.terminalRoot = ApplicationLifecycleProcessIdentity(
+            controller.rootIdentity
+        )
+        ready.terminalChild = ApplicationLifecycleProcessIdentity(
+            child.identity
+        )
+        ready.dirtyContentPresent = project.hasUnsavedChanges
+        ready.terminalRunning = tab.isProcessRunning
+        ready.windowVisible = window.isVisible
+        try await emit(ready)
+
+        installTerminationOverrides(project: project)
+        let cancelled = await requestTermination(mode: .cancel)
+        guard !cancelled else {
+            throw DriverFailure.unexpectedTerminationReply
+        }
+        let acceptedAfterCancel = tab.sendText("probe\n")
+        var cancellation = ApplicationLifecycleProcessEvidence(
+            phase: "cancelled-usable"
+        )
+        cancellation.dirtyContentPresent = project.hasUnsavedChanges
+        cancellation.terminalRunning = tab.isProcessRunning
+        cancellation.windowVisible = window.isVisible
+        cancellation.inputAccepted = acceptedAfterCancel
+        try await emit(cancellation)
+
+        try await waitForCommand("retry-failure")
+        let failed = await requestTermination(mode: .failSave)
+        guard !failed else {
+            throw DriverFailure.unexpectedTerminationReply
+        }
+        var saveFailure = ApplicationLifecycleProcessEvidence(
+            phase: "save-failure-usable"
+        )
+        saveFailure.dirtyContentPresent = project.hasUnsavedChanges
+        saveFailure.terminalRunning = tab.isProcessRunning
+        saveFailure.windowVisible = window.isVisible
+        saveFailure.inputAccepted = tab.sendText("probe\n")
+        try await emit(saveFailure)
+
+        try await waitForCommand("retry-success")
+        let confirmed = await requestTermination(mode: .saveAndQuit)
+        guard confirmed else {
+            throw DriverFailure.unexpectedTerminationReply
+        }
+        let savedToDisk = (try? String(
+            contentsOf: primaryFileURL,
+            encoding: .utf8
+        )) == Self.committedFixtureContent
+        var completion = ApplicationLifecycleProcessEvidence(
+            phase: "confirmed-quit"
+        )
+        completion.terminalRoot = ApplicationLifecycleProcessIdentity(
+            controller.rootIdentity
+        )
+        completion.terminalChild = initialTerminalChild.map(
+            ApplicationLifecycleProcessIdentity.init
+        )
+        completion.terminalReplacement = replacementTerminalChild.map(
+            ApplicationLifecycleProcessIdentity.init
+        )
+        completion.dirtyContentPresent = project.hasUnsavedChanges
+        completion.terminalRunning = tab.isProcessRunning
+        completion.windowVisible = window.isVisible
+        completion.savedToDisk = savedToDisk
+        try await emit(completion)
+        NSApp.terminate(nil)
+    }
+
+    private func runInterruptedSessionSave() async throws {
+        let project = try await makeProjectManager()
+        let session = try requireCommittedSession()
+        _ = ProjectSessionRestorer.restore(
+            session,
+            into: project,
+            rootURL: projectURL
+        )
+        guard FileManager.default.fileExists(atPath: secondaryFileURL.path)
+        else {
+            throw DriverFailure.missingSecondaryFile
+        }
+
+        let restoredTabs = project.allTabs
+        guard restoredTabs.count == 1,
+              restoredTabs.first?.fileURL?.standardizedFileURL
+                == primaryFileURL else {
+            throw DriverFailure.unexpectedSession
+        }
+        let staleOwnership = hasStaleProcessOwnership(project)
+        project.primaryTabManager.openTab(url: secondaryFileURL)
+        _ = makeFixtureWindow(for: project)
+
+        var ready = ApplicationLifecycleProcessEvidence(
+            phase: "crash-generation-ready"
+        )
+        ready.processIdentifier = ProcessInfo.processInfo.processIdentifier
+        ready.restoredFileCount = restoredTabs.count
+        ready.restoredTerminalCount = project.allTerminalTabs.count
+        ready.staleProcessOwnership = staleOwnership
+        try await emit(ready)
+
+        installTerminationOverrides(project: project)
+        let confirmed = await requestTermination(mode: .clean)
+        guard confirmed else {
+            throw DriverFailure.unexpectedTerminationReply
+        }
+        var committed = ApplicationLifecycleProcessEvidence(
+            phase: "crash-termination-committed"
+        )
+        committed.processIdentifier = ProcessInfo.processInfo.processIdentifier
+        try await emit(committed)
+        NSApp.terminate(nil)
+    }
+
+    private func runRestorationVerification() async throws {
+        let project = try await makeProjectManager()
+        let session = try requireCommittedSession()
+        _ = ProjectSessionRestorer.restore(
+            session,
+            into: project,
+            rootURL: projectURL
+        )
+        let restoredPaths = Set(project.allTabs.compactMap {
+            $0.fileURL?.standardizedFileURL
+        })
+        guard restoredPaths == [primaryFileURL] else {
+            throw DriverFailure.unexpectedSession
+        }
+        let savedToDisk = (try? String(
+            contentsOf: primaryFileURL,
+            encoding: .utf8
+        )) == Self.committedFixtureContent
+        _ = makeFixtureWindow(for: project)
+
+        var restored = ApplicationLifecycleProcessEvidence(
+            phase: "restoration-verified"
+        )
+        restored.processIdentifier = ProcessInfo.processInfo.processIdentifier
+        restored.savedToDisk = savedToDisk
+        restored.restoredFileCount = project.allTabs.count
+        restored.restoredTerminalCount = project.allTerminalTabs.count
+        restored.staleProcessOwnership = hasStaleProcessOwnership(project)
+        try await emit(restored)
+
+        installTerminationOverrides(project: project)
+        let confirmed = await requestTermination(mode: .clean)
+        guard confirmed else {
+            throw DriverFailure.unexpectedTerminationReply
+        }
+        NSApp.terminate(nil)
+    }
+
+    private func makeProjectManager() async throws -> ProjectManager {
+        guard let appDelegate,
+              let project = appDelegate.registry.projectManager(
+                for: projectURL
+              ) else {
+            throw DriverFailure.invalidProject
+        }
+        await project.workspace.waitForLoadingComplete()
+        return project
+    }
+
+    private func requireCommittedSession() throws -> SessionState {
+        guard let session = SessionState.load(
+            for: projectURL,
+            defaults: defaults
+        ) else {
+            throw DriverFailure.missingSession
+        }
+        guard session.existingFileURLs.map(\.standardizedFileURL)
+                == [primaryFileURL] else {
+            throw DriverFailure.unexpectedSession
+        }
+        return session
+    }
+
+    private func makeFixtureWindow(for project: ProjectManager) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Lifecycle Fixture"
+        window.contentView = NSView(frame: window.contentLayoutRect)
+        window.isReleasedWhenClosed = false
+        project.bindDialogOwnerWindow(window)
+        window.makeKeyAndOrderFront(nil)
+        fixtureWindow = window
+        return window
+    }
+
+    private func installTerminationOverrides(project: ProjectManager) {
+        guard let appDelegate else { return }
+        appDelegate.terminationAlertPresenterForProcessTest = { [weak self] template, _, _, _ in
+            guard let self else { return .abort }
+            return await self.present(template: template)
+        }
+        appDelegate.terminationSaveAllForProcessTest = { [weak self] projectManager, _ in
+            guard let self else { return false }
+            switch self.terminationMode {
+            case .failSave:
+                return false
+            case .cancel, .saveAndQuit, .clean:
+                return projectManager.saveAllPaneTabs()
+            }
+        }
+        project.primaryTabManager.autoSavePreferenceProvider = { false }
+    }
+
+    private func present(
+        template: AlertTemplate
+    ) async -> NSApplication.ModalResponse {
+        if template == .applicationQuitSummary,
+           terminationMode == .cancel {
+            var visible = ApplicationLifecycleProcessEvidence(
+                phase: "confirmation-visible"
+            )
+            visible.confirmationVisible = true
+            try? await emit(visible)
+            do {
+                try await waitForCommand("replace-and-cancel")
+                guard let terminalTab,
+                      terminalTab.sendText("replace\n") else {
+                    return .abort
+                }
+                let replacement = try await requireTraceIdentity(
+                    phase: "replacement",
+                    excluding: initialTerminalChild
+                )
+                replacementTerminalChild = replacement.identity
+                try? await Task.sleep(for: .milliseconds(100))
+                var evidence = ApplicationLifecycleProcessEvidence(
+                    phase: "replacement-while-confirming"
+                )
+                evidence.terminalReplacement =
+                    ApplicationLifecycleProcessIdentity(
+                        replacement.identity
+                    )
+                evidence.confirmationVisible = true
+                evidence.terminalRunning = terminalTab.isProcessRunning
+                try await emit(evidence)
+            } catch {
+                return .abort
+            }
+            return .abort
+        }
+
+        if template == .applicationQuitFailure
+            || template == .fileOperationErrorCritical {
+            return .alertFirstButtonReturn
+        }
+        return .alertFirstButtonReturn
+    }
+
+    private func requestTermination(mode: TerminationMode) async -> Bool {
+        guard let appDelegate else { return false }
+        terminationMode = mode
+        appDelegate.terminationDeadlineForProcessTest = .now() + 8
+        return await withCheckedContinuation { continuation in
+            let reply = appDelegate.beginApplicationTermination {
+                continuation.resume(returning: $0)
+            }
+            if reply == .terminateNow {
+                continuation.resume(returning: true)
+            }
+        }
+    }
+
+    private func hasStaleProcessOwnership(
+        _ project: ProjectManager
+    ) -> Bool {
+        let hasTerminalOwnership = project.allTerminalTabs.contains {
+            $0.isProcessRunning || $0.agentSession != nil
+        }
+        guard let appDelegate else { return true }
+        return hasTerminalOwnership
+            || !appDelegate.registry.agentTasks.tasks.isEmpty
+    }
+
+    private func requireTraceIdentity(
+        phase: String,
+        excluding excluded: UserTaskProcessIdentity? = nil
+    ) async throws -> TraceIdentity {
+        let traceURL = terminalTraceURL
+        let deadline = DispatchTime.now() + .seconds(5)
+        while DispatchTime.now() < deadline {
+            if let identity = await Task.detached(priority: .utility, operation: {
+                Self.lastTraceIdentity(phase: phase, at: traceURL)
+            }).value,
+               identity.identity != excluded {
+                return identity
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        switch phase {
+        case "child":
+            throw DriverFailure.terminalChildUnavailable
+        default:
+            throw DriverFailure.terminalReplacementUnavailable
+        }
+    }
+
+    nonisolated private static func lastTraceIdentity(
+        phase: String,
+        at url: URL
+    ) -> TraceIdentity? {
+        guard let data = try? Data(contentsOf: url),
+              let text = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        for line in text.split(whereSeparator: \.isNewline).reversed() {
+            var values: [Substring: Substring] = [:]
+            for field in line.split(separator: " ") {
+                let pair = field.split(separator: "=", maxSplits: 1)
+                guard pair.count == 2 else { continue }
+                values[pair[0]] = pair[1]
+            }
+            guard values["phase"] == Substring(phase),
+                  let processText = values["pid"],
+                  let processIdentifier = pid_t(processText),
+                  let identity = UserTaskProcessInspector.identity(
+                    for: processIdentifier
+                  ) else { continue }
+            return TraceIdentity(identity: identity)
+        }
+        return nil
+    }
+
+    private func prepareProtocolDirectories() async throws {
+        let events = eventsDirectory
+        let commands = commandsDirectory
+        do {
+            try await Task.detached(priority: .utility) {
+                try FileManager.default.createDirectory(
+                    at: events,
+                    withIntermediateDirectories: true
+                )
+                try FileManager.default.createDirectory(
+                    at: commands,
+                    withIntermediateDirectories: true
+                )
+            }.value
+        } catch {
+            throw DriverFailure.evidenceWriteFailed
+        }
+    }
+
+    private func emit(
+        _ evidence: ApplicationLifecycleProcessEvidence
+    ) async throws {
+        let destination = eventsDirectory.appending(
+            path: evidence.phase + ".json"
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data: Data
+        do {
+            data = try encoder.encode(evidence)
+        } catch {
+            throw DriverFailure.evidenceWriteFailed
+        }
+        do {
+            try await Task.detached(priority: .utility) {
+                try data.write(to: destination, options: .atomic)
+            }.value
+        } catch {
+            throw DriverFailure.evidenceWriteFailed
+        }
+    }
+
+    private func waitForCommand(_ name: String) async throws {
+        let marker = commandsDirectory.appending(path: name)
+        let deadline = DispatchTime.now() + .seconds(10)
+        while DispatchTime.now() < deadline {
+            let exists = await Task.detached(priority: .utility) {
+                FileManager.default.fileExists(atPath: marker.path)
+            }.value
+            if exists { return }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        throw DriverFailure.commandTimedOut
+    }
+
+    private func failAndExit(code: String) async {
+        var failure = ApplicationLifecycleProcessEvidence(
+            phase: "driver-failed"
+        )
+        failure.processIdentifier = ProcessInfo.processInfo.processIdentifier
+        failure.failureCode = code
+        try? await emit(failure)
+
+        if let controller = terminalTab?.stopForApplicationTermination() {
+            _ = await Task.detached(priority: .utility) {
+                controller.waitForTermination(timeout: 3)
+            }.value
+        }
+        Darwin.exit(70)
+    }
+}
+
+private actor ApplicationLifecycleProcessAgentStore:
+    AgentTaskPersisting {
+    func load(
+        project: AgentTaskProjectIdentity
+    ) async -> AgentTaskMetadataLoadResult {
+        AgentTaskMetadataLoadResult(status: .missing, tasks: [])
+    }
+
+    func save(
+        tasks: [AgentTask],
+        project: AgentTaskProjectIdentity,
+        authorization: AgentTaskPublicationAuthorization?
+    ) async -> AgentTaskMetadataSaveResult {
+        .saved(taskCount: tasks.count)
+    }
+}
+
+#endif

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -44,7 +44,10 @@ extension ContentView {
         guard projectManager.allTabs.isEmpty,
               projectManager.allTerminalTabs.isEmpty else { return .skipped }
 
-        guard let session = SessionState.load(for: rootURL) else {
+        guard let session = SessionState.load(
+            for: rootURL,
+            defaults: projectManager.sessionDefaults
+        ) else {
             // No persisted session for this root — candidate for terminal
             // seeding (subject to recovery discovery in the caller).
             return .noSavedSession

--- a/Pine/PersistenceFaultInjection.swift
+++ b/Pine/PersistenceFaultInjection.swift
@@ -91,14 +91,20 @@ nonisolated struct PersistenceFaultInjector: Sendable {
     /// Release builds deliberately ignore test-only process configuration.
     static let processEnvironment: PersistenceFaultInjector = {
         #if DEBUG
-        guard let encoded = ProcessInfo.processInfo.environment[
-            "PINE_PERSISTENCE_FAULT"
-        ],
-        let fault = PersistenceFault(encoded: encoded) else {
+        let environment = ProcessInfo.processInfo.environment
+        let fault = environment["PINE_PERSISTENCE_FAULT"].flatMap(
+            PersistenceFault.init(encoded:)
+        )
+        let pause = PersistenceProcessCheckpointPause(
+            environment: environment
+        )
+        guard fault != nil || pause != nil else {
             return .none
         }
         return PersistenceFaultInjector { store, phase in
-            guard store == fault.store,
+            try pause?.pauseIfMatching(store: store, phase: phase)
+            guard let fault,
+                  store == fault.store,
                   phase == fault.phase else { return }
             throw fault.failure
         }
@@ -107,6 +113,72 @@ nonisolated struct PersistenceFaultInjector: Sendable {
         #endif
     }()
 }
+
+#if DEBUG
+/// Test-only kill checkpoint used by the real-process lifecycle gate. The
+/// marker contains only phase and PID; it never records payload bytes, paths,
+/// environment values, prompts, or credentials. A hard timeout prevents a
+/// malformed harness configuration from hanging a developer launch forever.
+nonisolated private struct PersistenceProcessCheckpointPause: Sendable {
+    private struct Marker: Codable {
+        let store: String
+        let phase: String
+        let processIdentifier: Int32
+    }
+
+    private let store: PersistenceStoreKind
+    private let phase: PersistenceWritePhase
+    private let directory: URL
+
+    init?(environment: [String: String]) {
+        guard let encoded = environment["PINE_PERSISTENCE_PAUSE"],
+              let directoryPath = environment[
+                "PINE_PERSISTENCE_CHECKPOINT_DIRECTORY"
+              ] else { return nil }
+        let fields = encoded.split(
+            separator: ":",
+            omittingEmptySubsequences: false
+        )
+        guard fields.count == 2,
+              let store = PersistenceStoreKind(rawValue: String(fields[0])),
+              let phase = PersistenceWritePhase(
+                rawValue: String(fields[1])
+              ) else { return nil }
+        self.store = store
+        self.phase = phase
+        directory = URL(
+            fileURLWithPath: directoryPath,
+            isDirectory: true
+        )
+    }
+
+    func pauseIfMatching(
+        store: PersistenceStoreKind,
+        phase: PersistenceWritePhase
+    ) throws {
+        guard self.store == store, self.phase == phase else { return }
+        let marker = Marker(
+            store: store.rawValue,
+            phase: phase.rawValue,
+            processIdentifier: ProcessInfo.processInfo.processIdentifier
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        try encoder.encode(marker).write(
+            to: directory.appending(path: "persistence-checkpoint.json"),
+            options: .atomic
+        )
+
+        let release = directory.appending(path: "persistence-release")
+        let deadline = DispatchTime.now() + .seconds(10)
+        repeat {
+            if FileManager.default.fileExists(atPath: release.path) { return }
+            Thread.sleep(forTimeInterval: 0.01)
+        } while DispatchTime.now() < deadline
+        throw PersistenceFailureKind.interrupted
+    }
+}
+#endif
 
 /// Thread-safe, ordered, one-shot fault plan. Unrelated checkpoints cannot
 /// consume the next planned injection.

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -993,6 +993,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
     /// handlers know not to clear the saved session during app quit.
     private(set) var isTerminating = false
     private var terminationDecisionTask: Task<Void, Never>?
+    #if DEBUG
+    /// Retained only when a separately launched Debug app process opts into
+    /// the lifecycle integration protocol. Normal developer/UI-test launches
+    /// never create the driver or replace the production presenters.
+    private var applicationLifecycleProcessDriver:
+        ApplicationLifecycleProcessDriver?
+    var terminationAlertPresenterForProcessTest: TerminationAlertPresenter?
+    var terminationSaveAllForProcessTest: TerminationSaveAll?
+    var terminationDeadlineForProcessTest: DispatchTime?
+    #endif
     private var welcomeVisibilityGeneration = 0
     private var pendingWelcomeEnsureTask: Task<Void, Never>?
 
@@ -1290,6 +1300,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
     }
 
     func applicationWillFinishLaunching(_ notification: Notification) {
+        #if DEBUG
+        if let driver = ApplicationLifecycleProcessDriver.fromEnvironment() {
+            applicationLifecycleProcessDriver = driver
+            registry = driver.makeRegistry()
+            return
+        }
+        #endif
+
         // Must be set before applicationDidFinishLaunching — the system runs
         // window restoration between willFinishLaunching and didFinishLaunching.
         UserDefaults.standard.set(false, forKey: "NSQuitAlwaysKeepsWindows")
@@ -1327,6 +1345,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        #if DEBUG
+        if let applicationLifecycleProcessDriver {
+            applicationLifecycleProcessDriver.start(appDelegate: self)
+            return
+        }
+        #endif
+
         NSWindow.allowsAutomaticWindowTabbing = false
         bindQuickTerminalAgentRouting()
         agentNotifications.start()
@@ -1966,7 +1991,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 reply(false)
                 return
             }
+            #if DEBUG
+            let shouldTerminate = await confirmApplicationTermination(
+                presentAlert: terminationAlertPresenterForProcessTest,
+                saveAll: terminationSaveAllForProcessTest,
+                terminationDeadlineOverride:
+                    terminationDeadlineForProcessTest
+            )
+            #else
             let shouldTerminate = await confirmApplicationTermination()
+            #endif
             terminationDecisionTask = nil
             isTerminating = shouldTerminate
             if shouldTerminate {
@@ -3154,13 +3188,101 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             return false
         }
 
+        // A real application exit destroys the queues that perform terminal
+        // process-tree cleanup. Request every authorized stop now and wait
+        // off-main under the shared forward deadline, before the synchronous
+        // discard/task commit makes Quit irreversible. Cancelled and
+        // save-failed Quit paths return before this point, preserving dirty
+        // buffers and live terminals.
+        var terminalStopControllers: [TerminalProcessTreeController] = []
+        var terminalStopTabs: [TerminalTab] = []
+        func rollbackAfterRequestedTerminalStops() async {
+            await rollbackAgentTasks()
+            terminalStopTabs.forEach {
+                $0.reportDeferredApplicationTerminationLifecycleEnd()
+            }
+            guard let remaining = remainingTerminationDuration(
+                until: terminationDeadline
+            ), await registry.agentTasks.flushPersistence(
+                maximumDuration: remaining
+            ) == .saved else {
+                Logger.app.error(
+                    "Terminal-stop rollback did not reach a clean persistence barrier"
+                )
+                return
+            }
+        }
+        for projectManager in registry.openProjects.values {
+            let identifier = ObjectIdentifier(projectManager)
+            let tabs = projectManager.terminal.allTerminalTabs
+            let authorization: TerminalTabCloseAuthorization
+            if let captured = terminalAuthorizations[identifier] {
+                authorization = captured
+            } else {
+                let current = TerminalTabCloseAuthorization.authorizing(
+                    tabs: tabs
+                )
+                guard !current.requiresConfirmation else {
+                    await rollbackAfterRequestedTerminalStops()
+                    await presentTerminationFailure()
+                    return false
+                }
+                authorization = current
+            }
+            let capturedLaunches = agentLaunchAuthorizations[identifier]
+            let currentLaunches = projectManager.terminal
+                .capturePineAgentLaunchAuthorization()
+            terminalStopTabs.append(contentsOf: tabs)
+            guard let controllers = authorization.requestAuthorizedStops(
+                tabs,
+                pineAgentLaunches: capturedLaunches,
+                currentPineAgentLaunches: currentLaunches
+            ) else {
+                await rollbackAfterRequestedTerminalStops()
+                await presentTerminationFailure()
+                return false
+            }
+            terminalStopControllers.append(contentsOf: controllers)
+        }
+        terminalStopTabs.append(
+            contentsOf: quickTerminalCoordinator.paneState.terminalTabs
+        )
+        guard let quickTerminalAuthorization,
+              let quickTerminalControllers = quickTerminalAuthorization
+                .requestAuthorizedStops(
+                    quickTerminalCoordinator.paneState.terminalTabs
+                ) else {
+            await rollbackAfterRequestedTerminalStops()
+            await presentTerminationFailure()
+            return false
+        }
+        terminalStopControllers.append(
+            contentsOf: quickTerminalControllers
+        )
+        guard await TerminalTabCloseAuthorization.waitForAuthorizedStops(
+            terminalStopControllers,
+            until: forwardDeadline
+        ) else {
+            await rollbackAfterRequestedTerminalStops()
+            await presentTerminationFailure()
+            return false
+        }
+
+        // The waits above suspend the main actor. Reject any process/tab/task
+        // generation that appeared before the final synchronous commit.
+        guard destructiveAuthorizationsStillCoverCurrentState() else {
+            await rollbackAfterRequestedTerminalStops()
+            await presentTerminationFailure()
+            return false
+        }
+
         // Two-phase destructive commit: no project is mutated until every
         // project/terminal/task and editor authorization above passes.
         for projectManager in registry.openProjects.values {
             let identifier = ObjectIdentifier(projectManager)
             if let authorization = discardAuthorizations[identifier],
                !projectManager.canCommitDiscard(authorization) {
-                await rollbackAgentTasks()
+                await rollbackAfterRequestedTerminalStops()
                 await presentTerminationFailure()
                 return false
             }
@@ -3172,7 +3294,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                    authorization,
                    postReloadNotifications: false
                 ) {
-                await rollbackAgentTasks()
+                await rollbackAfterRequestedTerminalStops()
                 await presentTerminationFailure()
                 return false
             }
@@ -3184,7 +3306,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             Logger.app.critical(
                 "Prepared user-task shutdown changed during synchronous commit"
             )
-            await rollbackAgentTasks()
+            await rollbackAfterRequestedTerminalStops()
             await presentTerminationFailure()
             return false
         }

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -1534,6 +1534,10 @@ final class ProjectManager {
     let taskRunStore = UserTaskRunStore()
     /// Recovery snapshots and their lifecycle are owned by the main actor.
     private(set) var recoveryManager: RecoveryManager?
+    /// Project-scoped session persistence. Production uses `.standard`;
+    /// process-level lifecycle tests inject a namespaced suite so launching a
+    /// second real Pine process cannot read or overwrite developer state.
+    let sessionDefaults: UserDefaults
     private(set) var presentationLifecycle: PresentationLifecycle = .visible
     #if DEBUG
     private(set) var editorServiceSuspendCountForTesting = 0
@@ -1559,6 +1563,7 @@ final class ProjectManager {
 
     init(
         lspSettings: LSPSettings = .shared,
+        sessionDefaults: UserDefaults = .standard,
         agentProcessSnapshotPoller: AgentProcessSnapshotPoller? = nil,
         agentTaskRegistry: AgentTaskRegistry? = nil,
         workspaceFilesystemValidationSeam:
@@ -1567,6 +1572,7 @@ final class ProjectManager {
         contextPresentationIdentity: ContextPresentationIdentity =
             ContextPresentationIdentity(epoch: 1)
     ) {
+        self.sessionDefaults = sessionDefaults
         self.workspace = WorkspaceManager(
             filesystemValidationSeam: workspaceFilesystemValidationSeam
         )
@@ -2086,7 +2092,8 @@ final class ProjectManager {
             paneActiveEditorPaths: paneActiveEditorPaths,
             panePinnedPaths: panePinnedPaths,
             paneTransientPreviewPaths: paneTransientPreviewPaths,
-            globalTabSwitchOrder: globalTabSwitchOrder
+            globalTabSwitchOrder: globalTabSwitchOrder,
+            defaults: sessionDefaults
         )
     }
 

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -1710,6 +1710,7 @@ final class ProjectRegistry: LSPSettingsObserver {
         contextPresentationEpochs[canonical] = contextEpoch
         let pm = ProjectManager(
             lspSettings: lspSettings,
+            sessionDefaults: defaults,
             agentProcessSnapshotPoller: agentProcessSnapshotPoller,
             agentTaskRegistry: agentTasks,
             workspaceFilesystemValidationSeam:

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -255,6 +255,55 @@ struct TerminalTabCloseAuthorization {
         }
         return true
     }
+
+    /// Requests the final, authorization-fenced terminal stops for application
+    /// Quit. The caller collects every project and Quick Terminal controller
+    /// before performing one shared wait, so all trees tear down concurrently.
+    func requestAuthorizedStops(
+        _ tabs: [TerminalTab],
+        pineAgentLaunches: PineAgentLaunchAuthorization? = nil,
+        currentPineAgentLaunches: PineAgentLaunchAuthorization? = nil
+    ) -> [TerminalProcessTreeController]? {
+        guard stillCovers(
+            tabs,
+            pineAgentLaunches: pineAgentLaunches,
+            currentPineAgentLaunches: currentPineAgentLaunches
+        ) else { return nil }
+        var controllers: [TerminalProcessTreeController] = []
+        var runningTreeWasUnowned = false
+        for tab in tabs {
+            let wasRunning = tab.isProcessRunning
+            if let controller = tab.stopForApplicationTermination() {
+                controllers.append(controller)
+            } else if wasRunning {
+                runningTreeWasUnowned = true
+            }
+        }
+        return runningTreeWasUnowned ? nil : controllers
+    }
+
+    /// Waits off-main for every exact process tree to finish its bounded
+    /// TERM-to-KILL cleanup under one absolute application-Quit deadline.
+    static func waitForAuthorizedStops(
+        _ controllers: [TerminalProcessTreeController],
+        until deadline: DispatchTime
+    ) async -> Bool {
+        guard !controllers.isEmpty else { return true }
+
+        return await Task.detached(priority: .userInitiated) {
+            for controller in controllers {
+                let now = DispatchTime.now().uptimeNanoseconds
+                guard now < deadline.uptimeNanoseconds else { return false }
+                let remaining = Double(
+                    deadline.uptimeNanoseconds - now
+                ) / 1_000_000_000
+                guard controller.waitForTermination(timeout: remaining) else {
+                    return false
+                }
+            }
+            return true
+        }.value
+    }
 }
 
 @MainActor

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -1851,6 +1851,7 @@ final class TerminalTab: Identifiable, Hashable {
     let terminalView: LocalProcessTerminalView
     fileprivate(set) var isTerminated = false
     private var didReportLifecycleEnd = false
+    private var deferredTerminationLifecycleEnd = false
     /// The AppKit container currently presenting `terminalView`.
     ///
     /// A pane maximize/restore can keep outgoing and incoming SwiftUI
@@ -2263,6 +2264,32 @@ final class TerminalTab: Identifiable, Hashable {
         terminalView.terminate()
     }
 
+    /// Starts final application-termination cleanup and returns the exact
+    /// process-tree owner whose bounded completion must be observed before
+    /// the Pine process is allowed to exit. Ordinary tab closes remain
+    /// asynchronous; only the app-wide Quit transaction waits for this
+    /// handle, because exiting the parent would otherwise abandon its cleanup
+    /// queue and could leave foreground/background descendants alive.
+    func stopForApplicationTermination() -> TerminalProcessTreeController? {
+        let controller = processTreeController
+        if !didReportLifecycleEnd {
+            didReportLifecycleEnd = true
+            deferredTerminationLifecycleEnd = true
+        }
+        stop()
+        return controller
+    }
+
+    /// A failed application-Quit transaction keeps the process stopped but
+    /// returns Pine to normal task ownership. Publish the lifecycle end only
+    /// after the durable termination snapshot has been rolled back, so an
+    /// acknowledged launch cannot disappear from that snapshot mid-commit.
+    func reportDeferredApplicationTerminationLifecycleEnd() {
+        guard deferredTerminationLifecycleEnd else { return }
+        deferredTerminationLifecycleEnd = false
+        onLifecycleEnded?(id)
+    }
+
     func processDidTerminate() {
         if !didReportLifecycleEnd {
             didReportLifecycleEnd = true
@@ -2387,6 +2414,7 @@ final class TerminalTab: Identifiable, Hashable {
     }
 
     private func readForegroundProcessID() -> Int32 {
+        guard !isTerminated else { return -1 }
         #if DEBUG
         if let foregroundProcessIDResolverForTesting {
             return foregroundProcessIDResolverForTesting()

--- a/PineTests/ApplicationLifecycleProcessTests.swift
+++ b/PineTests/ApplicationLifecycleProcessTests.swift
@@ -1,0 +1,685 @@
+//
+//  ApplicationLifecycleProcessTests.swift
+//  PineTests
+//
+
+import Darwin
+import Foundation
+import Testing
+
+@testable import Pine
+
+nonisolated private enum ApplicationLifecycleHarnessError:
+    Error, CustomStringConvertible {
+    case launchFailed
+    case processIdentityUnavailable
+    case phaseTimedOut(String)
+    case driverFailed(String)
+    case unexpectedExit(String)
+
+    var description: String {
+        switch self {
+        case .launchFailed:
+            "Pine lifecycle harness could not launch the app process"
+        case .processIdentityUnavailable:
+            "Pine lifecycle harness could not capture an exact app identity"
+        case .phaseTimedOut(let phase):
+            "Pine lifecycle harness timed out in phase: \(phase)"
+        case .driverFailed(let code):
+            "Pine lifecycle driver failed with sanitized code: \(code)"
+        case .unexpectedExit(let phase):
+            "Pine lifecycle process exited unexpectedly in phase: \(phase)"
+        }
+    }
+}
+
+nonisolated private struct ApplicationLifecycleProcessExit: Sendable {
+    let reason: Process.TerminationReason
+    let status: Int32
+}
+
+nonisolated private final class ApplicationLifecycleLaunchedProcess:
+    @unchecked Sendable {
+    let process: Process
+    let identity: UserTaskProcessIdentity
+    let stateDirectory: URL
+
+    private let standardOutputHandle: FileHandle
+    private let standardErrorHandle: FileHandle
+
+    init(
+        executableURL: URL,
+        configuration: ApplicationLifecycleProcessConfiguration,
+        stateDirectory: URL,
+        pauseAtSessionCheckpoint: Bool = false
+    ) throws {
+        self.stateDirectory = stateDirectory
+        try FileManager.default.createDirectory(
+            at: stateDirectory,
+            withIntermediateDirectories: true
+        )
+        let configurationURL = stateDirectory.appending(path: "config.json")
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        try encoder.encode(configuration).write(
+            to: configurationURL,
+            options: .atomic
+        )
+
+        let stdoutURL = stateDirectory.appending(path: "stdout.log")
+        let stderrURL = stateDirectory.appending(path: "stderr.log")
+        FileManager.default.createFile(
+            atPath: stdoutURL.path,
+            contents: nil
+        )
+        FileManager.default.createFile(
+            atPath: stderrURL.path,
+            contents: nil
+        )
+        standardOutputHandle = try FileHandle(forWritingTo: stdoutURL)
+        standardErrorHandle = try FileHandle(forWritingTo: stderrURL)
+
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = [
+            "--application-lifecycle-process-test",
+            "--disable-agent-detection",
+            "--disable-metal",
+            "--disable-quick-terminal",
+            "--disable-terminal-seeding",
+            "-ApplePersistenceIgnoreState",
+            "YES",
+        ]
+        var environment = ProcessInfo.processInfo.environment
+        for key in [
+            "XCInjectBundleInto",
+            "XCTestBundlePath",
+            "XCTestConfigurationFilePath",
+            "DYLD_INSERT_LIBRARIES",
+            "LLVM_PROFILE_FILE",
+        ] {
+            environment.removeValue(forKey: key)
+        }
+        environment["PINE_APPLICATION_LIFECYCLE_CONFIG"] =
+            configurationURL.path
+        environment["PINE_DISABLE_AGENT_DETECTION"] = "1"
+        environment["PINE_DISABLE_METAL"] = "1"
+        environment["PINE_DISABLE_QUICK_TERMINAL"] = "1"
+        if pauseAtSessionCheckpoint {
+            environment["PINE_PERSISTENCE_PAUSE"] =
+                "session:before-atomic-replace"
+            environment["PINE_PERSISTENCE_CHECKPOINT_DIRECTORY"] =
+                stateDirectory.path
+        }
+        process.environment = environment
+        process.standardOutput = standardOutputHandle
+        process.standardError = standardErrorHandle
+
+        do {
+            try process.run()
+        } catch {
+            standardOutputHandle.closeFile()
+            standardErrorHandle.closeFile()
+            throw ApplicationLifecycleHarnessError.launchFailed
+        }
+        self.process = process
+
+        let deadline = DispatchTime.now() + .seconds(2)
+        var capturedIdentity: UserTaskProcessIdentity?
+        repeat {
+            capturedIdentity = UserTaskProcessInspector.identity(
+                for: process.processIdentifier
+            )
+            if capturedIdentity != nil { break }
+            Darwin.usleep(10_000)
+        } while DispatchTime.now() < deadline
+        guard let capturedIdentity else {
+            if process.isRunning {
+                process.terminate()
+            }
+            throw ApplicationLifecycleHarnessError
+                .processIdentityUnavailable
+        }
+        identity = capturedIdentity
+    }
+
+    deinit {
+        standardOutputHandle.closeFile()
+        standardErrorHandle.closeFile()
+    }
+
+    func evidence(
+        phase: String,
+        timeout: TimeInterval = 10
+    ) async throws -> ApplicationLifecycleProcessEvidence {
+        let eventURL = stateDirectory
+            .appending(path: "events", directoryHint: .isDirectory)
+            .appending(path: phase + ".json")
+        let failureURL = stateDirectory
+            .appending(path: "events", directoryHint: .isDirectory)
+            .appending(path: "driver-failed.json")
+        let deadline = DispatchTime.now() + timeout
+        while DispatchTime.now() < deadline {
+            if let failure = Self.decodeEvidence(at: failureURL) {
+                throw ApplicationLifecycleHarnessError.driverFailed(
+                    failure.failureCode ?? "unspecified"
+                )
+            }
+            if let evidence = Self.decodeEvidence(at: eventURL) {
+                return evidence
+            }
+            if !process.isRunning {
+                throw ApplicationLifecycleHarnessError.unexpectedExit(
+                    phase
+                )
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        throw ApplicationLifecycleHarnessError.phaseTimedOut(phase)
+    }
+
+    func waitForFile(
+        named name: String,
+        timeout: TimeInterval = 10
+    ) async throws -> URL {
+        let url = stateDirectory.appending(path: name)
+        let deadline = DispatchTime.now() + timeout
+        while DispatchTime.now() < deadline {
+            if FileManager.default.fileExists(atPath: url.path) { return url }
+            if !process.isRunning {
+                throw ApplicationLifecycleHarnessError.unexpectedExit(name)
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        throw ApplicationLifecycleHarnessError.phaseTimedOut(name)
+    }
+
+    func sendCommand(_ name: String) async throws {
+        let directory = stateDirectory.appending(
+            path: "commands",
+            directoryHint: .isDirectory
+        )
+        let destination = directory.appending(path: name)
+        try await Task.detached(priority: .utility) {
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+            try Data().write(to: destination, options: .atomic)
+        }.value
+    }
+
+    func waitForExit(timeout: TimeInterval = 10) async throws
+        -> ApplicationLifecycleProcessExit {
+        let process = process
+        let deadline = DispatchTime.now() + timeout
+        while process.isRunning, DispatchTime.now() < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        guard !process.isRunning else {
+            throw ApplicationLifecycleHarnessError.phaseTimedOut(
+                "process-exit"
+            )
+        }
+        await Task.detached(priority: .utility) {
+            process.waitUntilExit()
+        }.value
+        standardOutputHandle.synchronizeFile()
+        standardErrorHandle.synchronizeFile()
+        return ApplicationLifecycleProcessExit(
+            reason: process.terminationReason,
+            status: process.terminationStatus
+        )
+    }
+
+    func killIfRunning(signal: Int32 = SIGKILL) {
+        guard process.isRunning,
+              UserTaskProcessInspector.identity(
+                for: identity.processID
+              ) == identity else { return }
+        _ = Darwin.kill(identity.processID, signal)
+    }
+
+    nonisolated private static func decodeEvidence(
+        at url: URL
+    ) -> ApplicationLifecycleProcessEvidence? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(
+            ApplicationLifecycleProcessEvidence.self,
+            from: data
+        )
+    }
+}
+
+@Suite("Application lifecycle process gate", .serialized)
+struct ApplicationLifecycleProcessTests {
+    private struct PersistenceCheckpoint: Codable {
+        let store: String
+        let phase: String
+        let processIdentifier: Int32
+    }
+
+    private struct Fixture {
+        let project: URL
+        let primaryFile: URL
+        let secondaryFile: URL
+        let defaultsSuite: String
+        let terminalFixture: URL
+    }
+
+    @Test("quit, crash, and relaunch preserve the durable lifecycle contract")
+    func quitCrashAndRelaunchJourney() async throws {
+        let root = FileManager.default.temporaryDirectory.appending(
+            path: "pine-application-lifecycle-\(UUID().uuidString)",
+            directoryHint: .isDirectory
+        )
+        let project = root.appending(
+            path: "Lifecycle Project",
+            directoryHint: .isDirectory
+        )
+        let primaryFile = project.appending(path: "committed.swift")
+        let secondaryFile = project.appending(path: "interrupted.swift")
+        try FileManager.default.createDirectory(
+            at: project,
+            withIntermediateDirectories: true
+        )
+        try "// initial lifecycle fixture\n".write(
+            to: primaryFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        try "// secondary lifecycle fixture\n".write(
+            to: secondaryFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        let defaultsSuite =
+            "PineTests.ApplicationLifecycle.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsSuite))
+        defaults.removePersistentDomain(forName: defaultsSuite)
+        let executableURL = try #require(Bundle.main.executableURL)
+        let terminalFixture = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appending(path: "Fixtures/Terminal/pty-process-tree.sh")
+        let fixture = Fixture(
+            project: project,
+            primaryFile: primaryFile,
+            secondaryFile: secondaryFile,
+            defaultsSuite: defaultsSuite,
+            terminalFixture: terminalFixture
+        )
+
+        let unrelated = Process()
+        unrelated.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        unrelated.arguments = ["30"]
+        try unrelated.run()
+        let unrelatedIdentity = try #require(
+            UserTaskProcessInspector.identity(
+                for: unrelated.processIdentifier
+            )
+        )
+
+        var launchedProcesses: [ApplicationLifecycleLaunchedProcess] = []
+        var ownedTerminalIdentities: [UserTaskProcessIdentity] = []
+        defer {
+            retainSanitizedDiagnostics(from: root)
+            for launched in launchedProcesses {
+                launched.killIfRunning()
+            }
+            for identity in ownedTerminalIdentities where
+                    UserTaskProcessInspector.identity(
+                        for: identity.processID
+                    ) == identity {
+                _ = Darwin.kill(identity.processID, SIGKILL)
+            }
+            if unrelated.isRunning,
+               UserTaskProcessInspector.identity(
+                for: unrelatedIdentity.processID
+               ) == unrelatedIdentity {
+                unrelated.terminate()
+                unrelated.waitUntilExit()
+            }
+            defaults.removePersistentDomain(forName: defaultsSuite)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let interactiveState = root.appending(
+            path: "generation-1",
+            directoryHint: .isDirectory
+        )
+        let interactiveConfiguration = makeConfiguration(
+            scenario: .interactiveQuit,
+            stateDirectory: interactiveState,
+            fixture: fixture
+        )
+        let first = try ApplicationLifecycleLaunchedProcess(
+            executableURL: executableURL,
+            configuration: interactiveConfiguration,
+            stateDirectory: interactiveState
+        )
+        launchedProcesses.append(first)
+
+        let ready = try await first.evidence(phase: "interactive-ready")
+        #expect(ready.dirtyContentPresent == true)
+        #expect(ready.terminalRunning == true)
+        #expect(ready.windowVisible == true)
+        let rootIdentity = try #require(
+            ready.terminalRoot?.userTaskIdentity
+        )
+        let childIdentity = try #require(
+            ready.terminalChild?.userTaskIdentity
+        )
+        ownedTerminalIdentities.append(contentsOf: [
+            rootIdentity,
+            childIdentity,
+        ])
+        #expect(identityIsLive(rootIdentity))
+        #expect(identityIsLive(childIdentity))
+
+        let visible = try await first.evidence(
+            phase: "confirmation-visible"
+        )
+        #expect(visible.confirmationVisible == true)
+        try await first.sendCommand("replace-and-cancel")
+        let replacement = try await first.evidence(
+            phase: "replacement-while-confirming"
+        )
+        let replacementIdentity = try #require(
+            replacement.terminalReplacement?.userTaskIdentity
+        )
+        ownedTerminalIdentities.append(replacementIdentity)
+        #expect(replacement.confirmationVisible == true)
+        #expect(replacement.terminalRunning == true)
+        #expect(replacementIdentity != childIdentity)
+
+        let cancelled = try await first.evidence(
+            phase: "cancelled-usable"
+        )
+        #expect(cancelled.dirtyContentPresent == true)
+        #expect(cancelled.terminalRunning == true)
+        #expect(cancelled.windowVisible == true)
+        #expect(cancelled.inputAccepted == true)
+
+        try await first.sendCommand("retry-failure")
+        let failedSave = try await first.evidence(
+            phase: "save-failure-usable"
+        )
+        #expect(failedSave.dirtyContentPresent == true)
+        #expect(failedSave.terminalRunning == true)
+        #expect(failedSave.windowVisible == true)
+        #expect(failedSave.inputAccepted == true)
+
+        let livePineDescendants = descendantIdentities(of: first.identity)
+        #expect(livePineDescendants.contains(rootIdentity))
+        ownedTerminalIdentities.append(contentsOf: livePineDescendants)
+
+        try await first.sendCommand("retry-success")
+        let confirmed = try await first.evidence(
+            phase: "confirmed-quit"
+        )
+        #expect(confirmed.dirtyContentPresent == false)
+        #expect(confirmed.terminalRunning == false)
+        #expect(confirmed.windowVisible == true)
+        #expect(confirmed.savedToDisk == true)
+        let firstExit = try await first.waitForExit()
+        #expect(firstExit.reason == .exit)
+        #expect(firstExit.status == 0)
+        #expect(await waitUntilIdentitiesExit(ownedTerminalIdentities))
+        #expect(identityIsLive(unrelatedIdentity))
+
+        defaults.synchronize()
+        let committedSession = try #require(SessionState.load(
+            for: project,
+            defaults: defaults
+        ))
+        #expect(
+            committedSession.existingFileURLs.map(\.standardizedFileURL)
+                == [primaryFile.standardizedFileURL]
+        )
+
+        let crashState = root.appending(
+            path: "generation-2",
+            directoryHint: .isDirectory
+        )
+        let crashConfiguration = makeConfiguration(
+            scenario: .interruptedSessionSave,
+            stateDirectory: crashState,
+            fixture: fixture
+        )
+        let second = try ApplicationLifecycleLaunchedProcess(
+            executableURL: executableURL,
+            configuration: crashConfiguration,
+            stateDirectory: crashState,
+            pauseAtSessionCheckpoint: true
+        )
+        launchedProcesses.append(second)
+        let crashReady = try await second.evidence(
+            phase: "crash-generation-ready"
+        )
+        #expect(crashReady.restoredFileCount == 1)
+        #expect(crashReady.restoredTerminalCount == 1)
+        #expect(crashReady.staleProcessOwnership == false)
+        _ = try await second.evidence(
+            phase: "crash-termination-committed"
+        )
+        let checkpointURL = try await second.waitForFile(
+            named: "persistence-checkpoint.json"
+        )
+        let checkpoint = try String(
+            contentsOf: checkpointURL,
+            encoding: .utf8
+        )
+        #expect(checkpoint.contains("\"store\":\"session\""))
+        #expect(checkpoint.contains(
+            "\"phase\":\"before-atomic-replace\""
+        ))
+        #expect(identityIsLive(second.identity))
+        second.killIfRunning()
+        let secondExit = try await second.waitForExit()
+        #expect(secondExit.reason == .uncaughtSignal)
+        #expect(secondExit.status == SIGKILL)
+
+        let restoreState = root.appending(
+            path: "generation-3",
+            directoryHint: .isDirectory
+        )
+        let restoreConfiguration = makeConfiguration(
+            scenario: .verifyRestoration,
+            stateDirectory: restoreState,
+            fixture: fixture
+        )
+        let third = try ApplicationLifecycleLaunchedProcess(
+            executableURL: executableURL,
+            configuration: restoreConfiguration,
+            stateDirectory: restoreState
+        )
+        launchedProcesses.append(third)
+        let restored = try await third.evidence(
+            phase: "restoration-verified"
+        )
+        #expect(restored.savedToDisk == true)
+        #expect(restored.restoredFileCount == 1)
+        #expect(restored.restoredTerminalCount == 1)
+        #expect(restored.staleProcessOwnership == false)
+        let thirdExit = try await third.waitForExit()
+        #expect(thirdExit.reason == .exit)
+        #expect(thirdExit.status == 0)
+
+        #expect(!identityIsLive(first.identity))
+        #expect(!identityIsLive(second.identity))
+        #expect(!identityIsLive(third.identity))
+        #expect(await waitUntilIdentitiesExit(ownedTerminalIdentities))
+        #expect(identityIsLive(unrelatedIdentity))
+    }
+
+    private func makeConfiguration(
+        scenario: ApplicationLifecycleProcessScenario,
+        stateDirectory: URL,
+        fixture: Fixture
+    ) -> ApplicationLifecycleProcessConfiguration {
+        ApplicationLifecycleProcessConfiguration(
+            scenario: scenario,
+            stateDirectoryPath: stateDirectory.path,
+            projectPath: fixture.project.path,
+            primaryFilePath: fixture.primaryFile.path,
+            secondaryFilePath: fixture.secondaryFile.path,
+            defaultsSuiteName: fixture.defaultsSuite,
+            terminalFixturePath: fixture.terminalFixture.path
+        )
+    }
+
+    private func retainSanitizedDiagnostics(from root: URL) {
+        let sourceRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let configuredDestination = ProcessInfo.processInfo.environment[
+            "PINE_LIFECYCLE_DIAGNOSTICS"
+        ].flatMap { path in
+            path.isEmpty ? nil : URL(
+                fileURLWithPath: path,
+                isDirectory: true
+            )
+        }
+        let destination = configuredDestination ?? sourceRoot.appending(
+            path: "LifecycleDiagnostics",
+            directoryHint: .isDirectory
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        for generation in ["generation-1", "generation-2", "generation-3"] {
+            let source = root.appending(
+                path: generation,
+                directoryHint: .isDirectory
+            )
+            let retained = destination.appending(
+                path: generation,
+                directoryHint: .isDirectory
+            )
+            let events = source.appending(
+                path: "events",
+                directoryHint: .isDirectory
+            )
+            if let eventURLs = try? FileManager.default.contentsOfDirectory(
+                at: events,
+                includingPropertiesForKeys: nil
+            ) {
+                let retainedEvents = retained.appending(
+                    path: "events",
+                    directoryHint: .isDirectory
+                )
+                try? FileManager.default.createDirectory(
+                    at: retainedEvents,
+                    withIntermediateDirectories: true
+                )
+                for eventURL in eventURLs where
+                        eventURL.pathExtension == "json" {
+                    guard let data = try? Data(contentsOf: eventURL),
+                          let evidence = try? JSONDecoder().decode(
+                              ApplicationLifecycleProcessEvidence.self,
+                              from: data
+                          ),
+                          let sanitized = try? encoder.encode(evidence) else {
+                        continue
+                    }
+                    try? sanitized.write(
+                        to: retainedEvents.appending(
+                            path: eventURL.lastPathComponent
+                        ),
+                        options: .atomic
+                    )
+                }
+            }
+
+            let checkpointURL = source.appending(
+                path: "persistence-checkpoint.json"
+            )
+            guard let checkpointData = try? Data(contentsOf: checkpointURL),
+                  let checkpoint = try? JSONDecoder().decode(
+                      PersistenceCheckpoint.self,
+                      from: checkpointData
+                  ),
+                  let sanitized = try? encoder.encode(checkpoint) else {
+                continue
+            }
+            try? FileManager.default.createDirectory(
+                at: retained,
+                withIntermediateDirectories: true
+            )
+            try? sanitized.write(
+                to: retained.appending(
+                    path: "persistence-checkpoint.json"
+                ),
+                options: .atomic
+            )
+        }
+    }
+
+    nonisolated private func identityIsLive(
+        _ identity: UserTaskProcessIdentity
+    ) -> Bool {
+        UserTaskProcessInspector.identity(for: identity.processID) == identity
+    }
+
+    nonisolated private func waitUntilIdentitiesExit(
+        _ identities: [UserTaskProcessIdentity],
+        timeout: TimeInterval = 3
+    ) async -> Bool {
+        let deadline = DispatchTime.now() + timeout
+        while DispatchTime.now() < deadline {
+            if identities.allSatisfy({ !identityIsLive($0) }) {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return identities.allSatisfy { !identityIsLive($0) }
+    }
+
+    nonisolated private func descendantIdentities(
+        of root: UserTaskProcessIdentity
+    ) -> [UserTaskProcessIdentity] {
+        var pending = [root]
+        var visited: Set<UserTaskProcessIdentity> = []
+        var descendants: Set<UserTaskProcessIdentity> = []
+        while let parent = pending.popLast(),
+              visited.count < 1_024 {
+            guard visited.insert(parent).inserted else { continue }
+            for processIdentifier in childProcessIdentifiers(
+                of: parent.processID
+            ) {
+                guard let child = UserTaskProcessInspector.identity(
+                    for: processIdentifier,
+                    expectedParent: parent.processID
+                ) else { continue }
+                descendants.insert(child)
+                pending.append(child)
+            }
+        }
+        return Array(descendants)
+    }
+
+    nonisolated private func childProcessIdentifiers(
+        of parent: pid_t
+    ) -> [pid_t] {
+        let requestedCount = proc_listchildpids(parent, nil, 0)
+        guard requestedCount > 0 else { return [] }
+        let capacity = min(max(Int(requestedCount) + 16, 16), 1_024)
+        var processIdentifiers = [pid_t](repeating: 0, count: capacity)
+        let returnedCount = processIdentifiers.withUnsafeMutableBytes { buffer in
+            proc_listchildpids(
+                parent,
+                buffer.baseAddress,
+                Int32(buffer.count)
+            )
+        }
+        guard returnedCount > 0,
+              Int(returnedCount) < processIdentifiers.count else {
+            return []
+        }
+        return Array(
+            processIdentifiers
+                .prefix(Int(returnedCount))
+                .filter { $0 > 1 }
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add a deterministic process-level gate that launches three real Pine processes across cancel, save failure, confirmed quit, interrupted session publication, and relaunch
- stop all authorized terminal process trees before application exit under one deadline while preserving agent-task rollback semantics and unrelated processes
- retain whitelisted lifecycle phase diagnostics together with the unit-test xcresult artifact in CI
- isolate real-process session persistence in a namespaced defaults suite

## Review

Pre-PR review completed. Findings around cross-project stop concurrency, terminated foreground overrides, deferred agent lifecycle callbacks, descendant coverage, and diagnostics retention were fixed before opening this PR.

## Validation

- strict SwiftLint on every changed Swift file
- lifecycle, window termination, agent authorization, session, persistence-fault, and PTY process-tree suites
- full PineTests with CI retry, timeout, and serial settings; fuzz tests and AgentInboxToolbarButtonSnapshotTests excluded locally
- PineUITests were not run locally

Environment:
- macOS 27.0, build 26A5406e
- Xcode 27.0, build 27A5218g
- macOS SDK 27.0, build 26A5378i
- deployment target remains macOS 26.0

Closes #1437