### PR TITLE
feat(terminal): add Recover Terminal Display command (#1472)

### DIFF
--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -9750,6 +9750,66 @@
         }
       }
     },
+    "menu.recoverTerminalDisplay": {
+      "comment": "Menu item: rebuild the renderer of visible terminals that stopped presenting frames (#1472).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal-Anzeige wiederherstellen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recover Terminal Display"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recuperar la visualización del terminal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurer l’affichage du terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル表示を復元"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널 화면 복구"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recuperar exibição do terminal"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Восстановить отображение терминала"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复终端显示"
+          }
+        }
+      }
+    },
     "menu.toggleTerminalZoom": {
       "comment": "Menu item: toggle zoom-to-fullscreen of the focused terminal pane (#1115).",
       "extractionState": "manual",

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -57,6 +57,7 @@ nonisolated enum MenuIcons {
     static let newTerminalTab = "plus"
     static let sendToTerminal = "paperplane"
     static let maximizeTerminal = "arrow.up.left.and.arrow.down.right"
+    static let recoverTerminalDisplay = "arrow.triangle.2.circlepath"
 
     // MARK: - Tasks menu (issue #1009)
     static let tasks = "wrench.and.screwdriver"

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -35,6 +35,9 @@ struct PineApp: App {
                 toggleQuickTerminal: { [weak appDelegate] in
                     appDelegate?.quickTerminalCoordinator.toggle()
                 },
+                recoverQuickTerminalDisplay: { [weak appDelegate] in
+                    appDelegate?.quickTerminalCoordinator.recoverDisplay()
+                },
                 recentProjects: { [weak appDelegate] in
                     appDelegate?.registry.recentProjects ?? []
                 },

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -31,6 +31,10 @@ struct PineAppMenuCommands: Commands {
     /// accidentally starting another Sparkle runtime in hosted tests.
     let checkForUpdatesViewModel: CheckForUpdatesViewModel
     let toggleQuickTerminal: () -> Void
+    /// Recovers the quick terminal alongside the focused project's panes: the
+    /// panel is a separate window, so a stuck session there is unreachable
+    /// through `focusedProject`. Inert when the panel is hidden.
+    let recoverQuickTerminalDisplay: () -> Void
     /// Reads the app-scoped registry without coupling Commands back to the
     /// AppDelegate. The closure keeps hosted tests inert while preserving
     /// observation of `ProjectRegistry.recentProjects` in the menu body.
@@ -808,6 +812,27 @@ struct PineAppMenuCommands: Commands {
             }
             .keyboardShortcut(.return, modifiers: [.command, .option])
             .disabled(focusedProject?.hasTerminalPanes != true)
+
+            Divider()
+
+            // Escape hatch for a terminal that renders nothing while its shell
+            // keeps running: SwiftTerm's Metal renderer can drop into a state
+            // where every frame request is refused and no repaint recovers it,
+            // so this rebuilds the renderer itself (issue #1472).
+            //
+            // Deliberately never disabled. The quick terminal lives in its own
+            // window, where `focusedProject` is nil — gating on project panes
+            // would leave exactly the surface a user is staring at unfixable.
+            Button {
+                focusedProject?.terminal.recoverVisibleTerminalDisplays()
+                recoverQuickTerminalDisplay()
+            } label: {
+                Label(
+                    Strings.menuRecoverTerminalDisplay,
+                    systemImage: MenuIcons.recoverTerminalDisplay
+                )
+            }
+            .keyboardShortcut("r", modifiers: [.command, .option])
         }
 
         // MARK: - Tasks menu (issue #1009)

--- a/Pine/QuickTerminal/QuickTerminalController.swift
+++ b/Pine/QuickTerminal/QuickTerminalController.swift
@@ -170,6 +170,18 @@ final class QuickTerminalController {
 
     // MARK: - Public
 
+    /// Rebuilds the quick terminal's presentation layer, recovering a session
+    /// stuck on a renderer that refuses every frame (see
+    /// `TerminalTab.recoverDisplay()`).
+    ///
+    /// Only while on screen: a hidden panel is detached, so a rebuild would be
+    /// discarded and the next `show()` repaints through the ordinary
+    /// attachment path anyway.
+    func recoverDisplay() {
+        guard isVisible else { return }
+        paneState.activeTab?.recoverDisplay()
+    }
+
     /// Shows the quick terminal if hidden, hides it if visible. Bound to the
     /// global hotkey and the menu command.
     func toggle() {

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -2074,6 +2074,8 @@ enum Strings {
     static let menuFindInTerminal: LocalizedStringKey = "menu.findInTerminal"
     static let menuSendToTerminal: LocalizedStringKey = "menu.sendToTerminal"
     static let menuToggleTerminalZoom: LocalizedStringKey = "menu.toggleTerminalZoom"
+    static let menuRecoverTerminalDisplay: LocalizedStringKey =
+        "menu.recoverTerminalDisplay"
 
     static var terminalSearchPreviousTooltip: String {
         String(localized: "terminal.search.previousTooltip")

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -1096,6 +1096,27 @@ final class TerminalManager {
         }
     }
 
+    // MARK: - Display recovery
+
+    /// Rebuilds the presentation layer of every terminal the user can actually
+    /// see in this project, recovering panes stuck on a renderer that refuses
+    /// every frame (see `TerminalTab.recoverDisplay()`).
+    ///
+    /// Scoped to the active tab of each terminal pane rather than to
+    /// `allTerminalTabs`: a background tab is detached, so recovery there is a
+    /// no-op that would still pay a renderer rebuild, and its own re-attach
+    /// already repaints it. Every visible pane is covered rather than only the
+    /// focused one — the stuck pane is frequently not the one holding focus,
+    /// and a user reaching for this command should not have to guess which.
+    ///
+    /// A permanently invalidated manager owns no live PTYs worth repainting.
+    func recoverVisibleTerminalDisplays() {
+        guard !isPermanentlyInvalidated, let pm = paneManager else { return }
+        for state in pm.terminalStates.values {
+            state.activeTab?.recoverDisplay()
+        }
+    }
+
     // MARK: - Queries (delegate to PaneManager)
 
     var allTerminalTabs: [TerminalTab] {

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -383,6 +383,49 @@ final class PineTerminalView: LocalProcessTerminalView {
         }
     }
 
+    /// Rebuilds the presentation layer on explicit user request, recovering a
+    /// terminal whose renderer stopped presenting frames.
+    ///
+    /// SwiftTerm's Metal renderer re-requests a dropped frame only from the
+    /// completion handler of a *submitted* command buffer. Both refusal paths
+    /// in `MetalTerminalRenderer.draw(in:)` — a busy frame semaphore and a
+    /// missing drawable/render-pass descriptor — set the pending-redraw flag
+    /// without submitting anything, so nothing ever consumes it. The view then
+    /// keeps accepting input and PTY output while never presenting a frame,
+    /// and no invalidation from Pine recovers it: `setNeedsDisplay` and
+    /// `drawMetalFrameNow()` both re-enter the same refusal.
+    ///
+    /// Recreating the renderer is the only escape — it installs a fresh
+    /// `MTKView`, semaphore, and drawable chain while `Terminal`, the PTY, and
+    /// the scrollback stay untouched. CoreGraphics has no such trap, so a
+    /// repaint through the backend-aware bridge is both necessary and
+    /// sufficient there.
+    ///
+    /// No-op while detached: `viewDidMoveToWindow` rebuilds and repaints on
+    /// the next real attachment anyway.
+    func recoverRendererNow() {
+        guard window != nil else { return }
+
+        if isUsingMetalRenderer {
+            do {
+                try setUseMetal(false)
+                try setUseMetal(true)
+            } catch {
+                Logger.terminal.error(
+                    "SwiftTerm Metal renderer recreation during display recovery failed: \(String(describing: error), privacy: .public)"
+                )
+            }
+            if isUsingMetalRenderer {
+                // A freshly created CAMetalLayer can miss its first drawable
+                // exactly like one created on attach; reuse the same bounded
+                // retry batch instead of betting recovery on a single frame.
+                scheduleInitialMetalRedrawRetries()
+            }
+        }
+
+        requestRendererDisplay()
+    }
+
     /// Re-arms first-frame recovery when visible terminal content first
     /// changes, rather than relying solely on the earlier view-attachment
     /// window. This matters for shells whose startup takes longer than the
@@ -2370,6 +2413,27 @@ final class TerminalTab: Identifiable, Hashable {
         if terminalView.getTerminal().isCurrentBufferAlternate {
             kickPTYWindowSize()
         }
+    }
+
+    /// User-invoked escape hatch for a terminal that renders nothing while its
+    /// shell is demonstrably alive (Terminal ▸ Recover Display).
+    ///
+    /// Unlike `refreshAfterReparent()`, this rebuilds the renderer itself
+    /// rather than only repainting: the failure it targets is a Metal
+    /// presentation chain that refuses every frame, where repainting re-enters
+    /// the same refusal (see `PineTerminalView.recoverRendererNow()`).
+    ///
+    /// SIGWINCH is raised unconditionally rather than only for the alternate
+    /// screen. A stuck renderer leaves Pine unable to tell whether the primary
+    /// buffer still matches what the child last drew, and the signal is
+    /// harmless to an ordinary shell — it simply reprints its prompt.
+    ///
+    /// A terminated tab keeps its scrollback and is still worth repainting,
+    /// but has no child to signal.
+    func recoverDisplay() {
+        (terminalView as? PineTerminalView)?.recoverRendererNow()
+        forceFullRedraw()
+        kickPTYWindowSize()
     }
 
     /// Whether the shell process is still running.

--- a/PineTests/PineAppMenuCommandsTests.swift
+++ b/PineTests/PineAppMenuCommandsTests.swift
@@ -28,6 +28,7 @@ struct PineAppMenuCommandsTests {
                 checkForUpdatesAction: {}
             ),
             toggleQuickTerminal: {},
+            recoverQuickTerminalDisplay: {},
             recentProjects: { [] },
             showAgentInbox: {}
         )

--- a/PineTests/QuickTerminalTests.swift
+++ b/PineTests/QuickTerminalTests.swift
@@ -175,6 +175,41 @@ struct QuickTerminalTests {
         #expect(coordinator.paneState.activeTab?.id == firstTabID)
     }
 
+    @Test("display recovery while hidden is a no-op")
+    func recoverDisplayWhileHiddenIsNoOp() throws {
+        // The panel is a separate window: the menu command fires at it
+        // unconditionally because `focusedProject` is nil while it holds focus.
+        // While hidden it is detached, so a rebuild would be discarded and the
+        // next `show()` repaints through the ordinary attachment path.
+        let fixture = try QuickTerminalControllerFixture()
+        defer { fixture.cleanUp() }
+        let coordinator = fixture.controller
+
+        coordinator.recoverDisplay()
+
+        #expect(coordinator.isVisible == false)
+        #expect(coordinator.paneState.terminalTabs.isEmpty)
+    }
+
+    @Test("display recovery while visible repaints the live session")
+    func recoverDisplayWhileVisibleRepaints() throws {
+        let fixture = try QuickTerminalControllerFixture()
+        defer { fixture.cleanUp() }
+        let coordinator = fixture.controller
+        coordinator.show()
+        let tab = try #require(coordinator.paneState.activeTab)
+        let view = try #require(tab.terminalView as? PineTerminalView)
+        var redrawRequests = 0
+        view.backendRedrawRequestObserver = { redrawRequests += 1 }
+
+        coordinator.recoverDisplay()
+
+        #expect(redrawRequests >= 1)
+        // Recovery repaints the session; it must never restart it.
+        #expect(coordinator.paneState.activeTab?.id == tab.id)
+        coordinator.hide()
+    }
+
     @Test("cwd resolves to most-recent project, else $HOME")
     func cwdFallbackChain() throws {
         let fixture = try QuickTerminalControllerFixture()

--- a/PineTests/TerminalDisplayRecoveryTests.swift
+++ b/PineTests/TerminalDisplayRecoveryTests.swift
@@ -1,0 +1,311 @@
+//
+//  TerminalDisplayRecoveryTests.swift
+//  PineTests
+//
+//  Tests for the user-invoked display recovery that rescues a terminal whose
+//  renderer stopped presenting frames while its shell keeps running (#1472).
+//
+//  The failure being recovered from lives in SwiftTerm's Metal renderer: both
+//  refusal paths in `MetalTerminalRenderer.draw(in:)` (busy frame semaphore,
+//  missing drawable) set the pending-redraw flag without submitting a command
+//  buffer, and only that command buffer's completion handler consumes the
+//  flag. Nothing Pine can invalidate escapes it, so recovery must rebuild the
+//  renderer rather than merely repaint — that distinction is what these tests
+//  pin down.
+//
+
+import Testing
+import AppKit
+import Foundation
+import MetalKit
+import SwiftTerm
+@testable import Pine
+
+@Suite("Terminal Display Recovery Tests")
+@MainActor
+struct TerminalDisplayRecoveryTests {
+
+    // MARK: - View-level recovery
+
+    @Test("Recovery is inert while detached from a window")
+    func recoveryWithoutWindowIsInert() throws {
+        // A detached view has no presentation layer to rebuild, and
+        // `viewDidMoveToWindow` repaints on the next attachment anyway.
+        // Requesting a frame here would be wasted work against a dead layer.
+        let view = PineTerminalView(
+            frame: NSRect(x: 0, y: 0, width: 400, height: 200)
+        )
+        var redrawRequests = 0
+        view.backendRedrawRequestObserver = { redrawRequests += 1 }
+
+        view.recoverRendererNow()
+
+        #expect(redrawRequests == 0)
+        #expect(view.isUsingMetalRenderer == false)
+    }
+
+    @Test("Recovery under CoreGraphics repaints exactly once")
+    func coreGraphicsRecoveryRepaintsOnce() throws {
+        // CoreGraphics has no refusal trap, so recovery must not churn the
+        // backend — one repaint through the bridge is necessary and enough.
+        let tab = TerminalTab(name: "recover-core-graphics")
+        let view = try #require(tab.terminalView as? PineTerminalView)
+        view.metalRendererDisabledForTesting = true
+        let window = makeWindow(containing: view)
+        defer { window.contentView = nil }
+        var redrawRequests = 0
+        view.backendRedrawRequestObserver = { redrawRequests += 1 }
+
+        view.recoverRendererNow()
+
+        #expect(redrawRequests == 1)
+        #expect(view.isUsingMetalRenderer == false)
+    }
+
+    @Test("Recovery on a zero-sized view does not crash")
+    func recoveryOnZeroSizedViewIsSafe() throws {
+        // A collapsed split leaves a real window attachment behind a 0×0 view.
+        // Recovery runs there (the user cannot tell it is collapsed) and must
+        // stay safe rather than assume a valid drawable size.
+        let view = PineTerminalView(frame: .zero)
+        let window = makeWindow(containing: view)
+        defer { window.contentView = nil }
+
+        view.recoverRendererNow()
+        view.recoverRendererNow()
+
+        #expect(Bool(true))
+    }
+
+    @Test("Metal recovery installs a new MTKView and keeps the buffer")
+    func metalRecoveryRebuildsRendererPreservingBuffer() throws {
+        guard MTLCreateSystemDefaultDevice() != nil else { return }
+        let tab = TerminalTab(name: "recover-metal")
+        let view = try #require(tab.terminalView as? PineTerminalView)
+        let window = makeWindow(containing: view)
+        defer { window.contentView = nil }
+        guard view.isUsingMetalRenderer else { return }
+
+        let probe = "pine recovery probe"
+        view.getTerminal().feed(text: probe + "\r\n")
+        let before = Set(metalViewIdentities(in: view))
+
+        view.recoverRendererNow()
+
+        // Rebuilding is the whole point: a recovery that reuses the existing
+        // MTKView would re-enter the same refusal and change nothing. SwiftTerm
+        // defers removing the outgoing view until the replacement has drawn,
+        // so assert a *new* view appeared rather than that the old one is gone.
+        let after = Set(metalViewIdentities(in: view))
+        #expect(!after.subtracting(before).isEmpty)
+        #expect(view.isUsingMetalRenderer)
+        // The PTY, Terminal, and scrollback must survive — recovery is a
+        // repaint of the session, not a reset of it.
+        #expect(bufferText(of: view).contains(probe))
+    }
+
+    @Test("Repeated Metal recovery stays stable and lossless")
+    func repeatedMetalRecoveryIsStable() throws {
+        guard MTLCreateSystemDefaultDevice() != nil else { return }
+        let tab = TerminalTab(name: "recover-metal-repeat")
+        let view = try #require(tab.terminalView as? PineTerminalView)
+        let window = makeWindow(containing: view)
+        defer { window.contentView = nil }
+        guard view.isUsingMetalRenderer else { return }
+
+        let probe = "repeat probe"
+        view.getTerminal().feed(text: probe + "\r\n")
+
+        // A user who sees nothing happen will press the shortcut repeatedly;
+        // that must not degrade into a broken renderer or a lost buffer.
+        for _ in 0..<5 {
+            view.recoverRendererNow()
+        }
+
+        #expect(view.isUsingMetalRenderer)
+        #expect(bufferText(of: view).contains(probe))
+    }
+
+    // MARK: - Tab-level recovery
+
+    @Test("Tab recovery repaints through the backend-aware bridge")
+    func tabRecoveryRepaints() throws {
+        let tab = TerminalTab(name: "recover-tab")
+        let view = try #require(tab.terminalView as? PineTerminalView)
+        view.metalRendererDisabledForTesting = true
+        let window = makeWindow(containing: view)
+        defer { window.contentView = nil }
+        var redrawRequests = 0
+        view.backendRedrawRequestObserver = { redrawRequests += 1 }
+
+        tab.recoverDisplay()
+
+        #expect(redrawRequests >= 1)
+    }
+
+    @Test("Tab recovery is safe on a terminated tab")
+    func tabRecoveryOnTerminatedTabIsSafe() throws {
+        // A closed-but-still-listed tab keeps its scrollback and is worth
+        // repainting, but has no child left to receive SIGWINCH. Recovery must
+        // not fault on the closed PTY descriptor.
+        let tab = TerminalTab(name: "recover-terminated")
+        let view = try #require(tab.terminalView as? PineTerminalView)
+        view.metalRendererDisabledForTesting = true
+        let window = makeWindow(containing: view)
+        defer { window.contentView = nil }
+        tab.stop()
+        var redrawRequests = 0
+        view.backendRedrawRequestObserver = { redrawRequests += 1 }
+
+        tab.recoverDisplay()
+
+        #expect(redrawRequests >= 1)
+        #expect(tab.isProcessRunning == false)
+    }
+
+    @Test("Tab recovery is safe before the PTY ever started")
+    func tabRecoveryBeforeStartIsSafe() throws {
+        // Reaching for the command on a pane that never got a shell (the exact
+        // situation a confused user is in) must not fault on an absent process.
+        let tab = TerminalTab(name: "recover-unstarted")
+        let view = try #require(tab.terminalView as? PineTerminalView)
+        view.metalRendererDisabledForTesting = true
+
+        tab.recoverDisplay()
+
+        #expect(tab.isProcessRunning == false)
+        #expect(view.isUsingMetalRenderer == false)
+    }
+
+    // MARK: - Manager-level scope
+
+    @Test("Manager recovery skips background tabs in the same pane")
+    func managerRecoveryTargetsOnlyActiveTabs() throws {
+        let paneManager = PaneManager()
+        let manager = TerminalManager()
+        manager.paneManager = paneManager
+        let paneID = paneManager.createTerminalPaneAtBottom(
+            workingDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let state = try #require(paneManager.terminalState(for: paneID))
+        let background = try #require(state.activeTab)
+        let active = state.addTab(workingDirectory: URL(fileURLWithPath: "/tmp"))
+        defer {
+            background.stop()
+            active.stop()
+        }
+
+        var backgroundRedraws = 0
+        var activeRedraws = 0
+        (background.terminalView as? PineTerminalView)?
+            .backendRedrawRequestObserver = { backgroundRedraws += 1 }
+        (active.terminalView as? PineTerminalView)?
+            .backendRedrawRequestObserver = { activeRedraws += 1 }
+
+        manager.recoverVisibleTerminalDisplays()
+
+        // The background tab is detached; rebuilding its renderer would cost a
+        // GPU round-trip for pixels nobody can see, and its own re-attach
+        // already repaints it.
+        #expect(state.activeTerminalID == active.id)
+        #expect(activeRedraws >= 1)
+        #expect(backgroundRedraws == 0)
+    }
+
+    @Test("Manager recovery covers every terminal pane, not just the focused one")
+    func managerRecoveryCoversAllPanes() throws {
+        let paneManager = PaneManager()
+        let manager = TerminalManager()
+        manager.paneManager = paneManager
+        let firstPane = paneManager.createTerminalPaneAtBottom(
+            workingDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let secondPane = paneManager.createTerminalPaneAtBottom(
+            workingDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let firstTab = try #require(
+            paneManager.terminalState(for: firstPane)?.activeTab
+        )
+        let secondTab = try #require(
+            paneManager.terminalState(for: secondPane)?.activeTab
+        )
+        defer {
+            firstTab.stop()
+            secondTab.stop()
+        }
+        var firstRedraws = 0
+        var secondRedraws = 0
+        (firstTab.terminalView as? PineTerminalView)?
+            .backendRedrawRequestObserver = { firstRedraws += 1 }
+        (secondTab.terminalView as? PineTerminalView)?
+            .backendRedrawRequestObserver = { secondRedraws += 1 }
+
+        manager.recoverVisibleTerminalDisplays()
+
+        // The stuck pane is frequently not the focused one; a user reaching for
+        // this command should not have to guess which pane to click first.
+        #expect(firstRedraws >= 1)
+        #expect(secondRedraws >= 1)
+    }
+
+    @Test("Manager recovery without a pane manager is a no-op")
+    func managerRecoveryWithoutPaneManagerIsNoOp() {
+        let manager = TerminalManager()
+
+        manager.recoverVisibleTerminalDisplays()
+
+        #expect(manager.allTerminalTabs.isEmpty)
+    }
+
+    @Test("Manager recovery after permanent shutdown is a no-op")
+    func managerRecoveryAfterShutdownIsNoOp() throws {
+        let paneManager = PaneManager()
+        let manager = TerminalManager()
+        manager.paneManager = paneManager
+        let paneID = paneManager.createTerminalPaneAtBottom(
+            workingDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let tab = try #require(paneManager.terminalState(for: paneID)?.activeTab)
+        manager.shutdownPermanently()
+        var redrawRequests = 0
+        (tab.terminalView as? PineTerminalView)?
+            .backendRedrawRequestObserver = { redrawRequests += 1 }
+
+        manager.recoverVisibleTerminalDisplays()
+
+        // Post-shutdown the PTYs are gone; repainting their corpses would
+        // resurrect work the reclamation path deliberately ended.
+        #expect(redrawRequests == 0)
+    }
+
+    // MARK: - Helpers
+
+    private func makeWindow(containing view: NSView) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 300),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = view
+        return window
+    }
+
+    private func metalViewIdentities(in view: NSView) -> [ObjectIdentifier] {
+        var found: [ObjectIdentifier] = []
+        if let metalView = view as? MTKView {
+            found.append(ObjectIdentifier(metalView))
+        }
+        for subview in view.subviews {
+            found.append(contentsOf: metalViewIdentities(in: subview))
+        }
+        return found
+    }
+
+    private func bufferText(of view: PineTerminalView) -> String {
+        let terminal = view.getTerminal()
+        return (0..<terminal.rows)
+            .compactMap { terminal.getLine(row: $0)?.translateToString() }
+            .joined(separator: "\n")
+    }
+}


### PR DESCRIPTION
Closes #1472

## Problem

A terminal pane goes black while its shell keeps running, and nothing brings it back — typing included. Recreating the tab or relaunching Pine is the only way out.

Root cause is in SwiftTerm 1.18.0's `MetalTerminalRenderer.draw(in:)`. Two paths refuse a frame:

- the frame semaphore is already held,
- `currentDrawable` / `currentRenderPassDescriptor` is `nil`.

Both call `markPendingRedraw()` and return **without submitting a command buffer** — while `pendingRedraw` is consumed only inside `commandBuffer.addCompletedHandler`, i.e. only when a frame *was* submitted. The pending request ends up with no consumer, and the renderer goes quiet for good. With `isPaused = true` / `enableSetNeedsDisplay = true` / `autoResizeDrawable = false`, nothing re-drives it.

Input does not help: key events land on `metalView.setNeedsDisplay`, which re-enters the same refusal. Pine's own `requestRendererDisplay()` is reachable only from attachment-shaped events (`viewDidMoveToWindow`, host rebind, occlusion, backing properties) and a **one-shot** first-visible-content hook, so ordinary PTY output after that first chunk never routes through recovery.

Verified on a live session: every child shell was alive on its own tty while the pane showed nothing — the PTY had started fine and only presentation was lost.

## Why a command and not automatic recovery

Pine cannot detect the stuck state from outside. With the semaphore held, both `setNeedsDisplay` and `drawMetalFrameNow()` hit the same refusal, and SwiftTerm exposes no "frame presented" signal to poll. Rebuilding the renderer is the only escape — a fresh `MTKView`, semaphore, and drawable chain, while `Terminal`, the PTY, and the scrollback stay untouched.

The durable fix belongs upstream (re-request the dropped frame from the refusal paths themselves instead of from a completion handler that will never run) and will be filed separately. This command stays useful afterwards, just no longer load-bearing.

## Change

**Terminal ▸ Recover Terminal Display (⌘⌥R)**

- `PineTerminalView.recoverRendererNow()` — rebuilds the Metal renderer via the supported `setUseMetal(false/true)` pair and re-arms the bounded first-frame retry batch, since a fresh `CAMetalLayer` can miss its first drawable exactly like one created on attach. Under CoreGraphics (no such trap) it is a single repaint through the existing backend-aware bridge. No-op while detached.
- `TerminalTab.recoverDisplay()` — rebuild, then `forceFullRedraw()`, then SIGWINCH. The signal is raised unconditionally rather than only for the alternate screen: a stuck renderer leaves Pine unable to tell whether the primary buffer still matches what the child last drew, and an ordinary shell merely reprints its prompt.
- `TerminalManager.recoverVisibleTerminalDisplays()` — the active tab of *every* terminal pane. Background tabs are skipped: they are detached, so a rebuild would cost a GPU round-trip for pixels nobody sees, and their own re-attach already repaints them. All panes rather than just the focused one — the stuck pane is frequently not the focused one.
- `QuickTerminalController.recoverDisplay()` — the panel is a separate window where `focusedProject` is nil, so the menu item is deliberately never disabled; gating on project panes would leave exactly that surface unfixable.

## Tests

13 new tests (`TerminalDisplayRecoveryTests`, plus two in `QuickTerminalTests`), covering the negative and edge paths as well as the happy one:

- inert while detached; exactly one repaint under CoreGraphics; safe on a 0×0 view (collapsed split)
- Metal: a **new** `MTKView` really appears (asserted as a new identity, since SwiftTerm defers removing the outgoing view until the replacement has drawn) and the buffer survives; five consecutive recoveries stay stable and lossless
- tab-level: safe on a terminated tab and on one whose PTY never started
- manager-level: background tabs untouched, every pane covered, no-op without a pane manager and after permanent shutdown
- quick terminal: no-op while hidden; repaints without restarting the session when visible

Existing coverage missed this class entirely: `TerminalMetalRendererTests` exercises only attachment-shaped events, and the UI-test harness launches with `--disable-metal`, so the Metal path has no end-to-end coverage.

## Verification

- `xcodebuild build` — succeeds
- 53 tests across `TerminalDisplayRecoveryTests`, `TerminalMetalRendererTests`, `QuickTerminalTests`, `PineAppMenuCommandsTests` — all pass, with Metal genuinely available on the dev machine (the renderer-rebuild assertions really ran rather than being skipped)
- SwiftLint — clean

Not yet done: the in-window visual check of the menu item and shortcut. It needs a foreground app instance, and a working Pine with live agent sessions was running on the machine — UI tests launch with `--reset-state`, which clears saved project sessions in the standard domain, so running them was not worth the risk. Worth a quick manual pass before merge.
