### PR TITLE
fix: restore sidebar and quit persistence

### DIFF
--- a/Pine/Agent/AgentTaskMetadataStore.swift
+++ b/Pine/Agent/AgentTaskMetadataStore.swift
@@ -426,6 +426,11 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
     private static let directoryName = ".pine-agent-tasks-private"
 
     private let storageRoot: URL?
+    /// Injectable so tests can exercise the production Application Support
+    /// layout without touching the developer's real home directory. macOS may
+    /// attach its own ACL to this trusted anchor; only Pine's child directory
+    /// is required to be ACL-free and mode 0700.
+    private let applicationSupportDirectory: URL?
     private let limits: AgentTaskPersistenceLimits
     private let configuration: AgentTaskStoreConfiguration
     private let fileManager = FileManager()
@@ -433,10 +438,12 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
 
     init(
         storageRoot: URL? = nil,
+        applicationSupportDirectory: URL? = nil,
         limits: AgentTaskPersistenceLimits = AgentTaskPersistenceLimits(),
         configuration: AgentTaskStoreConfiguration = AgentTaskStoreConfiguration()
     ) {
         self.storageRoot = storageRoot
+        self.applicationSupportDirectory = applicationSupportDirectory
         self.limits = limits
         self.configuration = configuration
     }
@@ -740,10 +747,11 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         if let storageRoot {
             return storageRoot.standardizedFileURL
         }
