### PR TITLE
test(release): gate signed DMG lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
       - name: Tests for DMG packaging scripts
         run: bash scripts/tests/test-dmg-packaging.sh
 
+      - name: Tests for release artifact smoke
+        run: bash scripts/tests/test-release-artifact-smoke.sh
+
       - name: Tests for screenshot workflow coverage
         run: bash scripts/tests/test-screenshot-workflow.sh
 
@@ -578,7 +581,7 @@ jobs:
               -only-testing:PineUITests/BranchSwitcherTests
               -only-testing:PineUITests/CheckForUpdatesTests
               -only-testing:PineUITests/SplitPaneRoutingUITests
-          # Shard 5 — Files & Save (33 tests)
+          # Shard 5 — Files & Save (34 tests, release smoke skips outside release CI)
           - shard-name: "Files & Save"
             test-classes: >-
               -only-testing:PineUITests/EditorSaveFlowTests
@@ -587,6 +590,7 @@ jobs:
               -only-testing:PineUITests/SidebarFileOperationsTests
               -only-testing:PineUITests/UserTaskExecutionUITests
               -only-testing:PineUITests/UnsavedChangesUITests
+              -only-testing:PineUITests/ReleaseArtifactSmokeTests
           # Shard 6 — Search & Panes (32 tests)
           - shard-name: "Search & Panes"
             test-classes: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   build-and-release:
     runs-on: macos-26
-    timeout-minutes: 45
+    timeout-minutes: 90
     permissions:
       contents: write
     steps:
@@ -60,6 +60,7 @@ jobs:
             -scheme Pine \
             -archivePath $RUNNER_TEMP/Pine.xcarchive \
             -destination "generic/platform=macOS" \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages" \
             CODE_SIGN_IDENTITY="Developer ID Application" \
             DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
             CODE_SIGN_STYLE=Manual \
@@ -218,6 +219,67 @@ jobs:
           fi
           echo "Appcast URL and DMG file validated successfully"
 
