### PR TITLE
fix(release): skip incomplete previous releases

### DIFF
--- a/.github/scripts/select_previous_release.py
+++ b/.github/scripts/select_previous_release.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Select the newest usable release older than the current Pine tag.
+
+GitHub creates the Release Please release before the signed artifacts are
+uploaded. A failed publication can therefore leave a stable-looking release
+with no DMG. Release smoke tests must skip those incomplete releases instead
+of letting one failed publication block every later release.
+
+The GitHub releases API response is read from stdin. The selected tag is
+written to stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from typing import Any
+
+
+TAG_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+
+class ReleaseSelectionError(ValueError):
+    """The release list cannot provide a safe previous DMG."""
+
+
+def parse_stable_tag(tag: str) -> tuple[int, int, int]:
+    """Return a comparable version tuple for a stable Pine release tag."""
+    match = TAG_PATTERN.fullmatch(tag)
+    if match is None:
+        raise ReleaseSelectionError(f"invalid stable Pine tag: {tag!r}")
+    return tuple(int(component) for component in match.groups())
+
+
+def _usable_dmg(release: dict[str, Any], tag: str) -> bool:
+    """Whether release has one complete DMG whose name matches its tag."""
+    assets = release.get("assets")
+    if not isinstance(assets, list):
+        return False
+
+    pine_dmgs = [
+        asset
+        for asset in assets
+        if isinstance(asset, dict)
+        and isinstance(asset.get("name"), str)
+        and asset["name"].startswith("Pine-")
+        and asset["name"].endswith(".dmg")
+    ]
+    if len(pine_dmgs) != 1:
+        return False
+
+    asset = pine_dmgs[0]
+    expected_name = f"Pine-{tag.removeprefix('v')}.dmg"
+    return (
+        asset["name"] == expected_name
+        and asset.get("state") == "uploaded"
+        and isinstance(asset.get("size"), int)
+        and asset["size"] > 0
+    )
+
+
+def select_previous_release(
+    releases: object,
+    current_tag: str,
+) -> str:
+    """Select the highest usable stable version strictly below current_tag."""
+    current_version = parse_stable_tag(current_tag)
+    if not isinstance(releases, list):
+        raise ReleaseSelectionError("GitHub releases response must be a list")
+
+    candidates: list[tuple[tuple[int, int, int], str]] = []
+    for release in releases:
+        if not isinstance(release, dict):
+            continue
+        if release.get("draft") is True or release.get("prerelease") is True:
+            continue
+
+        tag = release.get("tag_name")
+        if not isinstance(tag, str):
+            continue
+        try:
+            version = parse_stable_tag(tag)
+        except ReleaseSelectionError:
+            continue
+        if version >= current_version or not _usable_dmg(release, tag):
+            continue
+        candidates.append((version, tag))
+
+    if not candidates:
+        raise ReleaseSelectionError(
+            "no earlier stable release with one uploaded Pine DMG exists "
+            f"before {current_tag}"
+        )
+    return max(candidates)[1]
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(
+            "Usage: select_previous_release.py <current-tag>",
+            file=sys.stderr,
+        )
+        return 64
+
+    try:
+        releases = json.load(sys.stdin)
+        selected = select_previous_release(releases, sys.argv[1])
+    except (json.JSONDecodeError, ReleaseSelectionError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+
+    print(selected)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_select_previous_release.py
+++ b/.github/scripts/test_select_previous_release.py
@@ -1,0 +1,150 @@
+"""Regression tests for selecting the previous signed Pine release."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from select_previous_release import (
+    ReleaseSelectionError,
+    parse_stable_tag,
+    select_previous_release,
+)
+
+
+def release(
+    tag: str,
+    *,
+    assets: list[dict] | None = None,
+    draft: bool = False,
+    prerelease: bool = False,
+) -> dict:
+    version = tag.removeprefix("v")
+    if assets is None:
+        assets = [{
+            "name": f"Pine-{version}.dmg",
+            "state": "uploaded",
+            "size": 14_000_000,
+        }]
+    return {
+        "tag_name": tag,
+        "draft": draft,
+        "prerelease": prerelease,
+        "assets": assets,
+    }
+
+
+class PreviousReleaseSelectionTests(unittest.TestCase):
+    def test_skips_consecutive_empty_releases(self):
+        releases = [
+            release("v2.3.5", assets=[]),
+            release("v2.3.4", assets=[]),
+            release(
+                "v2.3.3",
+                assets=[{"name": "appcast.xml", "state": "uploaded", "size": 10}],
+            ),
+            release("v2.3.2"),
+        ]
+
+        self.assertEqual(
+            select_previous_release(releases, "v2.3.5"),
+            "v2.3.2",
+        )
+
+    def test_rerun_never_selects_a_newer_release(self):
+        releases = [release("v2.3.4"), release("v2.3.2")]
+
+        self.assertEqual(
+            select_previous_release(releases, "v2.3.3"),
+            "v2.3.2",
+        )
+
+    def test_selects_highest_version_independent_of_api_order(self):
+        releases = [
+            release("v2.3.1"),
+            release("v2.3.3"),
+            release("v2.2.9"),
+            release("v2.3.2"),
+        ]
+
+        self.assertEqual(
+            select_previous_release(releases, "v2.4.0"),
+            "v2.3.3",
+        )
+
+    def test_skips_draft_prerelease_and_malformed_tags(self):
+        releases = [
+            release("v2.3.4", draft=True),
+            release("v2.3.3", prerelease=True),
+            release("nightly"),
+            release("v2.3.2"),
+        ]
+
+        self.assertEqual(
+            select_previous_release(releases, "v2.3.5"),
+            "v2.3.2",
+        )
+
+    def test_skips_ambiguous_mismatched_and_incomplete_dmgs(self):
+        releases = [
+            release(
+                "v2.3.4",
+                assets=[
+                    {"name": "Pine-2.3.4.dmg", "state": "uploaded", "size": 10},
+                    {"name": "Pine-debug.dmg", "state": "uploaded", "size": 10},
+                ],
+            ),
+            release(
+                "v2.3.3",
+                assets=[
+                    {"name": "Pine-2.3.2.dmg", "state": "uploaded", "size": 10},
+                ],
+            ),
+            release(
+                "v2.3.2",
+                assets=[
+                    {"name": "Pine-2.3.2.dmg", "state": "new", "size": 10},
+                ],
+            ),
+            release("v2.3.1"),
+        ]
+
+        self.assertEqual(
+            select_previous_release(releases, "v2.3.5"),
+            "v2.3.1",
+        )
+
+    def test_fails_closed_without_a_usable_earlier_release(self):
+        with self.assertRaisesRegex(ReleaseSelectionError, "before v2.3.5"):
+            select_previous_release(
+                [release("v2.3.4", assets=[]), release("v2.3.5")],
+                "v2.3.5",
+            )
+
+    def test_rejects_invalid_current_tag(self):
+        with self.assertRaisesRegex(ReleaseSelectionError, "invalid stable"):
+            select_previous_release([release("v2.3.2")], "latest")
+
+    def test_rejects_non_list_api_response(self):
+        with self.assertRaisesRegex(ReleaseSelectionError, "must be a list"):
+            select_previous_release({"message": "rate limited"}, "v2.3.5")
+
+    def test_stable_tag_comparison_is_numeric(self):
+        self.assertGreater(parse_stable_tag("v2.10.0"), parse_stable_tag("v2.9.9"))
+
+
+class ReleaseWorkflowIntegrationTests(unittest.TestCase):
+    def test_workflow_selects_and_downloads_the_validated_asset(self):
+        repository = Path(__file__).resolve().parents[2]
+        workflow = (repository / ".github/workflows/release.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("select_previous_release.py", workflow)
+        self.assertIn("releases?per_page=100", workflow)
+        self.assertIn('--pattern "$PREVIOUS_FILENAME"', workflow)
+        self.assertNotIn("gh release list", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,10 @@ jobs:
         working-directory: .github/scripts
         run: python3 -m unittest test_summarize_lifecycle_soak.py -v
 
+      - name: Unit tests for previous release selection
+        working-directory: .github/scripts
+        run: python3 -m unittest test_select_previous_release.py -v
+
       - name: Tests for lifecycle soak workflow
         run: bash scripts/tests/test-lifecycle-soak-workflow.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,42 +223,27 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          RELEASES_JSON=$(gh release list \
-            --exclude-drafts \
-            --exclude-pre-releases \
-            --limit 20 \
-            --json tagName)
-          PREVIOUS_TAG=$(RELEASES_JSON="$RELEASES_JSON" \
-            CURRENT_TAG="$GITHUB_REF_NAME" \
-            python3 -c '
-          import json
-          import os
-
-          releases = json.loads(os.environ["RELEASES_JSON"])
-          current = os.environ["CURRENT_TAG"]
-          print(next((
-              release["tagName"]
-              for release in releases
-              if release["tagName"] != current
-          ), ""))
-          ')
-          [ -n "$PREVIOUS_TAG" ] || {
-            echo "::error::No previous stable Pine release found"
-            exit 1
-          }
+          RELEASES_JSON=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/${GITHUB_REPOSITORY}/releases?per_page=100")
+          PREVIOUS_TAG=$(printf '%s' "$RELEASES_JSON" \
+            | python3 .github/scripts/select_previous_release.py \
+                "$GITHUB_REF_NAME")
+          PREVIOUS_VERSION=${PREVIOUS_TAG#v}
+          PREVIOUS_FILENAME="Pine-${PREVIOUS_VERSION}.dmg"
 
           mkdir -p "$RUNNER_TEMP/previous-release"
           gh release download "$PREVIOUS_TAG" \
-            --pattern 'Pine-*.dmg' \
+            --pattern "$PREVIOUS_FILENAME" \
             --dir "$RUNNER_TEMP/previous-release"
 
-          PREVIOUS_DMGS=("$RUNNER_TEMP"/previous-release/Pine-*.dmg)
-          if [ "${#PREVIOUS_DMGS[@]}" -ne 1 ] \
-            || [ ! -f "${PREVIOUS_DMGS[0]}" ]; then
-            echo "::error::Expected exactly one previous Pine DMG"
+          PREVIOUS_DMG="$RUNNER_TEMP/previous-release/$PREVIOUS_FILENAME"
+          if [ ! -f "$PREVIOUS_DMG" ]; then
+            echo "::error::Previous Pine DMG download is missing"
             exit 1
           fi
-          echo "PREVIOUS_DMG=${PREVIOUS_DMGS[0]}" >> "$GITHUB_ENV"
+          echo "PREVIOUS_DMG=$PREVIOUS_DMG" >> "$GITHUB_ENV"
           echo "Previous signed release: $PREVIOUS_TAG"
 
       - name: Record candidate DMG hash before publication


### PR DESCRIPTION
## Summary

- query GitHub Releases with asset metadata before running the signed artifact smoke
- select the highest older stable release containing exactly one complete, version-matched Pine DMG
- skip empty, draft, prerelease, malformed, newer, and ambiguous releases
- download the exact DMG validated by the selector
- add regression tests and run them in CI

## Context

The v2.3.3 release failed before uploading its DMG and appcast. The v2.3.4 workflow fixed that original smoke failure, but selected the empty v2.3.3 release as its previous artifact and failed with no assets to download. The old first-non-current selection also allowed a rerun of an older tag to select a newer release.

This change makes the release chain recover automatically. Against the current live GitHub release data, a future v2.3.5 correctly selects v2.3.2 as the previous signed release and skips the incomplete v2.3.3 and v2.3.4 entries.

## Verification

- 10 previous-release selector and workflow integration tests
- 129 total Python tests
- 7 appcast loopback server tests
- 9 signed release artifact smoke tests
- SwiftLint strict on all 759 tracked Swift files
- workflow YAML parse
- git diff check
- live GitHub API selection: v2.3.5 selects v2.3.2