-        guard let base = fileManager.urls(
+        let base = applicationSupportDirectory ?? fileManager.urls(
             for: .applicationSupportDirectory,
             in: .userDomainMask
-        ).first else {
+        ).first
+        guard let base else {
             return URL(fileURLWithPath: "/dev/null/pine-agent-tasks")
         }
         return base.resolvingSymlinksInPath()
@@ -757,7 +765,7 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         let components = url.standardizedFileURL.pathComponents.dropFirst()
         let names = Array(components)
         let privateCount = configuration.privateComponentCount
-            ?? (storageRoot == nil ? 2 : 1)
+            ?? 1
         guard !names.isEmpty, (1...names.count).contains(privateCount) else {
             throw AgentTaskDirectoryError.unsafe
         }

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Observation
+import os
 
 nonisolated private struct AgentTaskTerminalKey: Hashable, Sendable {
     let project: AgentTaskProjectIdentity
@@ -1364,6 +1365,10 @@ final class AgentTaskRegistry {
         _ project: AgentTaskProjectIdentity,
         rejection: AgentTaskMetadataRejection
     ) {
+        let diagnostic = String(describing: rejection)
+        Logger.task.error(
+            "Agent task metadata load rejected: \(diagnostic, privacy: .public)"
+        )
         loadStatusByProject[project.persistenceKey] = .rejected(rejection)
         loadedProjects.remove(project)
         diskRevisionByProject[project] = nil
@@ -1883,8 +1888,11 @@ final class AgentTaskRegistry {
                 )
             case .publishedButDurabilityUnknown(_, let revision):
                 diskRevisionByProject[project] = .versioned(revision)
-            case .rejected:
-                break
+            case .rejected(let rejection):
+                let diagnostic = String(describing: rejection)
+                Logger.task.error(
+                    "Agent task metadata save rejected: \(diagnostic, privacy: .public)"
+                )
             }
             let ownsTail = persistenceTailTicket == ticket
             if ownsTail {

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -567,6 +567,25 @@ extension ContentView {
 
 extension ContentView {
 
+    /// A key scene is authoritative evidence that its retained project is
+    /// visible. Reconcile a restoration race, then self-heal an empty settled
+    /// tree whose initial load may have been cancelled just before activation.
+    func reconcileKeyProjectPresentation() {
+        let wasSuspended = workspace.isSuspended
+        guard controlActiveState == .key,
+              registry.reconcileKeyProjectPresentation(projectManager) else {
+            return
+        }
+        if !wasSuspended,
+           workspace.rootURL != nil,
+           workspace.rootNodesRevision == 0,
+           workspace.rootNodes.isEmpty,
+           !workspace.isLoading,
+           !workspace.isSuspended {
+            workspace.refreshFileTreeAsync()
+        }
+    }
+
     var totalLineCount: Int {
         guard let content = activeTab?.content else { return 1 }
         let ns = content as NSString

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -133,6 +133,7 @@ struct ContentView: View {
             )
         }
         .task {
+            reconcileKeyProjectPresentation()
             let disposition = restoreSessionIfNeeded()
             if case .restored(let result) = disposition, result.didRestoreEditorTabs {
                 refreshLineDiffs()
@@ -159,6 +160,10 @@ struct ContentView: View {
                 afterWindowBindingFor: projectManager
             )
             #endif
+        }
+        .onChange(of: controlActiveState) { _, newState in
+            guard newState == .key else { return }
+            reconcileKeyProjectPresentation()
         }
         .sheet(isPresented: $showRecoveryDialog) {
             RecoveryDialogView(

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -3094,6 +3094,30 @@ final class ProjectRegistry: LSPSettingsObserver {
         return openProjects[canonical] != nil && !backgroundProjects.contains(canonical)
     }
 
+    /// Repairs a retained manager when AppKit makes its SwiftUI project scene
+    /// key without replaying the normal Open Recent admission path. This can
+    /// happen when window restoration reuses a WindowGroup scene after an
+    /// earlier close callback suspended editor-only services.
+    @discardableResult
+    func reconcileKeyProjectPresentation(
+        _ projectManager: ProjectManager
+    ) -> Bool {
+        guard let rootURL = projectManager.rootURL else { return false }
+        let canonical = canonicalProjectURL(rootURL)
+        guard openProjects[canonical] === projectManager,
+              let identity = agentTaskProjectsByRoot[canonical] else {
+            return false
+        }
+        guard backgroundProjects.contains(canonical) else {
+            return projectManager.presentationLifecycle == .visible
+        }
+        return markProjectWindowOpen(
+            canonical,
+            identity: identity,
+            manager: projectManager
+        )
+    }
+
     /// Checks if a project is already open (including background).
     func isProjectOpen(_ url: URL) -> Bool {
         openProjects[canonicalProjectURL(url)] != nil

--- a/PineTests/AgentTaskStoreRaceTests.swift
+++ b/PineTests/AgentTaskStoreRaceTests.swift
@@ -57,6 +57,36 @@ struct AgentTaskStoreRaceTests {
         #expect(permissions.intValue & 0o777 == 0o700)
     }
 
+    @Test("default Application Support anchor may carry system permissions")
+    func defaultApplicationSupportAnchorCreatesPrivateLeaf() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let applicationSupport = fixture.root.appendingPathComponent(
+            "Application Support"
+        )
+        try FileManager.default.createDirectory(
+            at: applicationSupport,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o755]
+        )
+        let store = AgentTaskMetadataStore(
+            applicationSupportDirectory: applicationSupport
+        )
+
+        #expect(await store.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let privateStorage = applicationSupport.appendingPathComponent(
+            ".pine-agent-tasks-private"
+        )
+        let attributes = try FileManager.default.attributesOfItem(
+            atPath: privateStorage.path
+        )
+        let permissions = try #require(
+            attributes[.posixPermissions] as? NSNumber
+        )
+        #expect(permissions.intValue & 0o777 == 0o700)
+    }
+
     @Test("owned intermediate symlink is rejected without traversal")
     func ownedIntermediateSymlinkIsRejected() async throws {
         let fixture = try StoreRaceFixture()

--- a/PineTests/BackgroundProjectLifecycleTests.swift
+++ b/PineTests/BackgroundProjectLifecycleTests.swift
@@ -115,6 +115,36 @@ struct BackgroundProjectLifecycleTests {
         #expect(manager.editorServiceResumeCountForTesting == 1)
     }
 
+    @Test("key restored scene repairs a suspended empty file tree")
+    func keySceneRepairsSuspendedTree() async throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        try "visible".write(
+            to: directory.appendingPathComponent("visible.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let registry = makeRegistry()
+        let manager = try #require(registry.projectManager(for: directory))
+
+        registry.closeProjectWindow(directory)
+        #expect(manager.presentationLifecycle == .backgroundSuspended)
+        #expect(manager.workspace.isSuspended)
+
+        #expect(registry.reconcileKeyProjectPresentation(manager))
+        await waitUntil {
+            manager.workspace.rootNodes.contains { $0.name == "visible.txt" }
+        }
+
+        #expect(registry.isWindowOpen(directory))
+        #expect(manager.presentationLifecycle == .visible)
+        #expect(!manager.workspace.isSuspended)
+        #expect(manager.workspace.hasActiveFileWatcherForTesting)
+        #expect(manager.workspace.rootNodes.contains {
+            $0.name == "visible.txt"
+        })
+    }
+
     @Test("workspace watcher events are fenced while suspended and rearmed")
     func workspaceWatcherEventsFollowLifecycle() throws {
         let directory = try makeTempDirectory()


### PR DESCRIPTION
## Summary

- restore retained project services and refresh an unpublished file tree when a restored project scene becomes key
- treat the system Application Support directory as a trusted anchor while keeping Pine's agent-task storage leaf private and ACL-free
- log metadata load/save rejection reasons and add regression coverage for both failures

## Related issue

No linked issue; reported from the installed Pine 2.3.2 build.

## Test plan

- [x] Unit tests added/updated
- [x] UI tests N/A; the restored-scene transition is covered at the registry/workspace lifecycle boundary

Passed:

- 45 tests in AgentTaskStoreRaceTests and BackgroundProjectLifecycleTests
- 61 isolated tests in ApplicationLifecycleProcessTests, MultiProjectAgentJourneyTests, and WindowLifecycleTests
- strict SwiftLint for all changed Swift files
- git diff --check

The full parallel PineTests run completed 754 tests with 19 issues across unrelated and resource-sensitive suites (60-second adapter/LSP/PTY/formatter timeouts plus hosted snapshot failures). The Quit and multi-project failures from that loaded run passed when rerun in the isolated 61-test group above.

## Compatibility matrix

- macOS 26: Not tested — runtime unavailable on this machine; CI/another runtime is required
- macOS 27 beta: Tested — macOS 27.0 (26A5406e), beta environment
- Xcode: Xcode 27.0, build 27A5194q
- macOS SDK: 27.0, build 26A5353p

Complete compatibility output:

```text
$ sw_vers
ProductName:            macOS
ProductVersion:         27.0
BuildVersion:           26A5406e

$ xcodebuild -version
Xcode 27.0
Build version 27A5194q

$ xcrun --sdk macosx --show-sdk-version
27.0

$ xcrun --sdk macosx --show-sdk-build-version
26A5353p
```

### Terminal renderer coverage

- Default path (Metal when available): N/A — no terminal rendering changes
- CoreGraphics (`--disable-metal`): N/A — no terminal rendering changes

## Manual testing checklist

- [ ] Verified the fixed build interactively; the currently installed app is still the unfixed 2.3.2 build
- [x] Related lifecycle and persistence regression tests pass
