### PR TITLE
feat: add multi-project workspaces

### DIFF
--- a/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle.git",
       "state" : {
-        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
-        "version" : "2.9.5"
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
       }
     },
     {

--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -57,6 +57,14 @@ nonisolated enum AccessibilityID {
     // MARK: - Main editor window
     static let sidebar = "sidebar"
     static let openFolderToolbarButton = "openFolderToolbarButton"
+    static let projectSwitcher = "projectSwitcher"
+    static let projectSwitcherNewAgent = "projectSwitcherNewAgent"
+    static func projectSwitcherProject(_ name: String) -> String {
+        "projectSwitcherProject_\(name)"
+    }
+    static func projectSwitcherWorktree(_ id: UUID) -> String {
+        "projectSwitcherWorktree_\(id.uuidString)"
+    }
     static func fileNode(_ name: String) -> String { "fileNode_\(name)" }
     static let inlineRenameTextField = "inlineRenameTextField"
 

--- a/Pine/Agent/AgentWorktreeService.swift
+++ b/Pine/Agent/AgentWorktreeService.swift
@@ -17,7 +17,7 @@ nonisolated struct AgentWorktreeCreateRequest: Sendable, Equatable {
     let startPoint: String
 }
 
-nonisolated struct AgentManagedWorktree: Sendable, Equatable {
+nonisolated struct AgentManagedWorktree: Codable, Sendable, Equatable {
     let taskID: UUID
     let repositoryRoot: URL
     let managedRoot: URL

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -203,7 +203,7 @@ extension ContentView {
 
     func openNewProject() {
         Task { @MainActor in
-            guard let url = await registry.openProjectViaPanel(for: projectManager) else { return }
+            guard let url = await registry.chooseProjectViaPanel(for: projectManager) else { return }
             await projectWindowSession.openProject(url, registry: registry)
         }
     }

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -204,7 +204,7 @@ extension ContentView {
     func openNewProject() {
         Task { @MainActor in
             guard let url = await registry.openProjectViaPanel(for: projectManager) else { return }
-            openWindow(value: url)
+            await projectWindowSession.openProject(url, registry: registry)
         }
     }
 

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -83,7 +83,7 @@ struct ContentView: View {
                             // owner before capturing the presentation context;
                             // otherwise the panel silently aborts right after
                             // the window appears or is replaced (#1344).
-                            if let url = await registry.openProjectViaPanel(for: projectManager) {
+                            if let url = await registry.chooseProjectViaPanel(for: projectManager) {
                                 await projectWindowSession.openProject(
                                     url,
                                     registry: registry

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -26,6 +26,7 @@ struct ContentView: View {
     @Environment(TabManager.self) var primaryTabManager
     @Environment(PaneManager.self) var paneManager
     @Environment(ProjectRegistry.self) var registry
+    @Environment(ProjectWindowSession.self) var projectWindowSession
     @Environment(\.openWindow) var openWindow
 
     @Environment(\.controlActiveState) var controlActiveState
@@ -83,7 +84,10 @@ struct ContentView: View {
                             // otherwise the panel silently aborts right after
                             // the window appears or is replaced (#1344).
                             if let url = await registry.openProjectViaPanel(for: projectManager) {
-                                openWindow(value: url)
+                                await projectWindowSession.openProject(
+                                    url,
+                                    registry: registry
+                                )
                             }
                         }
                     } label: {
@@ -110,6 +114,14 @@ struct ContentView: View {
         .navigationTitle(workspace.projectName)
         .navigationSubtitle(branchSubtitle)
         .toolbar {
+            ToolbarItem(placement: .navigation) {
+                ProjectSwitcherView(
+                    session: projectWindowSession,
+                    registry: registry,
+                    onOpenProject: { openNewProject() }
+                )
+            }
+
             // Agent Inbox entry point in the project window toolbar (#1337).
             // Additive to the existing ⌘⇧I chord and Window menu item.
             ToolbarItem(placement: .primaryAction) {
@@ -535,6 +547,9 @@ private struct ProblemsPanelRefreshObserver: ViewModifier {
 #Preview {
     let projectManager = ProjectManager()
     let registry = ProjectRegistry()
+    let windowSession = ProjectWindowSession(
+        initialProjectURL: URL(fileURLWithPath: "/tmp/Pine Preview")
+    )
     ContentView()
         .environment(projectManager)
         .environment(projectManager.workspace)
@@ -543,4 +558,5 @@ private struct ProblemsPanelRefreshObserver: ViewModifier {
         .environment(projectManager.paneManager)
         .environment(projectManager.toastManager)
         .environment(registry)
+        .environment(windowSession)
 }

--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -409,7 +409,12 @@ struct EditorTabBar: View {
                             paneManager.selectEditorTab(tab.id, in: paneID)
                         } label: {
                             Label {
-                                Text("\(tab.fileName)\(tab.isDirty ? " \u{25CF}" : "")")
+                                HStack(spacing: 0) {
+                                    Text(verbatim: tab.fileName)
+                                    if tab.isDirty {
+                                        Text(" \u{25CF}")
+                                    }
+                                }
                             } icon: {
                                 Image(systemName: tab.isPinned
                                       ? "pin.fill"

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -11069,6 +11069,171 @@
         }
       }
     },
+    "projectSwitcher.error.agentMissing %@": {
+      "comment": "Agent executable disappeared after the menu was opened. The argument is the agent name.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "%@ ist auf diesem Mac nicht mehr verfügbar." } },
+        "en": { "stringUnit": { "state": "translated", "value": "%@ is no longer available on this Mac." } },
+        "es": { "stringUnit": { "state": "translated", "value": "%@ ya no está disponible en este Mac." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "%@ n’est plus disponible sur ce Mac." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%@はこのMacでは利用できなくなりました。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이 Mac에서 더 이상 %@을(를) 사용할 수 없습니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "%@ não está mais disponível neste Mac." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "%@ больше не доступен на этом Mac." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "此 Mac 上已无法使用 %@。" } }
+      }
+    },
+    "projectSwitcher.error.alreadyOpen": {
+      "comment": "Shown when a project selected for the current workspace belongs to another Pine window.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Dieses Projekt ist bereits in einem anderen Fenster geöffnet." } },
+        "en": { "stringUnit": { "state": "translated", "value": "This project is already open in another window." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Este proyecto ya está abierto en otra ventana." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Ce projet est déjà ouvert dans une autre fenêtre." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "このプロジェクトは別のウインドウですでに開かれています。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이 프로젝트는 이미 다른 윈도우에서 열려 있습니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Este projeto já está aberto em outra janela." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Этот проект уже открыт в другом окне." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "此项目已在另一个窗口中打开。" } }
+      }
+    },
+    "projectSwitcher.error.destinationExists": {
+      "comment": "Diagnostic shown when the generated managed worktree destination already exists.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Der Worktree-Ordner ist bereits vorhanden." } },
+        "en": { "stringUnit": { "state": "translated", "value": "The worktree folder already exists." } },
+        "es": { "stringUnit": { "state": "translated", "value": "La carpeta del worktree ya existe." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Le dossier du worktree existe déjà." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "worktreeフォルダはすでに存在します。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "worktree 폴더가 이미 존재합니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "A pasta da worktree já existe." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Папка worktree уже существует." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "工作树文件夹已存在。" } }
+      }
+    },
+    "projectSwitcher.error.launch %@": {
+      "comment": "Agent launch failure after worktree creation. The argument is the agent name.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Pine hat den Worktree erstellt, konnte %@ aber nicht starten." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Pine created the worktree, but couldn’t start %@." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Pine creó el worktree, pero no pudo iniciar %@." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Pine a créé le worktree, mais n’a pas pu lancer %@." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Pineでworktreeを作成しましたが、%@を起動できませんでした。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "Pine에서 worktree를 만들었지만 %@을(를) 시작할 수 없습니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "O Pine criou a worktree, mas não pôde iniciar %@." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Pine создал worktree, но не смог запустить %@." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Pine 已创建工作树，但无法启动 %@。" } }
+      }
+    },
+    "projectSwitcher.error.notGitRepository": {
+      "comment": "Diagnostic shown when New Agent is used outside a Git repository.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Das ausgewählte Projekt ist kein Git-Repository." } },
+        "en": { "stringUnit": { "state": "translated", "value": "The selected project is not a Git repository." } },
+        "es": { "stringUnit": { "state": "translated", "value": "El proyecto seleccionado no es un repositorio Git." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Le projet sélectionné n’est pas un dépôt Git." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "選択したプロジェクトはGitリポジトリではありません。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "선택한 프로젝트가 Git 저장소가 아닙니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "O projeto selecionado não é um repositório Git." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Выбранный проект не является Git-репозиторием." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "所选项目不是 Git 仓库。" } }
+      }
+    },
+    "projectSwitcher.error.open %@": {
+      "comment": "Project open failure. The argument is the project folder name.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Pine konnte „%@“ nicht öffnen." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Pine couldn’t open “%@”." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Pine no pudo abrir «%@»." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Pine n’a pas pu ouvrir « %@ »." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Pineで「%@」を開けませんでした。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "Pine에서 ‘%@’을(를) 열 수 없습니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "O Pine não pôde abrir “%@”." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Pine не удалось открыть «%@»." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Pine 无法打开“%@”。" } }
+      }
+    },
+    "projectSwitcher.error.title": {
+      "comment": "Title for project switcher and agent launch errors.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Aktion konnte nicht abgeschlossen werden" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Couldn’t Complete Action" } },
+        "es": { "stringUnit": { "state": "translated", "value": "No se pudo completar la acción" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Impossible de terminer l’action" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "操作を完了できませんでした" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "작업을 완료할 수 없음" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Não foi possível concluir a ação" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Не удалось выполнить действие" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法完成操作" } }
+      }
+    },
+    "projectSwitcher.error.worktree %@": {
+      "comment": "Worktree creation failure. The argument contains a short diagnostic.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Pine konnte keinen isolierten Worktree erstellen. %@" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Pine couldn’t create an isolated worktree. %@" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Pine no pudo crear un worktree aislado. %@" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Pine n’a pas pu créer de worktree isolé. %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Pineで分離されたworktreeを作成できませんでした。%@" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "Pine에서 격리된 worktree를 만들 수 없습니다. %@" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "O Pine não pôde criar uma worktree isolada. %@" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Pine не удалось создать изолированный worktree. %@" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Pine 无法创建隔离的工作树。%@" } }
+      }
+    },
+    "projectSwitcher.newAgent": {
+      "comment": "Menu action that creates an isolated worktree and launches an agent in it.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Neuer Agent …" } },
+        "en": { "stringUnit": { "state": "translated", "value": "New Agent…" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Nuevo agente…" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Nouvel agent…" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "新しいエージェント…" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "새 에이전트…" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Novo agente…" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Новый агент…" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "新建智能体…" } }
+      }
+    },
+    "projectSwitcher.noAgents": {
+      "comment": "Shown when no supported command-line coding agent is installed.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Keine unterstützten Agenten installiert" } },
+        "en": { "stringUnit": { "state": "translated", "value": "No supported agents installed" } },
+        "es": { "stringUnit": { "state": "translated", "value": "No hay agentes compatibles instalados" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Aucun agent compatible installé" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "対応エージェントがインストールされていません" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "지원되는 에이전트가 설치되어 있지 않음" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Nenhum agente compatível instalado" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Поддерживаемые агенты не установлены" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "未安装支持的智能体" } }
+      }
+    },
+    "projectSwitcher.tooltip": {
+      "comment": "Tooltip for the project switcher in the project window toolbar.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Projekt wechseln" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Switch projects" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Cambiar de proyecto" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Changer de projet" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "プロジェクトを切り替える" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "프로젝트 전환" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Alternar projetos" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Переключить проект" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "切换项目" } }
+      }
+    },
     "quickOpen.noResults": {
       "comment": "Shown when Quick Open search finds no matching files.",
       "extractionState": "manual",

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -26,7 +26,7 @@ struct PineApp: App {
                 ProjectWindowView(projectURL: projectURL, registry: registry, appDelegate: appDelegate)
             }
         }
