### PR TITLE
fix(release): publish the smoke feed port without reverse DNS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Tests for release artifact smoke
         run: bash scripts/tests/test-release-artifact-smoke.sh
 
+      - name: Tests for release smoke loopback feed server
+        run: bash scripts/tests/test-appcast-server.sh
+
       - name: Tests for screenshot workflow coverage
         run: bash scripts/tests/test-screenshot-workflow.sh
 

--- a/scripts/appcast-loopback-server.py
+++ b/scripts/appcast-loopback-server.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Serve a release-smoke update feed over loopback and publish the bound port.
+
+Why this is not `python3 -m http.server`
+----------------------------------------
+`http.server.HTTPServer.server_bind()` finishes with
+`self.server_name = socket.getfqdn(host)` — a reverse DNS lookup performed
+inside the constructor, before the caller can read `server_address`. On a
+GitHub Actions macOS runner that lookup can stall for tens of seconds, so the
+release gate's `Pine-<version>.dmg` feed server never published its port and
+the whole `Release` workflow failed closed with a bare "local appcast server
+did not publish its port" (Pine #1465 — v2.3.3 shipped with no DMG asset and
+no Homebrew tap update because of it).
+
+`LoopbackFeedServer` binds through `socketserver.TCPServer.server_bind()` and
+names itself `127.0.0.1` literally, so no resolver is ever consulted: not at
+bind time, and not per request (`SimpleHTTPRequestHandler.address_string()`
+returns the raw client address). The port is written atomically — staged in a
+sibling file and `os.replace()`d into place — so a reader that polls with
+`test -s` can never observe a half-written port.
+
+Usage
+-----
+    appcast-loopback-server.py <feed-root> <port-file>
+
+The server runs until it is killed. `<port-file>` must not already exist: a
+stale file from an earlier run would let the caller connect to a server that
+is no longer serving the bytes under test.
+"""
+
+from __future__ import annotations
+
+import http.server
+import os
+import socketserver
+import sys
+from pathlib import Path
+
+EXIT_USAGE = 64
+EXIT_STALE_PORT_FILE = 65
+EXIT_BAD_FEED_ROOT = 66
+
+
+class LoopbackFeedServer(http.server.ThreadingHTTPServer):
+    """A threading HTTP server that never performs name resolution."""
+
+    daemon_threads = True
+
+    def server_bind(self) -> None:
+        socketserver.TCPServer.server_bind(self)
+        self.server_name = "127.0.0.1"
+        self.server_port = self.server_address[1]
+
+
+def publish_port(port_file: Path, port: int) -> None:
+    """Write `port` so that no reader can observe a partial value."""
+    staging = port_file.with_name(f"{port_file.name}.partial")
+    staging.write_text(f"{port}\n", encoding="utf-8")
+    os.replace(staging, port_file)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        sys.stderr.write(
+            "usage: appcast-loopback-server.py <feed-root> <port-file>\n"
+        )
+        return EXIT_USAGE
+
+    root = Path(argv[1])
+    port_file = Path(argv[2])
+
+    if not root.is_dir():
+        sys.stderr.write(f"feed root is not a directory: {root}\n")
+        return EXIT_BAD_FEED_ROOT
+    if port_file.exists():
+        sys.stderr.write(f"port file already exists: {port_file}\n")
+        return EXIT_STALE_PORT_FILE
+
+    def build_handler(*args: object, **kwargs: object):
+        return http.server.SimpleHTTPRequestHandler(
+            *args, directory=str(root), **kwargs
+        )
+
+    with LoopbackFeedServer(("127.0.0.1", 0), build_handler) as server:
+        port = server.server_address[1]
+        publish_port(port_file, port)
+        sys.stderr.write(f"serving {root} on 127.0.0.1:{port}\n")
+        sys.stderr.flush()
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/release-artifact-smoke.sh
+++ b/scripts/release-artifact-smoke.sh
@@ -81,6 +81,21 @@ SPARKLE_SOURCE="$(absolute_directory "$SPARKLE_SOURCE_ARGUMENT")"
 OUTPUT_PARENT="$(cd "$(dirname "$OUTPUT_ARGUMENT")" && pwd -P)"
 OUTPUT_ROOT="$OUTPUT_PARENT/$(basename "$OUTPUT_ARGUMENT")"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+APPCAST_SERVER="$REPO_ROOT/scripts/appcast-loopback-server.py"
+
+[ -f "$APPCAST_SERVER" ] \
+    || die "appcast loopback server not found: $APPCAST_SERVER"
+
+# Startup budget for the loopback update feed. Overridable so the script's own
+# regression tests can exercise the timeout path without stalling CI.
+SERVER_TIMEOUT_SECONDS="${PINE_RELEASE_SMOKE_SERVER_TIMEOUT:-30}"
+case "$SERVER_TIMEOUT_SECONDS" in
+    ''|0|*[!0-9]*)
+        die "appcast server timeout must be a positive integer:" \
+            "$SERVER_TIMEOUT_SECONDS"
+        ;;
+esac
+SERVER_ATTEMPTS=$((SERVER_TIMEOUT_SECONDS * 10))
 
 LOGS="$OUTPUT_ROOT/logs"
 METADATA="$OUTPUT_ROOT/metadata"
@@ -260,32 +275,52 @@ FEED_HASH="$(shasum -a 256 "$FEED_DMG" | awk '{print $1}')"
     || die "local update feed does not contain the candidate DMG bytes"
 
 PORT_FILE="$METADATA/appcast-port.txt"
-python3 - "$FEED_ROOT" "$PORT_FILE" <<'PYTHON' \
-    > "$LOGS/appcast-server.log" 2>&1 &
-import http.server
-import pathlib
-import sys
-
-root = pathlib.Path(sys.argv[1])
-port_file = pathlib.Path(sys.argv[2])
-handler = lambda *args, **kwargs: http.server.SimpleHTTPRequestHandler(
-    *args, directory=root, **kwargs
-)
-server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
-port_file.write_text(str(server.server_address[1]), encoding="utf-8")
-server.serve_forever()
-PYTHON
+SERVER_LOG="$LOGS/appcast-server.log"
+python3 "$APPCAST_SERVER" "$FEED_ROOT" "$PORT_FILE" \
+    > "$SERVER_LOG" 2>&1 &
 SERVER_PID="$!"
 
-for _ in {1..100}; do
-    [ -s "$PORT_FILE" ] && break
-    kill -0 "$SERVER_PID" >/dev/null 2>&1 \
-        || die "local appcast server exited before startup"
-    sleep 0.1
-done
-[ -s "$PORT_FILE" ] || die "local appcast server did not publish its port"
+# `kill -0` succeeds for a zombie, so a server that died during startup would
+# otherwise be indistinguishable from one that is merely slow, and every
+# startup failure would surface as the timeout below.
+server_is_running() {
+    local state
+    state="$(ps -o state= -p "$SERVER_PID" 2>/dev/null | tr -d '[:space:]')"
+    case "$state" in
+        ''|Z*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
 
-APPCAST_PORT="$(cat "$PORT_FILE")"
+report_appcast_server_log() {
+    echo "--- appcast server log ---" >&2
+    cat "$SERVER_LOG" >&2 2>/dev/null || true
+    echo "--- end appcast server log ---" >&2
+}
+
+attempt=0
+while [ "$attempt" -lt "$SERVER_ATTEMPTS" ]; do
+    [ -s "$PORT_FILE" ] && break
+    server_is_running || {
+        report_appcast_server_log
+        die "local appcast server exited before startup"
+    }
+    sleep 0.1
+    attempt=$((attempt + 1))
+done
+if [ ! -s "$PORT_FILE" ]; then
+    report_appcast_server_log
+    die "local appcast server did not publish its port within" \
+        "${SERVER_TIMEOUT_SECONDS}s"
+fi
+
+APPCAST_PORT="$(tr -d '[:space:]' < "$PORT_FILE")"
+case "$APPCAST_PORT" in
+    ''|*[!0-9]*)
+        report_appcast_server_log
+        die "local appcast server published an invalid port: $APPCAST_PORT"
+        ;;
+esac
 APPCAST_URL="http://127.0.0.1:$APPCAST_PORT/appcast.xml"
 DMG_URL="http://127.0.0.1:$APPCAST_PORT/$(basename "$FEED_DMG")"
 PINE_APPCAST_SOURCE="$APPCAST" \

--- a/scripts/tests/test-appcast-server.sh
+++ b/scripts/tests/test-appcast-server.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# Regression tests for the release-smoke loopback update feed server.
+#
+# The server exists because http.server.HTTPServer resolves its bound address
+# with socket.getfqdn(); that reverse DNS lookup stalled on a GitHub Actions
+# runner and took the whole v2.3.3 release with it (Pine #1465). Test 2 pins
+# exactly that: with every resolver entry point wedged, the port must still be
+# published and requests must still be answered.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd -P)"
+SERVER="$REPO_ROOT/scripts/appcast-loopback-server.py"
+SMOKE_SCRIPT="$REPO_ROOT/scripts/release-artifact-smoke.sh"
+PASS=0
+FAIL=0
+TEST_ROOT=""
+SERVER_PID=""
+
+cleanup() {
+    if [ -n "$SERVER_PID" ]; then
+        kill "$SERVER_PID" >/dev/null 2>&1 || true
+        wait "$SERVER_PID" >/dev/null 2>&1 || true
+        SERVER_PID=""
+    fi
+    [ -n "$TEST_ROOT" ] && rm -rf "$TEST_ROOT"
+    TEST_ROOT=""
+}
+trap cleanup EXIT
+
+pass() {
+    echo "  ✓ $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "  ✗ $1"
+    FAIL=$((FAIL + 1))
+}
+
+setup_fixture() {
+    cleanup
+    TEST_ROOT="$(mktemp -d)"
+    mkdir -p "$TEST_ROOT/feed" "$TEST_ROOT/metadata"
+    printf 'candidate artifact bytes\n' > "$TEST_ROOT/feed/Pine-2.0.0.dmg"
+    printf '<rss></rss>\n' > "$TEST_ROOT/feed/appcast.xml"
+    printf 'must-not-be-served\n' > "$TEST_ROOT/outside-the-feed.txt"
+}
+
+# Waits up to $2 tenths of a second for a non-empty $1.
+wait_for_port() {
+    local file="$1"
+    local limit="$2"
+    local waited=0
+
+    while [ "$waited" -lt "$limit" ]; do
+        [ -s "$file" ] && return 0
+        sleep 0.1
+        waited=$((waited + 1))
+    done
+    return 1
+}
+
+start_server() {
+    python3 "$SERVER" "$TEST_ROOT/feed" "$TEST_ROOT/metadata/port.txt" \
+        > "$TEST_ROOT/server.log" 2>&1 &
+    SERVER_PID="$!"
+}
+
+echo "Test 1: the feed server publishes a usable port and serves feed bytes"
+setup_fixture
+start_server
+if wait_for_port "$TEST_ROOT/metadata/port.txt" 100; then
+    port="$(tr -d '[:space:]' < "$TEST_ROOT/metadata/port.txt")"
+    expected="$(shasum -a 256 "$TEST_ROOT/feed/Pine-2.0.0.dmg" | awk '{print $1}')"
+    served="$(curl --fail --silent --show-error --max-time 10 \
+        "http://127.0.0.1:$port/Pine-2.0.0.dmg" \
+        | shasum -a 256 | awk '{print $1}')"
+    case "$port" in
+        ''|*[!0-9]*) served="non-numeric-port" ;;
+    esac
+    if [ "$served" = "$expected" ] \
+        && [ ! -e "$TEST_ROOT/metadata/port.txt.partial" ] \
+        && curl --fail --silent --show-error --max-time 10 \
+            "http://127.0.0.1:$port/appcast.xml" > /dev/null; then
+        pass "port published atomically and feed bytes served intact"
+    else
+        cat "$TEST_ROOT/server.log"
+        fail "feed server round trip"
+    fi
+else
+    cat "$TEST_ROOT/server.log"
+    fail "feed server never published a port"
+fi
+
+echo "Test 2: a wedged resolver cannot stall startup or requests (#1465)"
+setup_fixture
+mkdir -p "$TEST_ROOT/resolver-trap"
+cat > "$TEST_ROOT/resolver-trap/sitecustomize.py" <<'PYTHON'
+import socket
+import time
+
+
+def _wedged(*args, **kwargs):
+    time.sleep(600)
+    raise AssertionError("resolver must not be consulted")
+
+
+socket.getfqdn = _wedged
+socket.gethostbyaddr = _wedged
+socket.getnameinfo = _wedged
+PYTHON
+PYTHONPATH="$TEST_ROOT/resolver-trap" python3 "$SERVER" \
+    "$TEST_ROOT/feed" "$TEST_ROOT/metadata/port.txt" \
+    > "$TEST_ROOT/server.log" 2>&1 &
+SERVER_PID="$!"
+if wait_for_port "$TEST_ROOT/metadata/port.txt" 50; then
+    port="$(tr -d '[:space:]' < "$TEST_ROOT/metadata/port.txt")"
+    if curl --fail --silent --show-error --max-time 5 \
+        "http://127.0.0.1:$port/appcast.xml" > /dev/null; then
+        pass "binds and serves without any name resolution"
+    else
+        cat "$TEST_ROOT/server.log"
+        fail "request stalled on the resolver"
+    fi
+else
+    cat "$TEST_ROOT/server.log"
+    fail "startup stalled on the resolver"
+fi
+
+echo "Test 3: a stale port file fails closed instead of misdirecting the gate"
+setup_fixture
+printf '1\n' > "$TEST_ROOT/metadata/port.txt"
+if python3 "$SERVER" "$TEST_ROOT/feed" "$TEST_ROOT/metadata/port.txt" \
+    > "$TEST_ROOT/server.log" 2>&1; then
+    fail "stale port file was accepted"
+elif [ "$(tr -d '[:space:]' < "$TEST_ROOT/metadata/port.txt")" = "1" ] \
+    && grep -q 'port file already exists' "$TEST_ROOT/server.log"; then
+    pass "stale port file rejected without overwriting it"
+else
+    cat "$TEST_ROOT/server.log"
+    fail "stale port file diagnostic"
+fi
+
+echo "Test 4: wrong argument count is a usage error"
+setup_fixture
+status=0
+python3 "$SERVER" "$TEST_ROOT/feed" > "$TEST_ROOT/server.log" 2>&1 || status=$?
+if [ "$status" -eq 64 ] && grep -q 'usage:' "$TEST_ROOT/server.log"; then
+    pass "usage error reported for missing arguments"
+else
+    cat "$TEST_ROOT/server.log"
+    fail "usage error handling (status $status)"
+fi
+
+echo "Test 5: a missing feed root is rejected before any port is published"
+setup_fixture
+status=0
+python3 "$SERVER" "$TEST_ROOT/feed/absent" "$TEST_ROOT/metadata/port.txt" \
+    > "$TEST_ROOT/server.log" 2>&1 || status=$?
+if [ "$status" -eq 66 ] \
+    && [ ! -e "$TEST_ROOT/metadata/port.txt" ] \
+    && grep -q 'feed root is not a directory' "$TEST_ROOT/server.log"; then
+    pass "missing feed root rejected with no port published"
+else
+    cat "$TEST_ROOT/server.log"
+    fail "missing feed root handling (status $status)"
+fi
+
+echo "Test 6: the feed server does not serve paths outside the feed root"
+setup_fixture
+start_server
+if wait_for_port "$TEST_ROOT/metadata/port.txt" 100; then
+    port="$(tr -d '[:space:]' < "$TEST_ROOT/metadata/port.txt")"
+    escape="$(curl --silent --show-error --path-as-is --max-time 10 \
+        "http://127.0.0.1:$port/../outside-the-feed.txt" || true)"
+    if ! printf '%s' "$escape" | grep -q 'must-not-be-served'; then
+        pass "path traversal out of the feed root refused"
+    else
+        fail "feed server served a file outside its root"
+    fi
+else
+    cat "$TEST_ROOT/server.log"
+    fail "feed server never published a port"
+fi
+
+echo "Test 7: the release gate uses the shared server and a real startup budget"
+if grep -q 'scripts/appcast-loopback-server.py' "$SMOKE_SCRIPT" \
+    && grep -q 'PINE_RELEASE_SMOKE_SERVER_TIMEOUT:-30' "$SMOKE_SCRIPT" \
+    && ! grep -q 'ThreadingHTTPServer' "$SMOKE_SCRIPT"; then
+    pass "release gate wired to the shared loopback server"
+else
+    fail "release gate integration"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/test-release-artifact-smoke.sh
+++ b/scripts/tests/test-release-artifact-smoke.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd -P)"
 SMOKE_SCRIPT="$REPO_ROOT/scripts/release-artifact-smoke.sh"
 RELEASE_WORKFLOW="$REPO_ROOT/.github/workflows/release.yml"
+REAL_PYTHON3="$(command -v python3)"
 PASS=0
 FAIL=0
 TEST_ROOT=""
@@ -227,6 +228,28 @@ FAKE
 exit 0
 FAKE
 
+    # Only the loopback feed server is faked; every other python3 invocation
+    # (the appcast rewrite) must reach the real interpreter.
+    cat > "$TEST_ROOT/bin/python3" <<FAKE
+#!/bin/bash
+for argument in "\$@"; do
+    case "\$argument" in
+        *appcast-loopback-server.py)
+            case "\${TEST_APPCAST_SERVER_MODE:-normal}" in
+                die)
+                    echo 'fake appcast server exploded' >&2
+                    exit 3
+                    ;;
+                hang)
+                    exec sleep 600
+                    ;;
+            esac
+            ;;
+    esac
+done
+exec "$REAL_PYTHON3" "\$@"
+FAKE
+
     chmod +x "$TEST_ROOT/bin/"*
 }
 
@@ -377,6 +400,51 @@ if [ -n "$smoke_line" ] \
 else
     fail "release workflow integration"
 fi
+
+echo "Test 7: a feed server that dies at startup is named, not timed out"
+setup_fixture
+export TEST_APPCAST_SERVER_MODE=die
+if run_smoke > "$TEST_ROOT/run.log" 2>&1; then
+    fail "dead feed server was accepted"
+elif grep -q 'exited before startup' "$TEST_ROOT/run.log" \
+    && grep -q 'fake appcast server exploded' "$TEST_ROOT/run.log" \
+    && ! grep -q 'did not publish its port' "$TEST_ROOT/run.log"; then
+    pass "startup failure reported with the server log"
+else
+    cat "$TEST_ROOT/run.log"
+    fail "dead feed server diagnostic"
+fi
+unset TEST_APPCAST_SERVER_MODE
+
+echo "Test 8: a feed server that never publishes a port times out and fails"
+setup_fixture
+export TEST_APPCAST_SERVER_MODE=hang
+export PINE_RELEASE_SMOKE_SERVER_TIMEOUT=1
+if run_smoke > "$TEST_ROOT/run.log" 2>&1; then
+    fail "stalled feed server was accepted"
+elif grep -q 'did not publish its port within 1s' "$TEST_ROOT/run.log" \
+    && grep -q 'appcast server log' "$TEST_ROOT/run.log" \
+    && [ ! -d "$TEST_ROOT/output/ReleaseArtifactSmoke.xcresult" ]; then
+    pass "startup timeout fails closed before the release gate runs"
+else
+    cat "$TEST_ROOT/run.log"
+    fail "stalled feed server diagnostic"
+fi
+unset TEST_APPCAST_SERVER_MODE
+unset PINE_RELEASE_SMOKE_SERVER_TIMEOUT
+
+echo "Test 9: a non-numeric startup budget is rejected"
+setup_fixture
+export PINE_RELEASE_SMOKE_SERVER_TIMEOUT=soon
+if run_smoke > "$TEST_ROOT/run.log" 2>&1; then
+    fail "non-numeric startup budget was accepted"
+elif grep -q 'timeout must be a positive integer' "$TEST_ROOT/run.log"; then
+    pass "invalid startup budget rejected"
+else
+    cat "$TEST_ROOT/run.log"
+    fail "invalid startup budget diagnostic"
+fi
+unset PINE_RELEASE_SMOKE_SERVER_TIMEOUT
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

- The `Release` workflow for v2.3.3 failed at `Run signed release artifact smoke` with `local appcast server did not publish its port` ([run 31831444752](https://github.com/batonogov/pine/actions/runs/31831444752), both attempts), so `Upload DMG to GitHub Release`, `Verify published DMG matches tested bytes` and `Update Homebrew Tap` were all skipped and the tag shipped with zero assets.
- Root cause: the inline loopback feed server was `http.server.ThreadingHTTPServer`, whose `server_bind()` finishes with `socket.getfqdn(host)` — a reverse DNS lookup performed inside the constructor, before the port can be published. The uploaded diagnostics show the process alive and idle (`logs/processes.txt`: the Python child at 19s elapsed) with an empty `logs/appcast-server.log` and no `metadata/appcast-port.txt`; the 10s wait then expired.
- Fix: move the server to `scripts/appcast-loopback-server.py`, bind via `socketserver.TCPServer.server_bind()` and name it `127.0.0.1` literally so no resolver is consulted at bind time or per request, and publish the port atomically with `os.replace()`.
- Hardening in the gate: 30s startup budget (overridable via `PINE_RELEASE_SMOKE_SERVER_TIMEOUT` for tests), liveness checked through the process state instead of `kill -0` (which succeeds for a zombie, so every startup failure previously surfaced as the generic timeout), the published port is validated as numeric, and the server log is printed to stderr on failure instead of only landing in an uploaded artifact.

## Related issue

Follow-up to the failed release of #1465.

## Test plan

- [x] Unit tests added/updated — new `scripts/tests/test-appcast-server.sh` (7 cases) wired into CI, plus 3 new cases in `scripts/tests/test-release-artifact-smoke.sh` (9 total)
- [x] UI tests added/updated (if applicable) — N/A, this is release tooling; the existing `PineUITests/ReleaseArtifactSmokeTests` gate is unchanged

New coverage:

1. Port published atomically, feed bytes served intact, no `.partial` left behind.
2. **Regression pin for this bug:** with `socket.getfqdn`, `gethostbyaddr` and `getnameinfo` all wedged via a `sitecustomize.py` that sleeps 600s, the server must still publish its port and answer a request. Verified this test fails against the old implementation — the pre-fix server publishes no port within 6s under the same trap, while the new one is immediate.
3. A stale port file fails closed and is not overwritten.
4. / 5. Usage error and missing feed root exit with distinct codes and no port published.
6. Path traversal out of the feed root is refused.
7. The gate is wired to the shared server and keeps a real startup budget.
8. Gate-level: a server that dies at startup is reported as `exited before startup` *with its log*, never as a timeout.
9. Gate-level: a server that never publishes a port times out, fails closed before the release gate runs, and prints the server log.
10. Gate-level: a non-numeric startup budget is rejected.

Local run: `test-appcast-server.sh` 7/7, `test-release-artifact-smoke.sh` 9/9 (all 6 pre-existing cases still pass).

## Compatibility matrix

- macOS 26: Not tested locally — the failing path is CI-only; the shell/Python tests are OS-agnostic and run on the `macos-26` CI runner
- macOS 27 beta: Tested — 27.0 (26A5406e), Python 3.14.7
- Xcode: N/A — no Swift or project changes
- macOS SDK: N/A

### Terminal renderer coverage

- Default path (Metal when available): N/A
- CoreGraphics (`--disable-metal`): N/A

## Manual testing checklist

- [x] Verified the change works as expected — reproduced the stall with the pre-fix server under a wedged resolver, confirmed the new server binds and serves immediately under the same conditions
- [x] No regressions in related features — the full pre-existing release smoke suite passes unchanged

## After merge

The `Release` workflow needs to be re-run for `v2.3.3` (a plain re-run would not have helped: both attempts failed deterministically) so the DMG, the appcast and the Homebrew tap catch up.