+      - name: Download previous signed release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RELEASES_JSON=$(gh release list \
+            --exclude-drafts \
+            --exclude-pre-releases \
+            --limit 20 \
+            --json tagName)
+          PREVIOUS_TAG=$(RELEASES_JSON="$RELEASES_JSON" \
+            CURRENT_TAG="$GITHUB_REF_NAME" \
+            python3 -c '
+          import json
+          import os
+
+          releases = json.loads(os.environ["RELEASES_JSON"])
+          current = os.environ["CURRENT_TAG"]
+          print(next((
+              release["tagName"]
+              for release in releases
+              if release["tagName"] != current
+          ), ""))
+          ')
+          [ -n "$PREVIOUS_TAG" ] || {
+            echo "::error::No previous stable Pine release found"
+            exit 1
+          }
+
+          mkdir -p "$RUNNER_TEMP/previous-release"
+          gh release download "$PREVIOUS_TAG" \
+            --pattern 'Pine-*.dmg' \
+            --dir "$RUNNER_TEMP/previous-release"
+
+          PREVIOUS_DMGS=("$RUNNER_TEMP"/previous-release/Pine-*.dmg)
+          if [ "${#PREVIOUS_DMGS[@]}" -ne 1 ] \
+            || [ ! -f "${PREVIOUS_DMGS[0]}" ]; then
+            echo "::error::Expected exactly one previous Pine DMG"
+            exit 1
+          fi
+          echo "PREVIOUS_DMG=${PREVIOUS_DMGS[0]}" >> "$GITHUB_ENV"
+          echo "Previous signed release: $PREVIOUS_TAG"
+
+      - name: Record candidate DMG hash before publication
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          mkdir -p "$RUNNER_TEMP/publication-metadata"
+          shasum -a 256 "$RUNNER_TEMP/Pine-${VERSION}.dmg" \
+            | tee "$RUNNER_TEMP/publication-metadata/candidate-before-publication.sha256"
+
+      - name: Run signed release artifact smoke
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          bash scripts/release-artifact-smoke.sh \
+            "$RUNNER_TEMP/Pine-${VERSION}.dmg" \
+            "$PREVIOUS_DMG" \
+            "$VERSION" \
+            "$GITHUB_RUN_NUMBER" \
+            "$RUNNER_TEMP/appcast.xml" \
+            "$RUNNER_TEMP/SourcePackages/checkouts/Sparkle" \
+            "$RUNNER_TEMP/release-smoke"
+
       - name: Upload DMG to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -234,6 +296,45 @@ jobs:
               --title "Pine ${VERSION}" \
               --generate-notes
           fi
+
+      - name: Verify published DMG matches tested bytes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          mkdir -p "$RUNNER_TEMP/published-release"
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern "Pine-${VERSION}.dmg" \
+            --dir "$RUNNER_TEMP/published-release"
+
+          PUBLISHED_DMG="$RUNNER_TEMP/published-release/Pine-${VERSION}.dmg"
+          shasum -a 256 "$PUBLISHED_DMG" \
+            | tee "$RUNNER_TEMP/publication-metadata/candidate-after-publication.sha256"
+          TESTED_SHA=$(awk '{print $1}' \
+            "$RUNNER_TEMP/publication-metadata/candidate-before-publication.sha256")
+          PUBLISHED_SHA=$(awk '{print $1}' \
+            "$RUNNER_TEMP/publication-metadata/candidate-after-publication.sha256")
+          if [ "$PUBLISHED_SHA" != "$TESTED_SHA" ]; then
+            echo "::error::Published DMG differs from the tested candidate"
+            exit 1
+          fi
+
+      - name: Upload release smoke diagnostics
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-smoke-diagnostics-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/release-smoke/logs
+            ${{ runner.temp }}/release-smoke/ReleaseArtifactSmoke.xcresult
+            ${{ runner.temp }}/release-smoke/metadata/appcast.json
+            ${{ runner.temp }}/release-smoke/metadata/release-smoke.txt
+            ${{ runner.temp }}/release-smoke/metadata/toolchain.txt
+            ${{ runner.temp }}/release-smoke/metadata/candidate-before-smoke.sha256
+            ${{ runner.temp }}/release-smoke/metadata/candidate-after-smoke.sha256
+            ${{ runner.temp }}/publication-metadata
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Update Homebrew Tap
         env:

--- a/PineUITests/ReleaseArtifactSmokeTests.swift
+++ b/PineUITests/ReleaseArtifactSmokeTests.swift
@@ -1,0 +1,541 @@
+//
+//  ReleaseArtifactSmokeTests.swift
+//  PineUITests
+//
+
+import AppKit
+import Foundation
+import XCTest
+
+/// Release-only coverage for the exact signed application extracted from the
+/// final DMG. The normal UI shards intentionally skip this class: the release
+/// workflow supplies paths to signed artifacts and a locally served appcast.
+final class ReleaseArtifactSmokeTests: PineUITestCase {
+    private static let bundleIdentifier = "io.github.batonogov.pine"
+    private static let fixtureFileName = "ReleaseSmoke.swift"
+
+    private var activeApplication: XCUIApplication?
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    override func tearDown() {
+        if let activeApplication,
+           activeApplication.state != .notRunning {
+            activeApplication.terminate()
+        }
+        activeApplication = nil
+        super.tearDown()
+    }
+
+    func testSignedDMGLifecycleAndSparkleUpdate() throws {
+        let configuration = try ReleaseSmokeConfiguration.fromEnvironment()
+
+        let candidateHome = configuration.userRoot.appendingPathComponent(
+            "candidate-home",
+            isDirectory: true
+        )
+        let updateHome = configuration.userRoot.appendingPathComponent(
+            "update-home",
+            isDirectory: true
+        )
+        try prepareHome(candidateHome)
+        try prepareHome(updateHome)
+
+        var application = try launchThroughLaunchServices(
+            configuration.candidateApplication,
+            home: candidateHome,
+            project: nil,
+            logName: "candidate-welcome",
+            configuration: configuration
+        )
+        XCTAssertTrue(
+            application.buttons["welcomeOpenFolderButton"]
+                .waitForExistence(timeout: 20),
+            "The signed candidate must present its Welcome window"
+        )
+        try quitNormally(application)
+
+        application = try launchThroughLaunchServices(
+            configuration.candidateApplication,
+            home: candidateHome,
+            project: configuration.project,
+            logName: "candidate-project",
+            configuration: configuration
+        )
+        try permanentlyOpenFixture(in: application)
+        try quitNormally(application)
+
+        application = try launchThroughLaunchServices(
+            configuration.candidateApplication,
+            home: candidateHome,
+            project: configuration.project,
+            logName: "candidate-relaunch",
+            configuration: configuration
+        )
+        XCTAssertTrue(
+            editorTab(in: application).waitForExistence(timeout: 20),
+            "The signed candidate must restore its durable editor session"
+        )
+        try quitNormally(application)
+
+        application = try launchThroughLaunchServices(
+            configuration.updateApplication,
+            home: updateHome,
+            project: configuration.project,
+            logName: "previous-version",
+            configuration: configuration
+        )
+        try permanentlyOpenFixture(in: application)
+        try quitNormally(application)
+
+        try installUpdate(configuration)
+        try verifyInstalledCandidate(configuration)
+
+        application = try launchThroughLaunchServices(
+            configuration.updateApplication,
+            home: updateHome,
+            project: configuration.project,
+            logName: "updated-version",
+            configuration: configuration
+        )
+        XCTAssertTrue(
+            editorTab(in: application).waitForExistence(timeout: 20),
+            "Sparkle update must retain the previous version's session"
+        )
+        try quitNormally(application)
+    }
+
+    private func prepareHome(_ home: URL) throws {
+        try FileManager.default.createDirectory(
+            at: home.appendingPathComponent("tmp", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: home.appendingPathComponent("Library", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+    }
+
+    private func launchThroughLaunchServices(
+        _ applicationURL: URL,
+        home: URL,
+        project: URL?,
+        logName: String,
+        configuration: ReleaseSmokeConfiguration
+    ) throws -> XCUIApplication {
+        let standardOutput = configuration.logs.appendingPathComponent(
+            "\(logName).stdout.log"
+        )
+        let standardError = configuration.logs.appendingPathComponent(
+            "\(logName).stderr.log"
+        )
+        let temporaryDirectory = home.appendingPathComponent(
+            "tmp",
+            isDirectory: true
+        )
+        _ = FileManager.default.createFile(
+            atPath: standardOutput.path,
+            contents: nil
+        )
+        _ = FileManager.default.createFile(
+            atPath: standardError.path,
+            contents: nil
+        )
+        var arguments = [
+            "-n",
+            "-F",
+            "-a", applicationURL.path,
+            "--stdout", standardOutput.path,
+            "--stderr", standardError.path,
+            "--env", "HOME=\(home.path)",
+            "--env", "CFFIXED_USER_HOME=\(home.path)",
+            "--env", "TMPDIR=\(temporaryDirectory.path)",
+            "--env", "PINE_DISABLE_AGENT_DETECTION=1",
+            "--env", "PINE_DISABLE_METAL=1",
+            "--env", "PINE_DISABLE_QUICK_TERMINAL=1"
+        ]
+        if let project {
+            arguments += ["--env", "PINE_OPEN_PROJECT=\(project.path)"]
+        }
+        arguments += [
+            "--args",
+            "--disable-agent-detection",
+            "--disable-metal",
+            "--disable-quick-terminal",
+            "--disable-terminal-seeding",
+            "-ApplePersistenceIgnoreState", "YES",
+            "-AppleLanguages", "(en)",
+            "-AppleLocale", "en_US"
+        ]
+
+        let launch = try runProcess(
+            executable: URL(fileURLWithPath: "/usr/bin/open"),
+            arguments: arguments,
+            timeout: 20,
+            logURL: configuration.logs.appendingPathComponent(
+                "\(logName).launch.log"
+            )
+        )
+        guard launch == 0 else {
+            throw ReleaseSmokeError.commandFailed(
+                command: "open",
+                status: launch
+            )
+        }
+
+        let application = XCUIApplication(
+            bundleIdentifier: Self.bundleIdentifier
+        )
+        activeApplication = application
+        XCTAssertTrue(
+            application.wait(for: .runningForeground, timeout: 20),
+            "The signed app must reach the foreground"
+        )
+        XCTAssertTrue(
+            application.windows.firstMatch.waitForExistence(timeout: 20),
+            "The signed app must expose a window"
+        )
+        try assertExactBundle(applicationURL)
+        return application
+    }
+
+    private func assertExactBundle(_ expectedURL: URL) throws {
+        let runningApplications = NSRunningApplication.runningApplications(
+            withBundleIdentifier: Self.bundleIdentifier
+        )
+        XCTAssertEqual(
+            runningApplications.count,
+            1,
+            "Exactly one Pine process must be running during release smoke"
+        )
+        let runningApplication = try XCTUnwrap(
+            runningApplications.first
+        )
+        let actualURL = try XCTUnwrap(runningApplication.bundleURL)
+        XCTAssertEqual(
+            actualURL.resolvingSymlinksInPath().path,
+            expectedURL.resolvingSymlinksInPath().path,
+            "XCUITest must attach to the app extracted from the tested DMG"
+        )
+    }
+
+    private func permanentlyOpenFixture(
+        in application: XCUIApplication
+    ) throws {
+        let sidebar = application.scrollViews["sidebar"]
+        XCTAssertTrue(
+            sidebar.waitForExistence(timeout: 20),
+            "The fixture project must open with its sidebar"
+        )
+        let file = application.sidebarNodes[
+            "fileNode_\(Self.fixtureFileName)"
+        ]
+        XCTAssertTrue(
+            file.waitForExistence(timeout: 20),
+            "The release fixture file must appear in the sidebar"
+        )
+        file.doubleClick()
+        XCTAssertTrue(
+            editorTab(in: application).waitForExistence(timeout: 20),
+            "Opening the fixture must create a permanent editor tab"
+        )
+    }
+
+    private func editorTab(
+        in application: XCUIApplication
+    ) -> XCUIElement {
+        application.descendants(matching: .any)[
+            "editorTab_\(Self.fixtureFileName)"
+        ].firstMatch
+    }
+
+    private func quitNormally(_ application: XCUIApplication) throws {
+        let applicationMenu = application.menuBars.menuBarItems["Pine"]
+        XCTAssertTrue(
+            applicationMenu.waitForExistence(timeout: 10),
+            "Pine application menu must be available"
+        )
+        applicationMenu.click()
+        let quitItem = application.menuItems["Quit Pine"]
+        XCTAssertTrue(
+            quitItem.waitForExistence(timeout: 10),
+            "Quit Pine must be available"
+        )
+        quitItem.click()
+        XCTAssertTrue(
+            application.wait(for: .notRunning, timeout: 30),
+            "Pine must complete a normal application termination"
+        )
+        activeApplication = nil
+    }
+
+    private func installUpdate(
+        _ configuration: ReleaseSmokeConfiguration
+    ) throws {
+        var environment = ProcessInfo.processInfo.environment
+        let updateHome = configuration.userRoot.appendingPathComponent(
+            "update-home",
+            isDirectory: true
+        )
+        environment["HOME"] = updateHome.path
+        environment["CFFIXED_USER_HOME"] = updateHome.path
+        environment["TMPDIR"] = updateHome.appendingPathComponent(
+            "tmp",
+            isDirectory: true
+        ).path
+
+        let status = try runProcess(
+            executable: configuration.sparkleCLI,
+            arguments: [
+                configuration.updateApplication.path,
+                "--application", configuration.updateApplication.path,
+                "--check-immediately",
+                "--allow-major-upgrades",
+                "--feed-url", configuration.appcastURL.absoluteString,
+                "--user-agent-name", "PineReleaseArtifactSmoke",
+                "--verbose"
+            ],
+            timeout: 180,
+            logURL: configuration.logs.appendingPathComponent(
+                "sparkle-update.log"
+            ),
+            environment: environment
+        )
+        guard status == 0 else {
+            throw ReleaseSmokeError.commandFailed(
+                command: "sparkle-cli",
+                status: status
+            )
+        }
+    }
+
+    private func verifyInstalledCandidate(
+        _ configuration: ReleaseSmokeConfiguration
+    ) throws {
+        let infoPlist = configuration.updateApplication
+            .appendingPathComponent("Contents/Info.plist")
+        let data = try Data(contentsOf: infoPlist)
+        let rawPlist = try PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: nil
+        )
+        let plist = try XCTUnwrap(rawPlist as? [String: Any])
+        XCTAssertEqual(
+            plist["CFBundleShortVersionString"] as? String,
+            configuration.expectedVersion
+        )
+        XCTAssertEqual(
+            plist["CFBundleVersion"] as? String,
+            configuration.expectedBuild
+        )
+
+        for (name, executable, arguments) in [
+            (
+                "codesign",
+                URL(fileURLWithPath: "/usr/bin/codesign"),
+                ["--verify", "--deep", "--strict", "--verbose=2",
+                 configuration.updateApplication.path]
+            ),
+            (
+                "stapler",
+                URL(fileURLWithPath: "/usr/bin/xcrun"),
+                ["stapler", "validate", configuration.updateApplication.path]
+            ),
+            (
+                "gatekeeper",
+                URL(fileURLWithPath: "/usr/sbin/spctl"),
+                ["--assess", "--type", "execute", "--verbose=4",
+                 configuration.updateApplication.path]
+            )
+        ] {
+            let status = try runProcess(
+                executable: executable,
+                arguments: arguments,
+                timeout: 30,
+                logURL: configuration.logs.appendingPathComponent(
+                    "updated-\(name).log"
+                )
+            )
+            guard status == 0 else {
+                throw ReleaseSmokeError.commandFailed(
+                    command: name,
+                    status: status
+                )
+            }
+        }
+    }
+
+    private func runProcess(
+        executable: URL,
+        arguments: [String],
+        timeout: TimeInterval,
+        logURL: URL,
+        environment: [String: String]? = nil
+    ) throws -> Int32 {
+        _ = FileManager.default.createFile(
+            atPath: logURL.path,
+            contents: nil
+        )
+        let logHandle = try FileHandle(forWritingTo: logURL)
+        defer { try? logHandle.close() }
+
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = arguments
+        process.environment = environment
+        process.standardOutput = logHandle
+        process.standardError = logHandle
+        try process.run()
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning, Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
+        if process.isRunning {
+            process.terminate()
+            _ = process.waitUntilExit(timeout: 5)
+            XCTFail("Timed out running \(executable.lastPathComponent)")
+            return -1
+        }
+        return process.terminationStatus
+    }
+}
+
+private struct ReleaseSmokeConfiguration {
+    let candidateApplication: URL
+    let updateApplication: URL
+    let sparkleCLI: URL
+    let appcastURL: URL
+    let expectedVersion: String
+    let expectedBuild: String
+    let userRoot: URL
+    let project: URL
+    let logs: URL
+
+    static func fromEnvironment() throws -> ReleaseSmokeConfiguration {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["PINE_RELEASE_SMOKE_ENABLED"] == "1" else {
+            throw XCTSkip(
+                "Signed release artifacts are available only in release CI"
+            )
+        }
+
+        func required(_ key: String) throws -> String {
+            try XCTUnwrap(
+                environment[key],
+                "Missing release smoke environment value: \(key)"
+            )
+        }
+
+        let appcastURLString = try required(
+            "PINE_RELEASE_SMOKE_APPCAST_URL"
+        )
+        let appcastURL = try XCTUnwrap(URL(string: appcastURLString))
+        let configuration = ReleaseSmokeConfiguration(
+            candidateApplication: URL(
+                fileURLWithPath: try required(
+                    "PINE_RELEASE_SMOKE_CANDIDATE_APP"
+                ),
+                isDirectory: true
+            ),
+            updateApplication: URL(
+                fileURLWithPath: try required(
+                    "PINE_RELEASE_SMOKE_UPDATE_APP"
+                ),
+                isDirectory: true
+            ),
+            sparkleCLI: URL(
+                fileURLWithPath: try required(
+                    "PINE_RELEASE_SMOKE_SPARKLE_CLI"
+                )
+            ),
+            appcastURL: appcastURL,
+            expectedVersion: try required(
+                "PINE_RELEASE_SMOKE_EXPECTED_VERSION"
+            ),
+            expectedBuild: try required(
+                "PINE_RELEASE_SMOKE_EXPECTED_BUILD"
+            ),
+            userRoot: URL(
+                fileURLWithPath: try required(
+                    "PINE_RELEASE_SMOKE_USER_ROOT"
+                ),
+                isDirectory: true
+            ),
+            project: URL(
+                fileURLWithPath: try required(
+                    "PINE_RELEASE_SMOKE_PROJECT"
+                ),
+                isDirectory: true
+            ),
+            logs: URL(
+                fileURLWithPath: try required(
+                    "PINE_RELEASE_SMOKE_LOGS"
+                ),
+                isDirectory: true
+            )
+        )
+        try configuration.validate()
+        return configuration
+    }
+
+    private func validate() throws {
+        let fileManager = FileManager.default
+        for application in [candidateApplication, updateApplication] {
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(
+                atPath: application.path,
+                isDirectory: &isDirectory
+            ), isDirectory.boolValue else {
+                throw ReleaseSmokeError.invalidConfiguration(
+                    "Missing release smoke app: \(application.path)"
+                )
+            }
+        }
+        guard fileManager.isExecutableFile(atPath: sparkleCLI.path) else {
+            throw ReleaseSmokeError.invalidConfiguration(
+                "sparkle-cli must be executable"
+            )
+        }
+        guard project.resolvingSymlinksInPath().path.hasPrefix(
+            userRoot.resolvingSymlinksInPath().path + "/"
+        ) else {
+            throw ReleaseSmokeError.invalidConfiguration(
+                "Release fixture must remain inside the isolated user root"
+            )
+        }
+        guard appcastURL.scheme == "http",
+              appcastURL.host == "127.0.0.1" else {
+            throw ReleaseSmokeError.invalidConfiguration(
+                "The isolated appcast must use loopback HTTP"
+            )
+        }
+    }
+}
+
+private enum ReleaseSmokeError: LocalizedError {
+    case commandFailed(command: String, status: Int32)
+    case invalidConfiguration(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .commandFailed(command, status):
+            "\(command) failed with status \(status)"
+        case let .invalidConfiguration(message):
+            message
+        }
+    }
+}
+
+private extension Process {
+    func waitUntilExit(timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while isRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        return !isRunning
+    }
+}

--- a/scripts/release-artifact-smoke.sh
+++ b/scripts/release-artifact-smoke.sh
@@ -1,0 +1,438 @@
+#!/bin/bash
+# Exercise the signed candidate DMG and a real previous release before publish.
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/release-artifact-smoke.sh \
+  <candidate.dmg> <previous.dmg> <version> <build> \
+  <appcast.xml> <Sparkle source> <output-directory>
+
+The output directory is retained as release diagnostics. Both disk images and
+the appcast must already exist; the output directory must not exist.
+EOF
+}
+
+die() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 \
+        || die "required command not found: $1"
+}
+
+if [ "$#" -ne 7 ]; then
+    usage >&2
+    exit 64
+fi
+
+CANDIDATE_ARGUMENT="$1"
+PREVIOUS_ARGUMENT="$2"
+EXPECTED_VERSION="$3"
+EXPECTED_BUILD="$4"
+APPCAST_ARGUMENT="$5"
+SPARKLE_SOURCE_ARGUMENT="$6"
+OUTPUT_ARGUMENT="$7"
+
+[ "$(uname -s)" = "Darwin" ] \
+    || die "release artifact smoke requires macOS"
+[ -f "$CANDIDATE_ARGUMENT" ] \
+    || die "candidate DMG not found: $CANDIDATE_ARGUMENT"
+[ -f "$PREVIOUS_ARGUMENT" ] \
+    || die "previous release DMG not found: $PREVIOUS_ARGUMENT"
+[ -f "$APPCAST_ARGUMENT" ] \
+    || die "appcast not found: $APPCAST_ARGUMENT"
+[ -d "$SPARKLE_SOURCE_ARGUMENT/Sparkle.xcodeproj" ] \
+    || die "Sparkle source checkout not found: $SPARKLE_SOURCE_ARGUMENT"
+[ -n "$EXPECTED_VERSION" ] || die "candidate version must not be empty"
+case "$EXPECTED_BUILD" in
+    ''|*[!0-9]*) die "candidate build must be numeric: $EXPECTED_BUILD" ;;
+esac
+[ ! -e "$OUTPUT_ARGUMENT" ] \
+    || die "output already exists: $OUTPUT_ARGUMENT"
+
+for required_command in \
+    codesign curl ditto find log open ps shasum spctl sw_vers xcodebuild \
+    xcrun; do
+    require_command "$required_command"
+done
+require_command python3
+
+PLISTBUDDY="${PLISTBUDDY:-/usr/libexec/PlistBuddy}"
+[ -x "$PLISTBUDDY" ] || die "PlistBuddy not found: $PLISTBUDDY"
+
+absolute_file() {
+    local argument="$1"
+    local parent
+    parent="$(cd "$(dirname "$argument")" && pwd -P)"
+    printf '%s/%s\n' "$parent" "$(basename "$argument")"
+}
+
+absolute_directory() {
+    (cd "$1" && pwd -P)
+}
+
+CANDIDATE_DMG="$(absolute_file "$CANDIDATE_ARGUMENT")"
+PREVIOUS_DMG="$(absolute_file "$PREVIOUS_ARGUMENT")"
+APPCAST="$(absolute_file "$APPCAST_ARGUMENT")"
+SPARKLE_SOURCE="$(absolute_directory "$SPARKLE_SOURCE_ARGUMENT")"
+OUTPUT_PARENT="$(cd "$(dirname "$OUTPUT_ARGUMENT")" && pwd -P)"
+OUTPUT_ROOT="$OUTPUT_PARENT/$(basename "$OUTPUT_ARGUMENT")"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+
+LOGS="$OUTPUT_ROOT/logs"
+METADATA="$OUTPUT_ROOT/metadata"
+MOUNTS="$OUTPUT_ROOT/mounts"
+INSTALL_ROOT="$OUTPUT_ROOT/installed"
+FEED_ROOT="$OUTPUT_ROOT/feed"
+USER_ROOT="$OUTPUT_ROOT/user"
+FIXTURE_PROJECT="$USER_ROOT/project"
+HARNESS_HOME="$USER_ROOT/harness-home"
+DERIVED_DATA="$OUTPUT_ROOT/DerivedData"
+SPARKLE_DERIVED_DATA="$OUTPUT_ROOT/SparkleDerivedData"
+RESULT_BUNDLE="$OUTPUT_ROOT/ReleaseArtifactSmoke.xcresult"
+
+mkdir -p \
+    "$LOGS" \
+    "$METADATA" \
+    "$MOUNTS/candidate" \
+    "$MOUNTS/previous" \
+    "$INSTALL_ROOT/candidate" \
+    "$INSTALL_ROOT/update" \
+    "$FEED_ROOT" \
+    "$FIXTURE_PROJECT" \
+    "$HARNESS_HOME/Library" \
+    "$HARNESS_HOME/tmp"
+
+{
+    echo "sw_vers:"
+    sw_vers
+    echo "xcodebuild -version:"
+    xcodebuild -version
+    echo "macOS SDK version:"
+    xcrun --sdk macosx --show-sdk-version
+    echo "macOS SDK build version:"
+    xcrun --sdk macosx --show-sdk-build-version
+} > "$METADATA/toolchain.txt"
+
+OS_MAJOR="$(sw_vers -productVersion | awk -F . '{print $1}')"
+USE_DISKUTIL_IMAGE=false
+if [ "$OS_MAJOR" -ge 27 ] \
+    && [ "${PINE_DMG_FORCE_LEGACY_HDIUTIL:-0}" != "1" ]; then
+    require_command diskutil
+    USE_DISKUTIL_IMAGE=true
+else
+    require_command hdiutil
+fi
+
+ATTACHED_DEVICES=()
+SERVER_PID=""
+
+cleanup() {
+    local index
+    local device
+
+    ps -axo pid,ppid,state,etime,command > "$LOGS/processes.txt" \
+        2>&1 || true
+    log show \
+        --last 20m \
+        --style compact \
+        --predicate 'process == "Pine" OR process CONTAINS[c] "sparkle"' \
+        > "$LOGS/unified.log" 2>&1 || true
+
+    if [ -n "$SERVER_PID" ]; then
+        kill "$SERVER_PID" >/dev/null 2>&1 || true
+        wait "$SERVER_PID" >/dev/null 2>&1 || true
+        SERVER_PID=""
+    fi
+
+    for ((index=${#ATTACHED_DEVICES[@]} - 1; index >= 0; index--)); do
+        device="${ATTACHED_DEVICES[$index]}"
+        if [ "$USE_DISKUTIL_IMAGE" = true ]; then
+            diskutil eject "$device" >/dev/null 2>&1 || true
+        else
+            hdiutil detach "$device" >/dev/null 2>&1 || true
+        fi
+    done
+}
+trap cleanup EXIT INT TERM
+
+attach_image() {
+    local image="$1"
+    local mount_point="$2"
+    local plist="$3"
+    local device
+
+    if [ "$USE_DISKUTIL_IMAGE" = true ]; then
+        diskutil image --plist attach \
+            --readOnly \
+            --nobrowse \
+            --mountPoint "$mount_point" \
+            "$image" > "$plist"
+    else
+        hdiutil attach \
+            -plist \
+            -readonly \
+            -noverify \
+            -noautoopen \
+            -nobrowse \
+            -mountpoint "$mount_point" \
+            "$image" > "$plist"
+    fi
+
+    device="$($PLISTBUDDY \
+        -c 'Print :system-entities:0:dev-entry' "$plist")"
+    [ -n "$device" ] || die "could not determine attached device for $image"
+    ATTACHED_DEVICES+=("$device")
+}
+
+verify_signed_app() {
+    local app="$1"
+    local label="$2"
+
+    codesign --verify --deep --strict --verbose=2 "$app" \
+        > "$LOGS/$label-codesign.log" 2>&1
+    xcrun stapler validate "$app" \
+        > "$LOGS/$label-stapler.log" 2>&1
+    spctl --assess --type execute --verbose=4 "$app" \
+        > "$LOGS/$label-gatekeeper.log" 2>&1
+}
+
+CANDIDATE_HASH="$(shasum -a 256 "$CANDIDATE_DMG" | awk '{print $1}')"
+printf '%s  %s\n' "$CANDIDATE_HASH" "$(basename "$CANDIDATE_DMG")" \
+    > "$METADATA/candidate-before-smoke.sha256"
+
+attach_image \
+    "$CANDIDATE_DMG" \
+    "$MOUNTS/candidate" \
+    "$METADATA/candidate-attach.plist"
+attach_image \
+    "$PREVIOUS_DMG" \
+    "$MOUNTS/previous" \
+    "$METADATA/previous-attach.plist"
+
+[ -d "$MOUNTS/candidate/Pine.app" ] \
+    || die "candidate Pine.app is missing from the DMG"
+[ -d "$MOUNTS/previous/Pine.app" ] \
+    || die "previous Pine.app is missing from the DMG"
+
+CANDIDATE_APP="$INSTALL_ROOT/candidate/Pine.app"
+UPDATE_APP="$INSTALL_ROOT/update/Pine.app"
+ditto "$MOUNTS/candidate/Pine.app" "$CANDIDATE_APP"
+ditto "$MOUNTS/previous/Pine.app" "$UPDATE_APP"
+
+CANDIDATE_INFO="$CANDIDATE_APP/Contents/Info.plist"
+PREVIOUS_INFO="$UPDATE_APP/Contents/Info.plist"
+CANDIDATE_VERSION="$($PLISTBUDDY \
+    -c 'Print :CFBundleShortVersionString' "$CANDIDATE_INFO")"
+CANDIDATE_BUILD="$($PLISTBUDDY \
+    -c 'Print :CFBundleVersion' "$CANDIDATE_INFO")"
+PREVIOUS_VERSION="$($PLISTBUDDY \
+    -c 'Print :CFBundleShortVersionString' "$PREVIOUS_INFO")"
+PREVIOUS_BUILD="$($PLISTBUDDY \
+    -c 'Print :CFBundleVersion' "$PREVIOUS_INFO")"
+
+[ "$CANDIDATE_VERSION" = "$EXPECTED_VERSION" ] \
+    || die "candidate version mismatch: $CANDIDATE_VERSION"
+[ "$CANDIDATE_BUILD" = "$EXPECTED_BUILD" ] \
+    || die "candidate build mismatch: $CANDIDATE_BUILD"
+case "$PREVIOUS_BUILD" in
+    ''|*[!0-9]*) die "previous build is not numeric: $PREVIOUS_BUILD" ;;
+esac
+[ "$PREVIOUS_BUILD" -lt "$EXPECTED_BUILD" ] \
+    || die "previous build $PREVIOUS_BUILD is not older than $EXPECTED_BUILD"
+
+verify_signed_app "$CANDIDATE_APP" candidate
+verify_signed_app "$UPDATE_APP" previous
+
+cat > "$FIXTURE_PROJECT/ReleaseSmoke.swift" <<'EOF'
+import Foundation
+
+print("Pine signed release smoke")
+EOF
+
+FEED_DMG="$FEED_ROOT/$(basename "$CANDIDATE_DMG")"
+ditto "$CANDIDATE_DMG" "$FEED_DMG"
+FEED_HASH="$(shasum -a 256 "$FEED_DMG" | awk '{print $1}')"
+[ "$FEED_HASH" = "$CANDIDATE_HASH" ] \
+    || die "local update feed does not contain the candidate DMG bytes"
+
+PORT_FILE="$METADATA/appcast-port.txt"
+python3 - "$FEED_ROOT" "$PORT_FILE" <<'PYTHON' \
+    > "$LOGS/appcast-server.log" 2>&1 &
+import http.server
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+port_file = pathlib.Path(sys.argv[2])
+handler = lambda *args, **kwargs: http.server.SimpleHTTPRequestHandler(
+    *args, directory=root, **kwargs
+)
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+port_file.write_text(str(server.server_address[1]), encoding="utf-8")
+server.serve_forever()
+PYTHON
+SERVER_PID="$!"
+
+for _ in {1..100}; do
+    [ -s "$PORT_FILE" ] && break
+    kill -0 "$SERVER_PID" >/dev/null 2>&1 \
+        || die "local appcast server exited before startup"
+    sleep 0.1
+done
+[ -s "$PORT_FILE" ] || die "local appcast server did not publish its port"
+
+APPCAST_PORT="$(cat "$PORT_FILE")"
+APPCAST_URL="http://127.0.0.1:$APPCAST_PORT/appcast.xml"
+DMG_URL="http://127.0.0.1:$APPCAST_PORT/$(basename "$FEED_DMG")"
+PINE_APPCAST_SOURCE="$APPCAST" \
+PINE_APPCAST_OUTPUT="$FEED_ROOT/appcast.xml" \
+PINE_APPCAST_METADATA="$METADATA/appcast.json" \
+PINE_APPCAST_DMG_URL="$DMG_URL" \
+PINE_APPCAST_EXPECTED_VERSION="$EXPECTED_VERSION" \
+PINE_APPCAST_EXPECTED_BUILD="$EXPECTED_BUILD" \
+PINE_APPCAST_EXPECTED_LENGTH="$(wc -c < "$CANDIDATE_DMG" | tr -d ' ')" \
+PINE_APPCAST_CANDIDATE_SHA256="$CANDIDATE_HASH" \
+python3 <<'PYTHON'
+import json
+import os
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+source = Path(os.environ["PINE_APPCAST_SOURCE"]).read_text(encoding="utf-8")
+pattern = re.compile(r'(<enclosure\b[^>]*\burl=")[^"]*(")')
+rewritten, replacements = pattern.subn(
+    rf'\g<1>{os.environ["PINE_APPCAST_DMG_URL"]}\g<2>',
+    source,
+)
+if replacements != 1:
+    raise SystemExit(f"expected one appcast enclosure, found {replacements}")
+
+output = Path(os.environ["PINE_APPCAST_OUTPUT"])
+output.write_text(rewritten, encoding="utf-8")
+root = ET.fromstring(rewritten)
+item = root.find("./channel/item")
+if item is None:
+    raise SystemExit("appcast item is missing")
+enclosure = item.find("enclosure")
+if enclosure is None:
+    raise SystemExit("appcast enclosure is missing")
+
+def sparkle_text(name):
+    element = item.find(
+        f"{{http://www.andymatuschak.org/xml-namespaces/sparkle}}{name}"
+    )
+    return None if element is None else element.text
+
+signature = next(
+    (value for key, value in enclosure.attrib.items() if key.endswith("edSignature")),
+    None,
+)
+metadata = {
+    "candidateSHA256": os.environ["PINE_APPCAST_CANDIDATE_SHA256"],
+    "candidateVersion": sparkle_text("shortVersionString"),
+    "candidateBuild": sparkle_text("version"),
+    "enclosureURL": enclosure.attrib.get("url"),
+    "enclosureLength": enclosure.attrib.get("length"),
+    "edSignaturePresent": bool(signature),
+}
+expected = {
+    "candidateVersion": os.environ["PINE_APPCAST_EXPECTED_VERSION"],
+    "candidateBuild": os.environ["PINE_APPCAST_EXPECTED_BUILD"],
+    "enclosureURL": os.environ["PINE_APPCAST_DMG_URL"],
+    "enclosureLength": os.environ["PINE_APPCAST_EXPECTED_LENGTH"],
+}
+for key, value in expected.items():
+    if metadata[key] != value:
+        raise SystemExit(f"appcast {key} mismatch: {metadata[key]!r} != {value!r}")
+if not signature:
+    raise SystemExit("appcast EdDSA signature is missing")
+
+Path(os.environ["PINE_APPCAST_METADATA"]).write_text(
+    json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+PYTHON
+
+curl --fail --silent --show-error "$APPCAST_URL" \
+    > /dev/null
+curl --fail --silent --show-error "$DMG_URL" \
+    | shasum -a 256 \
+    | awk '{print $1}' \
+    | grep -qx "$CANDIDATE_HASH" \
+    || die "loopback server did not return the candidate DMG bytes"
+
+xcodebuild build \
+    -project "$SPARKLE_SOURCE/Sparkle.xcodeproj" \
+    -scheme sparkle-cli \
+    -configuration Release \
+    -derivedDataPath "$SPARKLE_DERIVED_DATA" \
+    MACOSX_DEPLOYMENT_TARGET=26.0 \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=YES \
+    > "$LOGS/sparkle-cli-build.log" 2>&1
+
+SPARKLE_CLI_CANDIDATES="$METADATA/sparkle-cli-candidates.txt"
+find "$SPARKLE_DERIVED_DATA/Build/Products/Release" \
+    -type f \
+    -path '*/sparkle.app/Contents/MacOS/sparkle' \
+    -perm -111 \
+    > "$SPARKLE_CLI_CANDIDATES"
+[ "$(wc -l < "$SPARKLE_CLI_CANDIDATES" | tr -d ' ')" = "1" ] \
+    || die "expected exactly one built sparkle-cli executable"
+SPARKLE_CLI="$(cat "$SPARKLE_CLI_CANDIDATES")"
+
+printf '%s\n' \
+    "candidateVersion=$CANDIDATE_VERSION" \
+    "candidateBuild=$CANDIDATE_BUILD" \
+    "previousVersion=$PREVIOUS_VERSION" \
+    "previousBuild=$PREVIOUS_BUILD" \
+    "candidateSHA256=$CANDIDATE_HASH" \
+    > "$METADATA/release-smoke.txt"
+
+SPM_SOURCE_ROOT="$(dirname "$(dirname "$SPARKLE_SOURCE")")"
+cd "$REPO_ROOT"
+set +e
+HOME="$HARNESS_HOME" \
+CFFIXED_USER_HOME="$HARNESS_HOME" \
+TMPDIR="$HARNESS_HOME/tmp" \
+PINE_RELEASE_SMOKE_ENABLED=1 \
+PINE_RELEASE_SMOKE_CANDIDATE_DMG="$CANDIDATE_DMG" \
+PINE_RELEASE_SMOKE_CANDIDATE_APP="$CANDIDATE_APP" \
+PINE_RELEASE_SMOKE_UPDATE_APP="$UPDATE_APP" \
+PINE_RELEASE_SMOKE_SPARKLE_CLI="$SPARKLE_CLI" \
+PINE_RELEASE_SMOKE_APPCAST_URL="$APPCAST_URL" \
+PINE_RELEASE_SMOKE_EXPECTED_VERSION="$EXPECTED_VERSION" \
+PINE_RELEASE_SMOKE_EXPECTED_BUILD="$EXPECTED_BUILD" \
+PINE_RELEASE_SMOKE_USER_ROOT="$USER_ROOT" \
+PINE_RELEASE_SMOKE_PROJECT="$FIXTURE_PROJECT" \
+PINE_RELEASE_SMOKE_LOGS="$LOGS" \
+xcodebuild test \
+    -project Pine.xcodeproj \
+    -scheme Pine \
+    -destination 'platform=macOS' \
+    -clonedSourcePackagesDirPath "$SPM_SOURCE_ROOT" \
+    -derivedDataPath "$DERIVED_DATA" \
+    -parallel-testing-enabled NO \
+    -only-testing:PineUITests/ReleaseArtifactSmokeTests \
+    -resultBundlePath "$RESULT_BUNDLE" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    2>&1 | tee "$LOGS/xcodebuild.log"
+XCODEBUILD_STATUS="${PIPESTATUS[0]}"
+set -e
+
+AFTER_HASH="$(shasum -a 256 "$CANDIDATE_DMG" | awk '{print $1}')"
+printf '%s  %s\n' "$AFTER_HASH" "$(basename "$CANDIDATE_DMG")" \
+    > "$METADATA/candidate-after-smoke.sha256"
+[ "$AFTER_HASH" = "$CANDIDATE_HASH" ] \
+    || die "candidate DMG changed while the release smoke was running"
+[ "$XCODEBUILD_STATUS" -eq 0 ] \
+    || die "release artifact XCUITest failed with status $XCODEBUILD_STATUS"
+
+echo "Release artifact smoke passed for Pine $EXPECTED_VERSION ($EXPECTED_BUILD)"
+echo "Candidate SHA-256: $CANDIDATE_HASH"

--- a/scripts/tests/test-release-artifact-smoke.sh
+++ b/scripts/tests/test-release-artifact-smoke.sh
@@ -1,0 +1,383 @@
+#!/bin/bash
+# Portable regression tests for the signed release artifact smoke orchestrator.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd -P)"
+SMOKE_SCRIPT="$REPO_ROOT/scripts/release-artifact-smoke.sh"
+RELEASE_WORKFLOW="$REPO_ROOT/.github/workflows/release.yml"
+PASS=0
+FAIL=0
+TEST_ROOT=""
+
+cleanup() {
+    [ -n "$TEST_ROOT" ] && rm -rf "$TEST_ROOT"
+    TEST_ROOT=""
+}
+trap cleanup EXIT
+
+pass() {
+    echo "  ✓ $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "  ✗ $1"
+    FAIL=$((FAIL + 1))
+}
+
+write_fakes() {
+    cat > "$TEST_ROOT/bin/uname" <<'FAKE'
+#!/bin/bash
+echo Darwin
+FAKE
+
+cat > "$TEST_ROOT/bin/sw_vers" <<'FAKE'
+#!/bin/bash
+if [ "$#" -eq 0 ]; then
+    printf 'ProductName:\tmacOS\nProductVersion:\t%s\nBuildVersion:\tTEST\n' \
+        "${TEST_OS_VERSION:-26.0}"
+elif [ "${1:-}" = "-productVersion" ]; then
+    echo "${TEST_OS_VERSION:-26.0}"
+else
+    exit 64
+fi
+FAKE
+
+    cat > "$TEST_ROOT/bin/PlistBuddy" <<'FAKE'
+#!/bin/bash
+set -euo pipefail
+command_text="${2:-}"
+plist_path="${3:-}"
+case "$command_text" in
+    *dev-entry*)
+        case "$plist_path" in
+            *candidate*) echo disk-candidate ;;
+            *) echo disk-previous ;;
+        esac
+        ;;
+    *CFBundleShortVersionString*)
+        case "$plist_path" in
+            *candidate*) echo "${TEST_CANDIDATE_VERSION:?}" ;;
+            *) echo "${TEST_PREVIOUS_VERSION:?}" ;;
+        esac
+        ;;
+    *CFBundleVersion*)
+        case "$plist_path" in
+            *candidate*) echo "${TEST_CANDIDATE_BUILD:?}" ;;
+            *) echo "${TEST_PREVIOUS_BUILD:?}" ;;
+        esac
+        ;;
+    *)
+        echo "unexpected PlistBuddy command: $*" >&2
+        exit 64
+        ;;
+esac
+FAKE
+
+    cat > "$TEST_ROOT/bin/hdiutil" <<'FAKE'
+#!/bin/bash
+set -euo pipefail
+printf 'hdiutil %s\n' "$*" >> "${TEST_COMMAND_LOG:?}"
+case "${1:-}" in
+    attach)
+        mount_point=""
+        image=""
+        previous=""
+        for argument in "$@"; do
+            if [ "$previous" = "-mountpoint" ]; then
+                mount_point="$argument"
+            fi
+            image="$argument"
+            previous="$argument"
+        done
+        [ -n "$mount_point" ] || exit 64
+        case "$(basename "$image")" in
+            candidate.dmg) image_root="${TEST_CANDIDATE_IMAGE:?}" ;;
+            previous.dmg) image_root="${TEST_PREVIOUS_IMAGE:?}" ;;
+            *) exit 64 ;;
+        esac
+        mkdir -p "$mount_point"
+        cp -R "$image_root/." "$mount_point/"
+        echo plist
+        ;;
+    detach)
+        ;;
+    *)
+        exit 64
+        ;;
+esac
+FAKE
+
+    cat > "$TEST_ROOT/bin/diskutil" <<'FAKE'
+#!/bin/bash
+set -euo pipefail
+printf 'diskutil %s\n' "$*" >> "${TEST_COMMAND_LOG:?}"
+if [ "${1:-}" = "image" ] && [ "${2:-}" = "--plist" ] \
+    && [ "${3:-}" = "attach" ]; then
+    mount_point=""
+    image=""
+    previous=""
+    for argument in "$@"; do
+        if [ "$previous" = "--mountPoint" ]; then
+            mount_point="$argument"
+        fi
+        image="$argument"
+        previous="$argument"
+    done
+    case "$(basename "$image")" in
+        candidate.dmg) image_root="${TEST_CANDIDATE_IMAGE:?}" ;;
+        previous.dmg) image_root="${TEST_PREVIOUS_IMAGE:?}" ;;
+        *) exit 64 ;;
+    esac
+    mkdir -p "$mount_point"
+    cp -R "$image_root/." "$mount_point/"
+    echo plist
+elif [ "${1:-}" = "eject" ]; then
+    :
+else
+    exit 64
+fi
+FAKE
+
+    cat > "$TEST_ROOT/bin/ditto" <<'FAKE'
+#!/bin/bash
+set -euo pipefail
+source_path="$1"
+destination_path="$2"
+if [ -d "$source_path" ]; then
+    mkdir -p "$destination_path"
+    cp -R "$source_path/." "$destination_path/"
+else
+    mkdir -p "$(dirname "$destination_path")"
+    cp "$source_path" "$destination_path"
+fi
+FAKE
+
+    for security_tool in codesign spctl xcrun; do
+        cat > "$TEST_ROOT/bin/$security_tool" <<'FAKE'
+#!/bin/bash
+set -euo pipefail
+printf '%s %s\n' "$(basename "$0")" "$*" >> "${TEST_COMMAND_LOG:?}"
+if [ "$(basename "$0")" = "xcrun" ]; then
+    case "$*" in
+        *--show-sdk-version*) echo 26.0 ;;
+        *--show-sdk-build-version*) echo TESTSDK ;;
+    esac
+fi
+FAKE
+    done
+
+    cat > "$TEST_ROOT/bin/xcodebuild" <<'FAKE'
+#!/bin/bash
+set -euo pipefail
+printf 'xcodebuild %s\n' "$*" >> "${TEST_COMMAND_LOG:?}"
+if [ "${1:-}" = "-version" ]; then
+    printf 'Xcode 26.0\nBuild version TEST\n'
+    exit 0
+fi
+derived_data=""
+result_bundle=""
+previous=""
+for argument in "$@"; do
+    if [ "$previous" = "-derivedDataPath" ]; then
+        derived_data="$argument"
+    elif [ "$previous" = "-resultBundlePath" ]; then
+        result_bundle="$argument"
+    fi
+    previous="$argument"
+done
+
+if printf '%s\n' "$*" | grep -q -- '-scheme sparkle-cli'; then
+    printf '%s\n' "$*" | grep -q 'MACOSX_DEPLOYMENT_TARGET=26.0' \
+        || exit 67
+    executable="$derived_data/Build/Products/Release/sparkle.app/Contents/MacOS/sparkle"
+    mkdir -p "$(dirname "$executable")"
+    printf '#!/bin/bash\nexit 0\n' > "$executable"
+    chmod +x "$executable"
+    exit 0
+fi
+
+for variable in \
+    PINE_RELEASE_SMOKE_CANDIDATE_APP \
+    PINE_RELEASE_SMOKE_UPDATE_APP \
+    PINE_RELEASE_SMOKE_APPCAST_URL \
+    PINE_RELEASE_SMOKE_CANDIDATE_DMG \
+    PINE_RELEASE_SMOKE_USER_ROOT; do
+    [ -n "${!variable:-}" ] || {
+        echo "missing test environment: $variable" >&2
+        exit 65
+    }
+done
+[ -n "$result_bundle" ] || exit 66
+mkdir -p "$result_bundle"
+printf 'fake xcresult\n' > "$result_bundle/Info.plist"
+if [ "${TEST_MUTATE_CANDIDATE:-0}" = "1" ]; then
+    printf 'mutated\n' >> "$PINE_RELEASE_SMOKE_CANDIDATE_DMG"
+fi
+exit "${TEST_XCODEBUILD_STATUS:-0}"
+FAKE
+
+    cat > "$TEST_ROOT/bin/log" <<'FAKE'
+#!/bin/bash
+echo 'fake unified log'
+FAKE
+
+    cat > "$TEST_ROOT/bin/open" <<'FAKE'
+#!/bin/bash
+exit 0
+FAKE
+
+    chmod +x "$TEST_ROOT/bin/"*
+}
+
+setup_fixture() {
+    cleanup
+    TEST_ROOT="$(mktemp -d)"
+    mkdir -p \
+        "$TEST_ROOT/bin" \
+        "$TEST_ROOT/candidate-image/Pine.app/Contents" \
+        "$TEST_ROOT/previous-image/Pine.app/Contents" \
+        "$TEST_ROOT/Sparkle/Sparkle.xcodeproj"
+    printf 'candidate artifact bytes\n' > "$TEST_ROOT/candidate.dmg"
+    printf 'previous artifact bytes\n' > "$TEST_ROOT/previous.dmg"
+    printf 'candidate plist\n' \
+        > "$TEST_ROOT/candidate-image/Pine.app/Contents/Info.plist"
+    printf 'previous plist\n' \
+        > "$TEST_ROOT/previous-image/Pine.app/Contents/Info.plist"
+    : > "$TEST_ROOT/commands.log"
+
+    candidate_length="$(wc -c < "$TEST_ROOT/candidate.dmg" | tr -d ' ')"
+    cat > "$TEST_ROOT/appcast.xml" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <item>
+      <sparkle:version>200</sparkle:version>
+      <sparkle:shortVersionString>2.0.0</sparkle:shortVersionString>
+      <enclosure url="https://example.invalid/Pine-2.0.0.dmg"
+        sparkle:edSignature="public-signature"
+        length="$candidate_length"
+        type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>
+EOF
+    write_fakes
+}
+
+run_smoke() {
+    PATH="$TEST_ROOT/bin:$PATH" \
+    PLISTBUDDY="$TEST_ROOT/bin/PlistBuddy" \
+    TEST_OS_VERSION="${TEST_OS_VERSION:-26.0}" \
+    TEST_COMMAND_LOG="$TEST_ROOT/commands.log" \
+    TEST_CANDIDATE_IMAGE="$TEST_ROOT/candidate-image" \
+    TEST_PREVIOUS_IMAGE="$TEST_ROOT/previous-image" \
+    TEST_CANDIDATE_VERSION=2.0.0 \
+    TEST_CANDIDATE_BUILD=200 \
+    TEST_PREVIOUS_VERSION=1.9.0 \
+    TEST_PREVIOUS_BUILD=150 \
+    TEST_XCODEBUILD_STATUS="${TEST_XCODEBUILD_STATUS:-0}" \
+    TEST_MUTATE_CANDIDATE="${TEST_MUTATE_CANDIDATE:-0}" \
+    SPARKLE_PRIVATE_KEY="must-not-appear-in-diagnostics" \
+    bash "$SMOKE_SCRIPT" \
+        "$TEST_ROOT/candidate.dmg" \
+        "$TEST_ROOT/previous.dmg" \
+        2.0.0 \
+        200 \
+        "$TEST_ROOT/appcast.xml" \
+        "$TEST_ROOT/Sparkle" \
+        "$TEST_ROOT/output"
+}
+
+echo "Test 1: candidate and previous signed artifacts reach the release gate"
+setup_fixture
+if run_smoke > "$TEST_ROOT/run.log" 2>&1 \
+    && [ -d "$TEST_ROOT/output/ReleaseArtifactSmoke.xcresult" ] \
+    && grep -q 'candidateVersion=2.0.0' \
+        "$TEST_ROOT/output/metadata/release-smoke.txt" \
+    && grep -q 'previousVersion=1.9.0' \
+        "$TEST_ROOT/output/metadata/release-smoke.txt" \
+    && grep -q -- '-only-testing:PineUITests/ReleaseArtifactSmokeTests' \
+        "$TEST_ROOT/commands.log" \
+    && [ "$(grep -c '^codesign --verify' "$TEST_ROOT/commands.log")" -eq 2 ] \
+    && ! grep -R -q 'must-not-appear-in-diagnostics' "$TEST_ROOT/output"; then
+    pass "signed candidate lifecycle and update orchestration"
+else
+    cat "$TEST_ROOT/run.log"
+    fail "happy-path orchestration"
+fi
+
+echo "Test 2: xcodebuild failure preserves diagnostics and fails closed"
+setup_fixture
+export TEST_XCODEBUILD_STATUS=42
+if run_smoke > "$TEST_ROOT/run.log" 2>&1; then
+    fail "xcodebuild failure was accepted"
+elif [ -d "$TEST_ROOT/output/ReleaseArtifactSmoke.xcresult" ] \
+    && [ -f "$TEST_ROOT/output/logs/processes.txt" ] \
+    && grep -q 'failed with status 42' "$TEST_ROOT/run.log"; then
+    pass "test failure and diagnostics retained"
+else
+    cat "$TEST_ROOT/run.log"
+    fail "xcodebuild failure handling"
+fi
+unset TEST_XCODEBUILD_STATUS
+
+echo "Test 3: candidate bytes are immutable across the gate"
+setup_fixture
+export TEST_MUTATE_CANDIDATE=1
+if run_smoke > "$TEST_ROOT/run.log" 2>&1; then
+    fail "mutated candidate was accepted"
+elif grep -q 'candidate DMG changed' "$TEST_ROOT/run.log"; then
+    pass "candidate mutation rejected"
+else
+    cat "$TEST_ROOT/run.log"
+    fail "candidate mutation diagnostic"
+fi
+unset TEST_MUTATE_CANDIDATE
+
+echo "Test 4: appcast signature metadata is required"
+setup_fixture
+sed -i.bak 's/sparkle:edSignature=/sparkle:missingSignature=/' \
+    "$TEST_ROOT/appcast.xml"
+if run_smoke > "$TEST_ROOT/run.log" 2>&1; then
+    fail "unsigned appcast was accepted"
+elif grep -q 'EdDSA signature is missing' "$TEST_ROOT/run.log"; then
+    pass "unsigned appcast rejected"
+else
+    cat "$TEST_ROOT/run.log"
+    fail "appcast signature diagnostic"
+fi
+
+echo "Test 5: macOS 27 uses diskutil image for both release DMGs"
+setup_fixture
+export TEST_OS_VERSION=27.0
+if run_smoke > "$TEST_ROOT/run.log" 2>&1 \
+    && [ "$(grep -c '^diskutil image --plist attach ' "$TEST_ROOT/commands.log")" -eq 2 ] \
+    && ! grep -q '^hdiutil ' "$TEST_ROOT/commands.log"; then
+    pass "macOS 27 disk image compatibility path"
+else
+    cat "$TEST_ROOT/run.log"
+    fail "macOS 27 disk image path"
+fi
+unset TEST_OS_VERSION
+
+echo "Test 6: release workflow tests before upload and verifies published bytes"
+smoke_line="$(grep -n 'name: Run signed release artifact smoke' \
+    "$RELEASE_WORKFLOW" | cut -d: -f1 || true)"
+upload_line="$(grep -n 'name: Upload DMG to GitHub Release' \
+    "$RELEASE_WORKFLOW" | cut -d: -f1 || true)"
+if [ -n "$smoke_line" ] \
+    && [ -n "$upload_line" ] \
+    && [ "$smoke_line" -lt "$upload_line" ] \
+    && grep -q 'release-artifact-smoke.sh' "$RELEASE_WORKFLOW" \
+    && grep -q 'candidate-before-publication.sha256' "$RELEASE_WORKFLOW" \
+    && grep -q 'candidate-after-publication.sha256' "$RELEASE_WORKFLOW" \
+    && grep -q 'name: Upload release smoke diagnostics' "$RELEASE_WORKFLOW"; then
+    pass "release workflow gate and publication hash checks"
+else
+    fail "release workflow integration"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- gate publication on launching the exact signed/notarized app extracted from the candidate DMG
- download the previous stable signed DMG and exercise a real Sparkle update to the candidate while retaining isolated user state
- verify signatures, stapling, Gatekeeper, appcast metadata, and candidate hashes before/after smoke and after publication
- retain sanitized launch logs, toolchain details, appcast metadata, hashes, and the xcresult on failure

## Review

Reviewed the complete diff before opening this PR. In particular, the release test asserts that LaunchServices started the extracted bundle path, confines HOME/CFFIXED_USER_HOME/TMPDIR and project data to the smoke directory, and never uploads the appcast signature value or signing inputs. The release-please PR is untouched.

## Validation

- `bash scripts/tests/test-release-artifact-smoke.sh` (6/6)
- `bash scripts/tests/test-dmg-packaging.sh` (11/11)
- `bash scripts/tests/test-xcodebuild-cli-options.sh`
- `python3 .github/scripts/check_ui_test_shards.py --tests-dir PineUITests --workflow .github/workflows/ci.yml --max-delta 3`
- `python3 -m unittest test_check_ui_test_shards.py -v`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swiftlint lint --strict --no-cache Pine PineTests PineUITests PinePerformanceTests`
- `xcodebuild build-for-testing ... -only-testing:PineUITests/ReleaseArtifactSmokeTests` (build only; no local UI test execution)
- built the pinned Sparkle 2.9.5 `sparkle-cli` scheme with `MACOSX_DEPLOYMENT_TARGET=26.0`

Closes #1438