-        .defaultSize(width: 1280, height: 800)
+        .defaultSize(width: 1440, height: 900)
         .defaultLaunchBehavior(.suppressed)
         .commands {
             PineAppMenuCommands(
@@ -143,7 +143,21 @@ private struct ProjectWindowView: View {
     let projectURL: URL
     let registry: ProjectRegistry
     let appDelegate: AppDelegate
+    @State private var windowSession: ProjectWindowSession
     @Environment(\.openWindow) var openWindow
+
+    init(
+        projectURL: URL,
+        registry: ProjectRegistry,
+        appDelegate: AppDelegate
+    ) {
+        self.projectURL = projectURL
+        self.registry = registry
+        self.appDelegate = appDelegate
+        _windowSession = State(initialValue: ProjectWindowSession(
+            initialProjectURL: projectURL
+        ))
+    }
 
     var body: some View {
         Group {
@@ -151,7 +165,9 @@ private struct ProjectWindowView: View {
             // Hidden windows from closed projects still get re-rendered by SwiftUI;
             // calling projectManager(for:) would silently re-add the closed project
             // to openProjects, breaking the "show Welcome when last project closes" logic.
-            if let pm = registry.projectManagerIfAdmitted(for: projectURL) {
+            if let pm = registry.projectManagerIfAdmitted(
+                for: windowSession.activeProjectURL
+            ) {
                 ContentView()
                     .id(ObjectIdentifier(pm))
                     .environment(pm)
@@ -161,16 +177,36 @@ private struct ProjectWindowView: View {
                     .environment(pm.paneManager)
                     .environment(pm.toastManager)
                     .environment(registry)
+                    .environment(windowSession)
                     .focusedSceneValue(\.projectManager, pm)
                     .background {
                         WindowCloseInterceptor(
                             projectManager: pm,
                             registry: registry,
-                            projectURL: projectURL,
-                            appDelegate: appDelegate
+                            projectURL: windowSession.activeProjectURL,
+                            appDelegate: appDelegate,
+                            windowSession: windowSession
                         )
                     }
             }
+        }
+        .task {
+            await windowSession.restoreIfNeeded(registry: registry)
+        }
+        .alert(
+            Strings.projectSwitcherErrorTitle,
+            isPresented: Binding(
+                get: { windowSession.alertMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        windowSession.alertMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button(Strings.dialogOK, role: .cancel) {}
+        } message: {
+            Text(windowSession.alertMessage ?? "")
         }
         .background { AppDelegateBridge(appDelegate: appDelegate, registry: registry) }
         // Note: project cleanup (session save, Welcome restore) is handled by
@@ -188,6 +224,7 @@ struct WindowCloseInterceptor: NSViewRepresentable {
     let registry: ProjectRegistry
     let projectURL: URL
     let appDelegate: AppDelegate
+    var windowSession: ProjectWindowSession? = nil
 
     func makeNSView(context: Context) -> InterceptorView {
         let view = InterceptorView()
@@ -198,7 +235,8 @@ struct WindowCloseInterceptor: NSViewRepresentable {
                 projectManager: projectManager,
                 registry: registry,
                 projectURL: projectURL,
-                appDelegate: appDelegate
+                appDelegate: appDelegate,
+                windowSession: windowSession
             )
         }
         return view
@@ -215,7 +253,8 @@ struct WindowCloseInterceptor: NSViewRepresentable {
                 projectManager: projectManager,
                 registry: registry,
                 projectURL: projectURL,
-                appDelegate: appDelegate
+                appDelegate: appDelegate,
+                windowSession: windowSession
             )
         }
     }
@@ -250,6 +289,7 @@ struct WindowCloseInterceptor: NSViewRepresentable {
         // Strong reference to keep the original delegate alive
         var originalDelegate: (any NSWindowDelegate)?
         weak var installedWindow: NSWindow?
+        weak var windowSession: ProjectWindowSession?
         private var lifecycleObservers: [Any] = []
         /// Once a replacement coordinator adopts this installation, SwiftUI
         /// may still deliver a stale update or move callback to the old
@@ -262,10 +302,12 @@ struct WindowCloseInterceptor: NSViewRepresentable {
             registry: ProjectRegistry,
             projectURL: URL,
             appDelegate: AppDelegate,
+            windowSession: ProjectWindowSession? = nil,
             presentAlert: CloseDelegate.CloseAlertPresenter? = nil,
             saveAll: CloseDelegate.CloseSaveAll? = nil
         ) {
             guard !isSuperseded else { return }
+            self.windowSession = windowSession
             if installedWindow !== window {
                 retireCurrentInstallation(restoringOriginal: true)
                 installedWindow = window
@@ -318,6 +360,7 @@ struct WindowCloseInterceptor: NSViewRepresentable {
                     closeDelegate = existing
                     originalDelegate = retainedOriginal
                     existing.interceptorOwner = self
+                    existing.windowSession = windowSession
                     if existing.didCompleteWindowLifecycle,
                        registry.isWindowOpen(projectURL),
                        registry.openProjects[
@@ -345,6 +388,7 @@ struct WindowCloseInterceptor: NSViewRepresentable {
                 presentAlert: presentAlert,
                 saveAll: saveAll
             )
+            delegate.windowSession = windowSession
             closeDelegate = delegate
             originalDelegate = original
             delegate.interceptorOwner = self
@@ -386,7 +430,8 @@ struct WindowCloseInterceptor: NSViewRepresentable {
                                 projectManager: projectManager,
                                 registry: registry,
                                 projectURL: projectURL,
-                                appDelegate: appDelegate
+                                appDelegate: appDelegate,
+                                windowSession: self.windowSession
                             )
                         }
                     }
@@ -470,6 +515,7 @@ class CloseDelegate: NSObject, NSWindowDelegate {
     let registry: ProjectRegistry
     let projectURL: URL
     weak var appDelegate: AppDelegate?
+    weak var windowSession: ProjectWindowSession?
     /// Weak ref to original — Coordinator holds the strong ref separately
     /// to avoid a potential retain cycle through the delegate chain.
     weak var original: (any NSWindowDelegate)?
@@ -802,6 +848,7 @@ class CloseDelegate: NSObject, NSWindowDelegate {
             )
             DialogPresenter.ownerDidClose(ownerWindow)
         }
+        windowSession?.windowDidClose(registry: registry)
         appDelegate?.handleProjectWindowDisappear(
             projectURL: projectURL,
             registry: registry,
@@ -1840,6 +1887,36 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                canonicalURL: canonical
            ) {
             window.makeKeyAndOrderFront(nil)
+            NSApp.activate()
+            hideWelcome()
+            return true
+        }
+
+        // File > Open Recent follows the same one-window project flow as the
+        // toolbar switcher when a project window is currently eligible. A
+        // linked worktree can join only when this exact session already owns
+        // its persisted proof; otherwise the existing separate-scene path
+        // remains the fail-closed fallback.
+        if let destination = nativeCommandDestination(requestedProject: nil),
+           let windowSession = destination.delegate.windowSession,
+           windowSession.managedWorktrees[canonical] != nil
+                || targetRegistry.isOrdinaryProjectScope(canonical) {
+            if windowSession.managedWorktrees[canonical] != nil {
+                await windowSession.activate(
+                    canonical,
+                    registry: targetRegistry
+                )
+            } else {
+                await windowSession.openProject(
+                    canonical,
+                    registry: targetRegistry,
+                    allowAlreadyOpenTarget: true
+                )
+            }
+            guard windowSession.activeProjectURL == canonical else {
+                return false
+            }
+            destination.window.makeKeyAndOrderFront(nil)
             NSApp.activate()
             hideWelcome()
             return true

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -1364,6 +1364,16 @@ final class ProjectRegistry: LSPSettingsObserver {
         openProjects[canonicalProjectURL(projectURL)]
     }
 
+    /// Whether an admitted URL is an ordinary folder project rather than a
+    /// linked-worktree scope that requires its persisted exact proof.
+    func isOrdinaryProjectScope(_ projectURL: URL) -> Bool {
+        let canonical = canonicalProjectURL(projectURL)
+        guard let identity = agentTaskProjectsByRoot[canonical] else {
+            return false
+        }
+        return identity.canonicalProjectPath == identity.canonicalWorktreePath
+    }
+
     /// Registers the immutable persistence/ownership scope captured when the
     /// keep-alive Quick Terminal session is first created. A project-backed
     /// session reuses the exact open worktree identity when available; the

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -1941,6 +1941,21 @@ final class ProjectRegistry: LSPSettingsObserver {
     func openProjectViaPanel(
         context: DialogPresentationContext
     ) async -> URL? {
+        guard let canonical = await chooseProjectViaPanel(context: context),
+              projectManager(for: canonical) != nil else { return nil }
+        return canonical
+    }
+
+    /// Chooses a project directory without admitting it into the registry.
+    ///
+    /// Multi-project windows need to perform their own collision check before
+    /// admission. Reusing ``openProjectViaPanel(context:)`` there would create
+    /// the manager first, making a newly selected directory indistinguishable
+    /// from a project already presented by another window.
+    @discardableResult
+    func chooseProjectViaPanel(
+        context: DialogPresentationContext
+    ) async -> URL? {
         let panel = NSOpenPanel()
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
@@ -1950,9 +1965,7 @@ final class ProjectRegistry: LSPSettingsObserver {
 
         guard await panel.runSheet(on: context) == .OK,
               let url = panel.url else { return nil }
-        let canonical = canonicalProjectURL(url)
-        guard projectManager(for: canonical) != nil else { return nil }
-        return canonical
+        return canonicalProjectURL(url)
     }
 
     /// Opens a project via folder picker, first waiting for the project
@@ -1984,6 +1997,28 @@ final class ProjectRegistry: LSPSettingsObserver {
         }
         let context = DialogPresenter.forProject(projectManager)
         return await openProjectViaPanel(context: context)
+    }
+
+    /// Project-window variant of ``chooseProjectViaPanel(context:)``. It keeps
+    /// the same bounded owner recovery as the admitting API while leaving the
+    /// selected URL untouched until the window session validates it.
+    @discardableResult
+    func chooseProjectViaPanel(
+        for projectManager: ProjectManager,
+        maximumAttempts: Int = 80,
+        waitForNextAttempt: (@MainActor () async -> Void)? = nil,
+        isEligible: (@MainActor (NSWindow) -> Bool)? = nil
+    ) async -> URL? {
+        guard await projectManager.awaitDialogOwnerWindow(
+            maximumAttempts: maximumAttempts,
+            waitForNextAttempt: waitForNextAttempt,
+            isEligible: isEligible
+        ) != nil else {
+            Logger.app.error("Open Folder aborted: no eligible project dialog owner after bounded recovery (#1407)")
+            return nil
+        }
+        let context = DialogPresenter.forProject(projectManager)
+        return await chooseProjectViaPanel(context: context)
     }
 
     /// Closes the project window but keeps the ProjectManager alive. Terminal

--- a/Pine/ProjectSwitcherView.swift
+++ b/Pine/ProjectSwitcherView.swift
@@ -1,0 +1,171 @@
+//
+//  ProjectSwitcherView.swift
+//  Pine
+//
+//  Compact project and agent-worktree navigation for one Pine window.
+//
+
+import SwiftUI
+
+struct ProjectSwitcherView: View {
+    let session: ProjectWindowSession
+    let registry: ProjectRegistry
+    let onOpenProject: () -> Void
+
+    var body: some View {
+        Menu {
+            ForEach(Array(session.groups.enumerated()), id: \.element.id) { index, group in
+                if index > 0 {
+                    Divider()
+                }
+                projectButton(group.projectURL)
+                ForEach(group.worktrees, id: \.worktreeRoot) { worktree in
+                    worktreeButton(worktree)
+                }
+            }
+
+            Divider()
+
+            Menu {
+                if session.availableAgentOptions.isEmpty {
+                    Text(Strings.projectSwitcherNoAgents)
+                } else {
+                    ForEach(session.availableAgentOptions) { option in
+                        Button(option.displayName) {
+                            Task { @MainActor in
+                                await session.launchAgent(
+                                    option,
+                                    registry: registry
+                                )
+                            }
+                        }
+                    }
+                }
+            } label: {
+                Label(
+                    Strings.projectSwitcherNewAgent,
+                    systemImage: "sparkles"
+                )
+            }
+            .disabled(
+                session.isLaunchingAgent
+                    || session.availableAgentOptions.isEmpty
+            )
+            .accessibilityIdentifier(AccessibilityID.projectSwitcherNewAgent)
+
+            Button(action: onOpenProject) {
+                Label(Strings.menuOpenFolder, systemImage: "folder.badge.plus")
+            }
+            .disabled(session.isLaunchingAgent)
+        } label: {
+            HStack(spacing: 6) {
+                if session.isLaunchingAgent {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Image(systemName: "folder.stack")
+                }
+                Text(session.activeDisplayName)
+                    .lineLimit(1)
+                Image(systemName: "chevron.down")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize(horizontal: true, vertical: false)
+        .help(Strings.projectSwitcherTooltip)
+        .accessibilityIdentifier(AccessibilityID.projectSwitcher)
+    }
+
+    @ViewBuilder
+    private func projectButton(_ url: URL) -> some View {
+        Button {
+            Task { @MainActor in
+                await session.activate(url, registry: registry)
+            }
+        } label: {
+            Label {
+                Text(url.lastPathComponent)
+            } icon: {
+                Image(systemName: session.activeProjectURL == url
+                    ? "checkmark"
+                    : "folder")
+            }
+        }
+        .disabled(session.isLaunchingAgent)
+        .accessibilityIdentifier(
+            AccessibilityID.projectSwitcherProject(url.lastPathComponent)
+        )
+    }
+
+    @ViewBuilder
+    private func worktreeButton(_ worktree: AgentManagedWorktree) -> some View {
+        let task = session.worktreeTask(worktree, registry: registry)
+        let presentation = WorktreePresentation(
+            worktree: worktree,
+            task: task,
+            isActive: session.activeProjectURL == worktree.worktreeRoot
+        )
+        Button {
+            Task { @MainActor in
+                await session.activate(
+                    worktree.worktreeRoot,
+                    registry: registry
+                )
+            }
+        } label: {
+            Label {
+                Text(presentation.title)
+            } icon: {
+                Image(systemName: presentation.symbolName)
+            }
+        }
+        .disabled(session.isLaunchingAgent)
+        .accessibilityIdentifier(
+            AccessibilityID.projectSwitcherWorktree(worktree.taskID)
+        )
+    }
+}
+
+private struct WorktreePresentation {
+    let title: String
+    let symbolName: String
+
+    init(
+        worktree: AgentManagedWorktree,
+        task: AgentTask?,
+        isActive: Bool
+    ) {
+        let taskTitle = task?.title?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        let agentName = task?.descriptor.agentType.displayName
+        let branch = worktree.branchName
+            .split(separator: "/")
+            .suffix(2)
+            .joined(separator: "/")
+        let displayName: String
+        if let taskTitle, !taskTitle.isEmpty {
+            displayName = taskTitle
+        } else {
+            displayName = agentName ?? branch
+        }
+        title = "    \(displayName)"
+
+        if isActive {
+            symbolName = "checkmark"
+        } else if task?.attention == .waitingInput {
+            symbolName = "exclamationmark.circle.fill"
+        } else if task?.attention == .failed {
+            symbolName = "xmark.circle.fill"
+        } else if task?.lifecycle == .completed
+                    || task?.runs.last?.state == .done {
+            symbolName = "checkmark.circle"
+        } else if task?.runs.last?.liveness == .live {
+            symbolName = "circle.fill"
+        } else {
+            symbolName = "circle"
+        }
+    }
+}

--- a/Pine/ProjectWindowSession.swift
+++ b/Pine/ProjectWindowSession.swift
@@ -1,0 +1,508 @@
+//
+//  ProjectWindowSession.swift
+//  Pine
+//
+//  One native window containing several independent project contexts.
+//
+
+import CryptoKit
+import Foundation
+import Observation
+
+nonisolated struct ProjectAgentLaunchOption: Identifiable, Equatable, Sendable {
+    let id: String
+    let displayName: String
+    let command: String
+
+    @MainActor
+    var descriptor: AgentDescriptor {
+        AgentDescriptor(
+            agentType: AgentType(stableIdentifier: id)
+                ?? .generic(name: displayName),
+            launchExecutable: command
+        )
+    }
+}
+
+nonisolated struct ProjectWindowGroup: Identifiable, Equatable, Sendable {
+    let projectURL: URL
+    let worktrees: [AgentManagedWorktree]
+
+    var id: URL { projectURL }
+}
+
+@MainActor
+@Observable
+final class ProjectWindowSession {
+    private struct PersistedState: Codable {
+        let version: Int
+        let projectURLs: [URL]
+        let worktrees: [AgentManagedWorktree]
+        let activeURL: URL
+    }
+
+    let id = UUID()
+    let sceneProjectURL: URL
+
+    private(set) var projectURLs: [URL]
+    private(set) var managedWorktrees: [URL: AgentManagedWorktree]
+    private(set) var activeProjectURL: URL
+    private(set) var isLaunchingAgent = false
+    var alertMessage: String?
+
+    @ObservationIgnored private let defaults: UserDefaults
+    @ObservationIgnored private let worktreeService: AgentWorktreeService
+    @ObservationIgnored private let toolResolver: ExternalToolResolver
+    @ObservationIgnored private var backgroundLeases: [URL: UUID] = [:]
+    @ObservationIgnored private var pendingRestoredActiveURL: URL?
+    @ObservationIgnored private var didRestore = false
+
+    init(
+        initialProjectURL: URL,
+        defaults: UserDefaults = .standard,
+        worktreeService: AgentWorktreeService = AgentWorktreeService(),
+        toolResolver: ExternalToolResolver = .fromEnvironment()
+    ) {
+        let initial = initialProjectURL.standardizedFileURL
+        self.defaults = defaults
+        self.worktreeService = worktreeService
+        self.toolResolver = toolResolver
+        let anchor = Self.persistenceAnchor(
+            for: initial,
+            defaults: defaults
+        )
+        sceneProjectURL = anchor
+
+        if let restored = Self.loadState(
+            for: anchor,
+            defaults: defaults
+        ) {
+            var projects = restored.projectURLs.map(\.standardizedFileURL)
+            var worktrees: [URL: AgentManagedWorktree] = [:]
+            for worktree in restored.worktrees {
+                worktrees[worktree.worktreeRoot.standardizedFileURL] = worktree
+            }
+            if worktrees[initial] == nil, !projects.contains(initial) {
+                projects.insert(initial, at: 0)
+            }
+            projectURLs = Self.uniqued(projects)
+            managedWorktrees = worktrees
+            activeProjectURL = initial
+            let restoredActive = restored.activeURL.standardizedFileURL
+            let members = Set(projectURLs + Array(worktrees.keys))
+            pendingRestoredActiveURL = initial == anchor
+                && members.contains(restoredActive)
+                    ? restoredActive
+                    : initial
+        } else {
+            projectURLs = [initial]
+            managedWorktrees = [:]
+            activeProjectURL = initial
+        }
+    }
+
+    var groups: [ProjectWindowGroup] {
+        projectURLs.map { projectURL in
+            ProjectWindowGroup(
+                projectURL: projectURL,
+                worktrees: managedWorktrees.values
+                    .filter { $0.repositoryRoot == projectURL }
+                    .sorted { lhs, rhs in
+                        if lhs.branchName != rhs.branchName {
+                            return lhs.branchName < rhs.branchName
+                        }
+                        return lhs.taskID.uuidString < rhs.taskID.uuidString
+                    }
+            )
+        }
+    }
+
+    var activeRepositoryURL: URL {
+        managedWorktrees[activeProjectURL]?.repositoryRoot
+            ?? activeProjectURL
+    }
+
+    var activeDisplayName: String {
+        let projectName = activeRepositoryURL.lastPathComponent
+        guard let worktree = managedWorktrees[activeProjectURL] else {
+            return projectName
+        }
+        return "\(projectName) — \(Self.shortBranchName(worktree.branchName))"
+    }
+
+    var availableAgentOptions: [ProjectAgentLaunchOption] {
+        let options = FirstPartyAgentCompatibilityCatalog.records.compactMap { record ->
+            ProjectAgentLaunchOption? in
+            let commands = record.executableAliases.sorted { lhs, rhs in
+                if lhs.count != rhs.count { return lhs.count < rhs.count }
+                return lhs < rhs
+            }
+            guard let command = commands.first(where: {
+                toolResolver.resolve(tool: $0) != nil
+            }) else { return nil }
+            return ProjectAgentLaunchOption(
+                id: record.stableIdentifier,
+                displayName: record.displayName,
+                command: command
+            )
+        }
+        let lastIdentifier = defaults.string(
+            forKey: Self.lastAgentIdentifierKey
+        )
+        return options.sorted { lhs, rhs in
+            if lhs.id == lastIdentifier { return true }
+            if rhs.id == lastIdentifier { return false }
+            return lhs.displayName.localizedStandardCompare(rhs.displayName)
+                == .orderedAscending
+        }
+    }
+
+    func restoreIfNeeded(registry: ProjectRegistry) async {
+        guard !didRestore else { return }
+        didRestore = true
+        guard let target = pendingRestoredActiveURL else { return }
+        pendingRestoredActiveURL = nil
+        await activate(target, registry: registry, reportFailure: false)
+    }
+
+    func openProject(
+        _ url: URL,
+        registry: ProjectRegistry,
+        allowAlreadyOpenTarget: Bool = false
+    ) async {
+        guard !isLaunchingAgent else { return }
+        let canonical = registry.canonicalProjectURL(url)
+        let belongsToSession = projectURLs.contains(canonical)
+            || managedWorktrees[canonical] != nil
+        guard allowAlreadyOpenTarget
+                || belongsToSession
+                || !registry.isWindowOpen(canonical) else {
+            alertMessage = Strings.projectSwitcherAlreadyOpenText
+            return
+        }
+        if !projectURLs.contains(canonical) {
+            projectURLs.append(canonical)
+        }
+        await activate(canonical, registry: registry)
+    }
+
+    func activate(
+        _ url: URL,
+        registry: ProjectRegistry,
+        reportFailure: Bool = true
+    ) async {
+        guard !isLaunchingAgent else { return }
+        let target = url.standardizedFileURL
+
+        let manager: ProjectManager?
+        if let worktree = managedWorktrees[target] {
+            manager = await registry.projectManager(for: worktree)
+        } else {
+            manager = registry.projectManager(for: target)
+        }
+        guard let manager else {
+            if reportFailure {
+                alertMessage = Strings.projectSwitcherOpenFailureText(
+                    target.lastPathComponent
+                )
+            }
+            removeUnavailableTarget(target)
+            return
+        }
+        guard target != activeProjectURL else {
+            _ = registry.reconcileKeyProjectPresentation(manager)
+            return
+        }
+
+        transition(
+            to: target,
+            manager: manager,
+            registry: registry
+        )
+    }
+
+    func launchAgent(
+        _ option: ProjectAgentLaunchOption,
+        registry: ProjectRegistry
+    ) async {
+        guard !isLaunchingAgent else { return }
+        isLaunchingAgent = true
+        defer { isLaunchingAgent = false }
+
+        guard toolResolver.resolve(tool: option.command) != nil else {
+            alertMessage = Strings.projectSwitcherAgentMissingText(
+                option.displayName
+            )
+            return
+        }
+
+        let repository = activeRepositoryURL.standardizedFileURL
+        let worktreeID = UUID()
+        let managedRoot: URL
+        do {
+            managedRoot = try await Task.detached(priority: .utility) {
+                try Self.prepareManagedRoot(for: repository)
+            }.value
+        } catch {
+            alertMessage = Strings.projectSwitcherWorktreeFailureText(
+                error.localizedDescription
+            )
+            return
+        }
+
+        let branch = Self.branchName(
+            agentIdentifier: option.id,
+            worktreeID: worktreeID
+        )
+        let result = await worktreeService.create(AgentWorktreeCreateRequest(
+            taskID: worktreeID,
+            repositoryRoot: repository,
+            managedRoot: managedRoot,
+            branchName: branch,
+            startPoint: "HEAD"
+        ))
+        guard case .created(let worktree) = result else {
+            alertMessage = Strings.projectSwitcherWorktreeFailureText(
+                Self.worktreeFailureDescription(result)
+            )
+            return
+        }
+        guard let manager = await registry.projectManager(for: worktree) else {
+            alertMessage = Strings.projectSwitcherOpenFailureText(
+                worktree.worktreeRoot.lastPathComponent
+            )
+            return
+        }
+
+        if !projectURLs.contains(repository) {
+            projectURLs.append(repository)
+        }
+        managedWorktrees[worktree.worktreeRoot.standardizedFileURL] = worktree
+        transition(
+            to: worktree.worktreeRoot,
+            manager: manager,
+            registry: registry
+        )
+        saveState()
+
+        let launch = await manager.terminal.launchAgentInNewTerminal(
+            option.command,
+            descriptor: option.descriptor,
+            workingDirectory: worktree.worktreeRoot
+        )
+        guard case .reserved = launch else {
+            alertMessage = Strings.projectSwitcherAgentLaunchFailureText(
+                option.displayName
+            )
+            return
+        }
+        defaults.set(option.id, forKey: Self.lastAgentIdentifierKey)
+    }
+
+    func windowDidClose(registry: ProjectRegistry) {
+        for (url, leaseID) in backgroundLeases {
+            registry.releaseBackgroundProjectPresentation(
+                leaseID,
+                for: url
+            )
+        }
+        backgroundLeases.removeAll()
+        saveState()
+    }
+
+    func worktreeTask(
+        _ worktree: AgentManagedWorktree,
+        registry: ProjectRegistry
+    ) -> AgentTask? {
+        registry.agentTasks.tasks
+            .filter {
+                $0.project.canonicalProjectPath
+                    == worktree.repositoryRoot.path
+                    && $0.project.canonicalWorktreePath
+                        == worktree.worktreeRoot.path
+            }
+            .max { lhs, rhs in lhs.updatedAt < rhs.updatedAt }
+    }
+
+    private func transition(
+        to target: URL,
+        manager: ProjectManager,
+        registry: ProjectRegistry
+    ) {
+        let previous = activeProjectURL
+        if let previousManager = registry.projectManagerIfAdmitted(
+            for: previous
+        ) {
+            if backgroundLeases[previous] == nil,
+               let leaseID = registry.retainBackgroundProjectForPresentation(
+                   previous,
+                   manager: previousManager
+               ) {
+                backgroundLeases[previous] = leaseID
+            }
+            registry.closeProjectWindow(
+                previous,
+                expectedManager: previousManager,
+                expectedWindowGeneration: nil
+            )
+        }
+
+        if let leaseID = backgroundLeases.removeValue(forKey: target) {
+            registry.releaseBackgroundProjectPresentation(
+                leaseID,
+                for: target
+            )
+        }
+        _ = registry.reconcileKeyProjectPresentation(manager)
+        activeProjectURL = target
+        saveState()
+    }
+
+    private func removeUnavailableTarget(_ target: URL) {
+        managedWorktrees[target] = nil
+        if target != sceneProjectURL {
+            projectURLs.removeAll { $0 == target }
+        }
+        saveState()
+    }
+
+    private func saveState() {
+        let state = PersistedState(
+            version: 1,
+            projectURLs: projectURLs,
+            worktrees: Array(managedWorktrees.values),
+            activeURL: activeProjectURL
+        )
+        guard let data = try? JSONEncoder().encode(state) else { return }
+        defaults.set(data, forKey: persistenceKey)
+        saveMembershipIndex()
+    }
+
+    private func saveMembershipIndex() {
+        var membership = defaults.dictionary(
+            forKey: Self.membershipIndexKey
+        ) as? [String: String] ?? [:]
+        membership = membership.filter { _, anchorPath in
+            anchorPath != sceneProjectURL.path
+        }
+        let memberURLs = projectURLs + Array(managedWorktrees.keys)
+        for url in memberURLs {
+            membership[url.standardizedFileURL.path] = sceneProjectURL.path
+        }
+        defaults.set(membership, forKey: Self.membershipIndexKey)
+    }
+
+    private var persistenceKey: String {
+        Self.persistenceKey(for: sceneProjectURL)
+    }
+
+    private static func loadState(
+        for projectURL: URL,
+        defaults: UserDefaults
+    ) -> PersistedState? {
+        guard let data = defaults.data(
+            forKey: persistenceKey(for: projectURL)
+        ), let state = try? JSONDecoder().decode(
+            PersistedState.self,
+            from: data
+        ), state.version == 1 else { return nil }
+        return state
+    }
+
+    private static func persistenceAnchor(
+        for initialURL: URL,
+        defaults: UserDefaults
+    ) -> URL {
+        guard let membership = defaults.dictionary(
+            forKey: membershipIndexKey
+        ) as? [String: String],
+        let anchorPath = membership[initialURL.path] else {
+            return initialURL
+        }
+        let anchor = URL(
+            fileURLWithPath: anchorPath,
+            isDirectory: true
+        ).standardizedFileURL
+        guard let state = loadState(for: anchor, defaults: defaults) else {
+            return initialURL
+        }
+        let members = Set(
+            state.projectURLs.map { $0.standardizedFileURL.path }
+                + state.worktrees.map {
+                    $0.worktreeRoot.standardizedFileURL.path
+                }
+        )
+        return members.contains(initialURL.path) ? anchor : initialURL
+    }
+
+    private static func persistenceKey(for projectURL: URL) -> String {
+        let digest = SHA256.hash(data: Data(projectURL.path.utf8))
+        let hex = digest.prefix(16).map {
+            String(format: "%02x", $0)
+        }.joined()
+        return "projectWindowSession.\(hex)"
+    }
+
+    nonisolated private static func prepareManagedRoot(
+        for repository: URL
+    ) throws -> URL {
+        let digest = SHA256.hash(data: Data(repository.path.utf8))
+        let name = digest.prefix(12).map {
+            String(format: "%02x", $0)
+        }.joined()
+        let root = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        )[0]
+            .appendingPathComponent("Pine", isDirectory: true)
+            .appendingPathComponent("AgentWorktrees", isDirectory: true)
+            .appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        return root.standardizedFileURL
+    }
+
+    private static func branchName(
+        agentIdentifier: String,
+        worktreeID: UUID
+    ) -> String {
+        let safeAgent = String(agentIdentifier.lowercased().map { character in
+            character.isLetter || character.isNumber ? character : "-"
+        })
+        let prefix = String(worktreeID.uuidString.lowercased().prefix(8))
+        return "pine/agent/\(safeAgent)/\(prefix)"
+    }
+
+    private static func shortBranchName(_ branch: String) -> String {
+        branch.split(separator: "/").suffix(2).joined(separator: "/")
+    }
+
+    private static func worktreeFailureDescription(
+        _ result: AgentWorktreeCreateResult
+    ) -> String {
+        guard case .failed(let failure) = result else { return "" }
+        switch failure {
+        case .invalidRepository:
+            return String(localized: "projectSwitcher.error.notGitRepository")
+        case .destinationAlreadyExists:
+            return String(localized: "projectSwitcher.error.destinationExists")
+        case .gitRejected(let message):
+            return message
+        default:
+            return String(describing: failure)
+        }
+    }
+
+    private static func uniqued(_ urls: [URL]) -> [URL] {
+        var seen = Set<URL>()
+        return urls.filter { seen.insert($0).inserted }
+    }
+
+    private static let lastAgentIdentifierKey =
+        "projectWindowSession.lastAgentIdentifier"
+    private static let membershipIndexKey =
+        "projectWindowSession.membership"
+}

--- a/Pine/Settings/GeneralSettingsView.swift
+++ b/Pine/Settings/GeneralSettingsView.swift
@@ -113,7 +113,9 @@ struct GeneralSettingsView: View {
                         .accessibilityIdentifier(
                             AccessibilityID.generalFontSizeSlider
                         )
-                        Text("\(Int(fontSizeSettings.fontSize)) pt")
+                        Text(
+                            verbatim: "\(Int(fontSizeSettings.fontSize)) pt"
+                        )
                             .monospacedDigit()
                             .frame(minWidth: 48, alignment: .trailing)
                     }

--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -154,8 +154,9 @@ final class SidebarEditState {
 final class SidebarKeyboardFocusController {
     /// A disclosure change can rebuild the SwiftUI host after an AppKit focus
     /// claim has already succeeded. Keep the retry window bounded, but cover
-    /// both the next run loop and the later reconciliation pass.
-    private static let focusRetryDelays: [TimeInterval] = [0, 0.1, 0.5]
+    /// the next run loop, disclosure reconciliation, and the later AppKit
+    /// activation used by an expanded search toolbar item.
+    private static let focusRetryDelays: [TimeInterval] = [0, 0.1, 0.5, 1.0]
 
     private weak var responderView: SidebarKeyboardResponderView?
     private(set) var isFocused = false
@@ -177,9 +178,9 @@ final class SidebarKeyboardFocusController {
         if retryOnNextRunLoop {
             // A pointer action can arrive while SwiftUI is still attaching the
             // representable, or an editor preview can displace a successful
-            // claim during a later disclosure reconciliation pass. Retry at
-            // two bounded points; an explicit editor-focus action invalidates
-            // this generation before either retry can steal focus back.
+            // claim during a later disclosure or toolbar reconciliation pass.
+            // An explicit editor-focus action invalidates this generation
+            // before any retry can steal focus back.
             for delay in Self.focusRetryDelays {
                 DispatchQueue.main.asyncAfter(
                     deadline: .now() + delay

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -726,6 +726,86 @@ enum Strings {
         )
     }
 
+    // MARK: - Project switcher
+    static let projectSwitcherTooltip: LocalizedStringKey =
+        "projectSwitcher.tooltip"
+    static let projectSwitcherNewAgent: LocalizedStringKey =
+        "projectSwitcher.newAgent"
+    static let projectSwitcherNoAgents: LocalizedStringKey =
+        "projectSwitcher.noAgents"
+    static let projectSwitcherErrorTitle: LocalizedStringKey =
+        "projectSwitcher.error.title"
+    static var projectSwitcherAlreadyOpenText: String {
+        String(
+            localized: "projectSwitcher.error.alreadyOpen",
+            defaultValue: "This project is already open in another window."
+        )
+    }
+
+    static func projectSwitcherOpenFailureText(
+        _ projectName: String,
+        locale: Locale = .current
+    ) -> String {
+        let format = localizedString(
+            forKey: "projectSwitcher.error.open %@",
+            fallback: "Pine couldn’t open “%@”.",
+            locale: locale
+        )
+        return String(
+            format: format,
+            locale: locale,
+            arguments: [projectName]
+        )
+    }
+
+    static func projectSwitcherAgentMissingText(
+        _ agentName: String,
+        locale: Locale = .current
+    ) -> String {
+        let format = localizedString(
+            forKey: "projectSwitcher.error.agentMissing %@",
+            fallback: "%@ is no longer available on this Mac.",
+            locale: locale
+        )
+        return String(
+            format: format,
+            locale: locale,
+            arguments: [agentName]
+        )
+    }
+
+    static func projectSwitcherWorktreeFailureText(
+        _ reason: String,
+        locale: Locale = .current
+    ) -> String {
+        let format = localizedString(
+            forKey: "projectSwitcher.error.worktree %@",
+            fallback: "Pine couldn’t create an isolated worktree. %@",
+            locale: locale
+        )
+        return String(
+            format: format,
+            locale: locale,
+            arguments: [reason]
+        )
+    }
+
+    static func projectSwitcherAgentLaunchFailureText(
+        _ agentName: String,
+        locale: Locale = .current
+    ) -> String {
+        let format = localizedString(
+            forKey: "projectSwitcher.error.launch %@",
+            fallback: "Pine created the worktree, but couldn’t start %@.",
+            locale: locale
+        )
+        return String(
+            format: format,
+            locale: locale,
+            arguments: [agentName]
+        )
+    }
+
     // MARK: - Agent notifications (#1306)
     static let agentNotificationsSettingsTitle: LocalizedStringKey =
         "agentNotifications.settings.title"

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -705,6 +705,43 @@ final class TerminalManager {
         }
     }
 
+    /// Creates an ordinary shell terminal rooted in an isolated worktree,
+    /// waits for its exact PTY generation to become writable, then uses the
+    /// existing Pine-owned reservation path to launch one known agent token.
+    /// The shell remains interactive after the agent exits.
+    func launchAgentInNewTerminal(
+        _ command: String,
+        descriptor: AgentDescriptor,
+        workingDirectory: URL,
+        maximumAttempts: Int = 120,
+        waitForNextAttempt: (@MainActor () async -> Void)? = nil
+    ) async -> AgentTaskLaunchResult {
+        guard Self.exactAgentLaunchDescriptor(for: command) == descriptor,
+              !isPermanentlyInvalidated else { return .rejected }
+        ensureAgentDetectionStarted()
+        guard let (_, tab) = createTerminalTabForRecovery(
+            workingDirectory: workingDirectory,
+            initialProcess: nil
+        ) else { return .rejected }
+
+        let wait = waitForNextAttempt ?? {
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        for _ in 0..<max(0, maximumAttempts) where !tab.isProcessRunning {
+            guard !Task.isCancelled else {
+                cancelAgentLaunch(in: tab)
+                return .rejected
+            }
+            await wait()
+        }
+        guard tab.isProcessRunning else { return .rejected }
+        return await launchAgentCommand(
+            command,
+            descriptor: descriptor,
+            in: tab
+        )
+    }
+
 #if DEBUG
     var agentCallbacksFrozenForTesting: Bool {
         agentTaskCallbacksFrozen

--- a/PineTests/ProjectWindowSessionTests.swift
+++ b/PineTests/ProjectWindowSessionTests.swift
@@ -1,0 +1,267 @@
+//
+//  ProjectWindowSessionTests.swift
+//  PineTests
+//
+
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Project Window Session", .serialized)
+@MainActor
+struct ProjectWindowSessionTests {
+    fileprivate static let noOpProcessRunner: ProcessRunner = { _, _, _, _ in
+        ProcessRunResult(
+            stdout: "",
+            stderr: "",
+            exitCode: 0,
+            timedOut: false
+        )
+    }
+
+    @Test("switching keeps each project alive and restores the active project")
+    func switchingAndRestoration() async throws {
+        let fixture = try ProjectWindowSessionFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        let firstManager = try #require(
+            registry.projectManager(for: fixture.firstProject)
+        )
+        let session = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+
+        await session.openProject(
+            fixture.secondProject,
+            registry: registry
+        )
+
+        let secondManager = try #require(
+            registry.projectManagerIfAdmitted(for: fixture.secondProject)
+        )
+        #expect(session.projectURLs == [
+            fixture.firstProject.standardizedFileURL,
+            fixture.secondProject.standardizedFileURL,
+        ])
+        #expect(
+            session.activeProjectURL
+                == fixture.secondProject.standardizedFileURL
+        )
+        #expect(firstManager.presentationLifecycle == .backgroundSuspended)
+        #expect(secondManager.presentationLifecycle == .visible)
+
+        registry.runBackgroundReclamationPassForTesting()
+        #expect(
+            registry.projectManagerIfAdmitted(for: fixture.firstProject)
+                === firstManager
+        )
+
+        session.windowDidClose(registry: registry)
+        registry.closeProjectWindow(fixture.secondProject)
+
+        let restored = ProjectWindowSession(
+            initialProjectURL: fixture.secondProject,
+            defaults: fixture.defaults
+        )
+        await restored.restoreIfNeeded(registry: registry)
+
+        #expect(
+            restored.sceneProjectURL
+                == fixture.firstProject.standardizedFileURL
+        )
+        #expect(restored.projectURLs == session.projectURLs)
+        #expect(
+            restored.activeProjectURL
+                == fixture.secondProject.standardizedFileURL
+        )
+        #expect(registry.isWindowOpen(fixture.secondProject))
+        #expect(!registry.isWindowOpen(fixture.firstProject))
+    }
+
+    @Test("closing the window releases inactive project leases")
+    func closingReleasesLeases() async throws {
+        let fixture = try ProjectWindowSessionFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        _ = try #require(registry.projectManager(for: fixture.firstProject))
+        let session = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+
+        await session.openProject(
+            fixture.secondProject,
+            registry: registry
+        )
+        session.windowDidClose(registry: registry)
+        registry.closeProjectWindow(fixture.secondProject)
+        registry.runBackgroundReclamationPassForTesting()
+
+        #expect(registry.openProjects.isEmpty)
+    }
+
+    @Test("a project already visible in another window is not adopted")
+    func visibleProjectIsNotAdopted() async throws {
+        let fixture = try ProjectWindowSessionFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        _ = try #require(registry.projectManager(for: fixture.firstProject))
+        _ = try #require(registry.projectManager(for: fixture.secondProject))
+        let session = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+
+        await session.openProject(
+            fixture.secondProject,
+            registry: registry
+        )
+
+        #expect(
+            session.activeProjectURL
+                == fixture.firstProject.standardizedFileURL
+        )
+        #expect(session.projectURLs.count == 1)
+        #expect(session.alertMessage != nil)
+    }
+
+    @Test("managed worktree identity round-trips through session persistence")
+    func managedWorktreeCodableRoundTrip() throws {
+        let proof = RecentAgentTaskRepositoryProof(
+            commonDirectoryDevice: 1,
+            commonDirectoryInode: 2,
+            commonDirectoryGeneration: 3,
+            commonDirectoryBirthSeconds: 4,
+            commonDirectoryBirthNanoseconds: 5
+        )
+        let worktree = AgentManagedWorktree(
+            taskID: UUID(),
+            repositoryRoot: URL(fileURLWithPath: "/tmp/repository"),
+            managedRoot: URL(fileURLWithPath: "/tmp/managed"),
+            worktreeRoot: URL(fileURLWithPath: "/tmp/managed/worktree"),
+            branchName: "pine/agent/codex/12345678",
+            baseCommit: String(repeating: "a", count: 40),
+            repositoryProof: proof
+        )
+
+        let data = try JSONEncoder().encode(worktree)
+        let decoded = try JSONDecoder().decode(
+            AgentManagedWorktree.self,
+            from: data
+        )
+
+        #expect(decoded == worktree)
+    }
+
+    @Test("corrupt duplicate entries and foreign active URLs fail closed")
+    func corruptPersistenceFailsClosed() async throws {
+        struct PersistedFixture: Codable {
+            let version: Int
+            let projectURLs: [URL]
+            let worktrees: [AgentManagedWorktree]
+            let activeURL: URL
+        }
+
+        let fixture = try ProjectWindowSessionFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        _ = try #require(registry.projectManager(for: fixture.firstProject))
+        let worktree = AgentManagedWorktree(
+            taskID: UUID(),
+            repositoryRoot: fixture.firstProject,
+            managedRoot: fixture.root,
+            worktreeRoot: fixture.root.appendingPathComponent("worktree"),
+            branchName: "pine/agent/codex/12345678",
+            baseCommit: String(repeating: "a", count: 40),
+            repositoryProof: RecentAgentTaskRepositoryProof(
+                commonDirectoryDevice: 1,
+                commonDirectoryInode: 2,
+                commonDirectoryGeneration: 3,
+                commonDirectoryBirthSeconds: 4,
+                commonDirectoryBirthNanoseconds: 5
+            )
+        )
+        let state = PersistedFixture(
+            version: 1,
+            projectURLs: [fixture.firstProject],
+            worktrees: [worktree, worktree],
+            activeURL: fixture.root.appendingPathComponent("foreign")
+        )
+        let digest = SHA256.hash(data: Data(
+            fixture.firstProject.standardizedFileURL.path.utf8
+        ))
+        let suffix = digest.prefix(16).map {
+            String(format: "%02x", $0)
+        }.joined()
+        fixture.defaults.set(
+            try JSONEncoder().encode(state),
+            forKey: "projectWindowSession.\(suffix)"
+        )
+
+        let session = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+        await session.restoreIfNeeded(registry: registry)
+
+        #expect(session.managedWorktrees.count == 1)
+        #expect(
+            session.activeProjectURL
+                == fixture.firstProject.standardizedFileURL
+        )
+    }
+}
+
+@MainActor
+private final class ProjectWindowSessionFixture {
+    let root: URL
+    let firstProject: URL
+    let secondProject: URL
+    let defaults: UserDefaults
+    private let suiteName: String
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "Pine-ProjectWindowSession-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        firstProject = root.appendingPathComponent(
+            "First Project",
+            isDirectory: true
+        )
+        secondProject = root.appendingPathComponent(
+            "Second Project",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: firstProject,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: secondProject,
+            withIntermediateDirectories: true
+        )
+        suiteName = "ProjectWindowSessionTests.\(UUID().uuidString)"
+        defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    func makeRegistry() -> ProjectRegistry {
+        ProjectRegistry(
+            defaults: defaults,
+            agentDetectionProcessRunner:
+                ProjectWindowSessionTests.noOpProcessRunner,
+            agentDetectionPollInterval: 3_600,
+            backgroundReclamationInterval: .seconds(3_600)
+        )
+    }
+
+    func cleanup() {
+        defaults.removePersistentDomain(forName: suiteName)
+        try? FileManager.default.removeItem(at: root)
+    }
+}

--- a/PineTests/SidebarAccessibilityHostedTests.swift
+++ b/PineTests/SidebarAccessibilityHostedTests.swift
@@ -213,6 +213,37 @@ struct SidebarAccessibilityHostedTests {
         #expect(window.firstResponder === responder)
     }
 
+    @Test("Row focus claim survives expanded search toolbar activation")
+    func responderFocusRetryAfterExpandedSearchActivation() async throws {
+        let controller = SidebarKeyboardFocusController()
+        let responder = SidebarKeyboardResponderView(
+            frame: NSRect(x: 0, y: 0, width: 1, height: 1)
+        )
+        let searchField = NSSearchField(
+            frame: NSRect(x: 0, y: 0, width: 180, height: 24)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 100),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(responder)
+        window.contentView?.addSubview(searchField)
+        controller.attach(responder)
+        defer { window.orderOut(nil) }
+
+        #expect(controller.requestFocus(retryOnNextRunLoop: true))
+        try await Task.sleep(for: .milliseconds(750))
+        #expect(window.makeFirstResponder(searchField))
+        #expect(!controller.isFocused)
+
+        try await Task.sleep(for: .milliseconds(350))
+
+        #expect(controller.isFocused)
+        #expect(window.firstResponder === responder)
+    }
+
     @Test("Explicit editor focus cancels a pending sidebar retry")
     func explicitEditorFocusCancelsSidebarRetry() async throws {
         let controller = SidebarKeyboardFocusController()
@@ -237,7 +268,9 @@ struct SidebarAccessibilityHostedTests {
         controller.cancelPendingFocusRetry()
         #expect(window.makeFirstResponder(editor))
 
-        try await Task.sleep(for: .milliseconds(150))
+        // Wait beyond the final bounded retry so this locks the entire retry
+        // window, including the expanded-toolbar reconciliation attempt.
+        try await Task.sleep(for: .milliseconds(1_100))
 
         #expect(!controller.isFocused)
         #expect(window.firstResponder === editor)

--- a/PineTests/TerminalManagerTests.swift
+++ b/PineTests/TerminalManagerTests.swift
@@ -36,6 +36,25 @@ struct TerminalManagerTests {
         #expect(manager.lastActiveTerminalPaneID == nil)
     }
 
+    @Test("new agent terminal rejects a mismatched launch descriptor")
+    func newAgentTerminalRejectsMismatchedDescriptor() async {
+        let paneManager = PaneManager()
+        let manager = TerminalManager()
+        manager.paneManager = paneManager
+
+        let result = await manager.launchAgentInNewTerminal(
+            "codex",
+            descriptor: AgentDescriptor(
+                agentType: .claudeCode,
+                launchExecutable: "claude"
+            ),
+            workingDirectory: URL(fileURLWithPath: "/tmp")
+        )
+
+        #expect(result == .rejected)
+        #expect(manager.allTerminalTabs.isEmpty)
+    }
+
     @Test("createTerminalTab creates pane when no terminal pane exists")
     func createTerminalTabCreatesPane() {
         let pm = PaneManager()

--- a/PineUITests/NativeFileWindowMenuUITests.swift
+++ b/PineUITests/NativeFileWindowMenuUITests.swift
@@ -53,6 +53,26 @@ final class NativeFileWindowMenuUITests: PineUITestCase {
         ) == .completed
     }
 
+    private func switchProject(to url: URL) {
+        let switcher = app.descendants(matching: .any)[
+            "projectSwitcher"
+        ].firstMatch
+        XCTAssertTrue(
+            switcher.waitForExistence(timeout: 5),
+            "The project switcher should be visible"
+        )
+        switcher.click()
+
+        let project = app.descendants(matching: .any)[
+            "projectSwitcherProject_\(url.lastPathComponent)"
+        ].firstMatch
+        XCTAssertTrue(
+            project.waitForExistence(timeout: 5),
+            "The switcher should contain \(url.lastPathComponent)"
+        )
+        project.click()
+    }
+
     /// Polls for the first hittable text field within `timeout`.
     ///
     /// `NSOpenPanel`'s "Go to Folder" sheet animates its path field in
@@ -428,11 +448,11 @@ final class NativeFileWindowMenuUITests: PineUITestCase {
         XCTAssertTrue(agentStatus.label.contains("Executing"))
     }
 
-    func testOpenFolderSelectsDirectoryAndRoutesCommandToNewWindow() throws {
+    func testOpenFolderAddsProjectToCurrentWindowAndPreservesContexts() throws {
         launchWithProject(projectURL)
-        let firstWindow = app.windows[projectURL.lastPathComponent].firstMatch
         XCTAssertTrue(
-            firstWindow.waitForExistence(timeout: 10),
+            app.windows[projectURL.lastPathComponent]
+                .firstMatch.waitForExistence(timeout: 10),
             "The original project window should be visible"
         )
 
@@ -475,31 +495,46 @@ final class NativeFileWindowMenuUITests: PineUITestCase {
         )
         openButton.click()
 
-        let secondWindow = app.windows[
-            secondProjectURL.lastPathComponent
-        ].firstMatch
         XCTAssertTrue(
-            secondWindow.waitForExistence(timeout: 10),
-            "Selecting a directory should open its project window"
+            app.descendants(matching: .any)["fileNode_second.swift"]
+                .firstMatch.waitForExistence(timeout: 10),
+            "The current window should switch to the selected project"
         )
+
+        switchProject(to: projectURL)
         XCTAssertTrue(
-            secondWindow.descendants(matching: .any)[
-                "fileNode_second.swift"
-            ].firstMatch.waitForExistence(timeout: 10),
-            "The new window should display the selected project"
+            app.descendants(matching: .any)["fileNode_main.swift"]
+                .firstMatch.waitForExistence(timeout: 10),
+            "The original project should remain available in the switcher"
+        )
+
+        switchProject(to: secondProjectURL)
+        XCTAssertTrue(
+            app.descendants(matching: .any)["fileNode_second.swift"]
+                .firstMatch.waitForExistence(timeout: 10),
+            "Switching back should restore the second project context"
         )
 
         clickMenuBarItem("File")
         app.menuItems["New File"].firstMatch.click()
 
         XCTAssertTrue(
-            secondWindow.buttons["editorTab_Untitled"]
+            app.buttons["editorTab_Untitled"]
                 .firstMatch.waitForExistence(timeout: 5),
-            "File > New File should route to the newly focused project"
+            "File > New File should route to the active project"
         )
+
+        switchProject(to: projectURL)
         XCTAssertFalse(
-            firstWindow.buttons["editorTab_Untitled"].firstMatch.exists,
-            "The command must not mutate the background project"
+            app.buttons["editorTab_Untitled"].firstMatch.exists,
+            "The command must not mutate the inactive project"
+        )
+
+        switchProject(to: secondProjectURL)
+        XCTAssertTrue(
+            app.buttons["editorTab_Untitled"]
+                .firstMatch.waitForExistence(timeout: 5),
+            "The active project's tabs should survive project switches"
         )
     }
 

--- a/PineUITests/SidebarSearchTests.swift
+++ b/PineUITests/SidebarSearchTests.swift
@@ -73,20 +73,25 @@ final class SidebarSearchTests: PineUITestCase {
         XCTAssertEqual(noResults.value as? String, "No Results")
     }
 
-    // MARK: - Magnifying glass toolbar button exists
+    // MARK: - Search toolbar entry exists
 
-    func testMagnifyingGlassButtonExists() throws {
+    func testSearchToolbarEntryExists() throws {
         launchWithProject(projectURL)
 
         let sidebar = app.scrollViews["sidebar"]
         XCTAssertTrue(waitForExistence(sidebar, timeout: 10))
 
-        let toolbarButton = app.toolbars.buttons.matching(
+        // NSSearchToolbarItem adapts to the available window width: compact
+        // toolbars expose a button, while wider windows expose the search
+        // field directly. Both are valid, reachable search entry points.
+        let searchField = app.searchFields.firstMatch
+        let searchButton = app.toolbars.buttons.matching(
             NSPredicate(format: "label CONTAINS[c] 'search' OR label CONTAINS[c] 'поиск'")
         ).firstMatch
         XCTAssertTrue(
-            waitForExistence(toolbarButton, timeout: 10),
-            "Magnifying glass button should exist in toolbar"
+            waitForExistence(searchField, timeout: 5)
+                || waitForExistence(searchButton, timeout: 5),
+            "Search field or compact search button should exist in the toolbar"
         )
     }
 


### PR DESCRIPTION
## Summary

- Keep several independent project contexts in one Pine window and switch between them from a compact toolbar menu.
- Make Open Folder and eligible Open Recent actions add projects to the current window while preserving editor panes, terminal processes, and per-project state.
- Add New Agent: create a persistent isolated git worktree, launch an installed supported agent in a normal terminal, and keep explicit fail-closed worktree identity checks with no automatic accept, merge, or cleanup.
- Persist window composition and active project, increase the default Pine window to 1440×900, and update Sparkle to 2.9.6.

## Related issue

N/A

## Test plan

- [x] Unit tests added/updated
- [x] UI tests added/updated
- 87 focused tests passed: ProjectWindowSessionTests and TerminalManagerTests.
- Focused lifecycle, worktree, close-delegate, menu, and localization suites passed during implementation.
- The updated XCUITest acceptance flow compiles and covers same-window Open Folder, switching both directions, command routing, tab isolation, and tab preservation.
- Local XCUITest execution on the current macOS 27 beta stopped before test start because Automation Mode timed out twice; macOS 26 CI is the execution gate.
- SwiftLint strict passed for all changed Swift files; UI shard validation passed for 40 classes and 231 tests with delta 3.
- Clean app/test compilation, localization JSON and nine-locale checks, dependency ancestry audit, and diff hygiene passed.

## Compatibility matrix

- macOS 26: Not tested locally — macOS 26 GitHub CI is required before merge
- macOS 27 beta: Tested — macOS 27.0 build 26A5406e
- Xcode: Xcode 27.0 build 27A5237l
- macOS SDK: 27.0 build 26A5406c

Complete environment output:

```
ProductName:        macOS
ProductVersion:     27.0
BuildVersion:       26A5406e
Xcode 27.0
Build version 27A5237l
2026-08-17 22:31:18.265 xcodebuild[31065:2902722]  DVTFilePathFSEvents: Failed to start fs event stream.
2026-08-17 22:31:18.388 xcodebuild[31065:2902721] [MT] DVTDeveloperPaths: Failed to get length of DARWIN_USER_CACHE_DIR from confstr(3), error = Error Domain=NSPOSIXErrorDomain Code=5 "Input/output error". Using NSCachesDirectory instead.
27.0
2026-08-17 22:31:18.802 xcodebuild[31068:2902735]  DVTFilePathFSEvents: Failed to start fs event stream.
2026-08-17 22:31:18.918 xcodebuild[31068:2902734] [MT] DVTDeveloperPaths: Failed to get length of DARWIN_USER_CACHE_DIR from confstr(3), error = Error Domain=NSPOSIXErrorDomain Code=5 "Input/output error". Using NSCachesDirectory instead.
26A5406c
```

### Terminal renderer coverage

- Default path (Metal when available): Not tested manually — the feature reuses the existing terminal implementation; focused launch-routing tests passed
- CoreGraphics (`--disable-metal`): Not tested — the local XCUITest runner timed out while enabling Automation Mode before test start

## Manual testing checklist

- [ ] Verified the complete visual flow as expected
- [ ] No regressions in related features — full CI pending
