### PR TITLE
fix: stop repeating the project name in the title bar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,7 +554,7 @@ jobs:
             --workflow .github/workflows/ci.yml \
             --max-delta 3
 
-  # UI test shards — 7 parallel jobs, 31-34 tests each (delta 3).
+  # UI test shards — 7 parallel jobs, 32-34 tests each (delta 2).
   # To rebalance: count tests per class, redistribute so shards stay within ±3 tests.
   # List classes with: grep -r "func test" PineUITests/ | sed 's/:.*//' | sort | uniq -c | sort -rn
   ui-tests:
@@ -588,7 +588,7 @@ jobs:
               -only-testing:PineUITests/EditorTabNavigationTests
               -only-testing:PineUITests/DiffNavigationUITests
               -only-testing:PineUITests/AccessibilityLocalizationSmokeTests
-          # Shard 4 — Editor Chrome (31 tests)
+          # Shard 4 — Editor Chrome (32 tests)
           - shard-name: "Editor Chrome"
             test-classes: >-
               -only-testing:PineUITests/EditorWindowTests

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -65,6 +65,18 @@ struct ContentView: View {
 
     var activeTab: EditorTab? { activeTabManager.activeTab }
 
+    /// Title-bar text. The title carries the active file and the switcher
+    /// carries the project, so neither repeats the other.
+    var windowChrome: WindowChromePresentation {
+        WindowChromePresentation(
+            activeFileName: activeTab?.fileName,
+            repositoryName: projectWindowSession
+                .activeRepositoryURL
+                .lastPathComponent,
+            switcherLabel: projectWindowSession.activeDisplayName
+        )
+    }
+
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             SidebarSearchableContent(
@@ -111,13 +123,14 @@ struct ContentView: View {
             isSearchPresented: $isSearchPresented
         ))
         .frame(minWidth: 800, minHeight: 500)
-        .navigationTitle(workspace.projectName)
+        .navigationTitle(windowChrome.title)
         .navigationSubtitle(branchSubtitle)
         .toolbar {
             ToolbarItem(placement: .navigation) {
                 ProjectSwitcherView(
                     session: projectWindowSession,
                     registry: registry,
+                    label: windowChrome.switcherLabel,
                     onOpenProject: { openNewProject() }
                 )
             }

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -104,4 +104,15 @@ nonisolated enum MenuIcons {
     static let copyPath = "doc.on.clipboard"
     static let copyRelativePath = "link"
     static let revealInSidebar = "sidebar.left"
+
+    // MARK: - Project switcher (#1470)
+    // These live here rather than inline in the view so `MenuIconTests`
+    // proves they resolve: an unknown SF Symbol name renders as nothing at
+    // all, which is invisible in review and easy to miss on screen.
+    static let projectSwitcher = "square.stack"
+    static let projectSwitcherNewAgent = "sparkles"
+    static let projectSwitcherOpenFolder = "folder.badge.plus"
+    static let projectSwitcherDisclosure = "chevron.down"
+    static let projectSwitcherActive = "checkmark"
+    static let projectSwitcherProject = "folder"
 }

--- a/Pine/ProjectSwitcherView.swift
+++ b/Pine/ProjectSwitcherView.swift
@@ -10,6 +10,10 @@ import SwiftUI
 struct ProjectSwitcherView: View {
     let session: ProjectWindowSession
     let registry: ProjectRegistry
+    /// Text beside the icon, or `nil` when the window title already says the
+    /// same thing and the switcher should not repeat it. Resolved by
+    /// ``WindowChromePresentation``.
+    let label: String?
     let onOpenProject: () -> Void
 
     var body: some View {
@@ -44,7 +48,7 @@ struct ProjectSwitcherView: View {
             } label: {
                 Label(
                     Strings.projectSwitcherNewAgent,
-                    systemImage: "sparkles"
+                    systemImage: MenuIcons.projectSwitcherNewAgent
                 )
             }
             .disabled(
@@ -54,7 +58,10 @@ struct ProjectSwitcherView: View {
             .accessibilityIdentifier(AccessibilityID.projectSwitcherNewAgent)
 
             Button(action: onOpenProject) {
-                Label(Strings.menuOpenFolder, systemImage: "folder.badge.plus")
+                Label(
+                    Strings.menuOpenFolder,
+                    systemImage: MenuIcons.projectSwitcherOpenFolder
+                )
             }
             .disabled(session.isLaunchingAgent)
         } label: {
@@ -63,11 +70,17 @@ struct ProjectSwitcherView: View {
                     ProgressView()
                         .controlSize(.small)
                 } else {
-                    Image(systemName: "folder.stack")
+                    // Was `folder.stack`, which is not an SF Symbol and so
+                    // rendered as nothing — invisible while the label sat
+                    // beside it, a bare chevron once the label could be
+                    // suppressed.
+                    Image(systemName: MenuIcons.projectSwitcher)
                 }
-                Text(session.activeDisplayName)
-                    .lineLimit(1)
-                Image(systemName: "chevron.down")
+                if let label {
+                    Text(label)
+                        .lineLimit(1)
+                }
+                Image(systemName: MenuIcons.projectSwitcherDisclosure)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
@@ -75,6 +88,10 @@ struct ProjectSwitcherView: View {
         .menuStyle(.borderlessButton)
         .fixedSize(horizontal: true, vertical: false)
         .help(Strings.projectSwitcherTooltip)
+        // Spoken name stays the project even when the visible text is
+        // suppressed as a duplicate — an icon-only control must not reach
+        // VoiceOver as an unnamed button.
+        .accessibilityLabel(Text(session.activeDisplayName))
         .accessibilityIdentifier(AccessibilityID.projectSwitcher)
     }
 
@@ -89,8 +106,8 @@ struct ProjectSwitcherView: View {
                 Text(url.lastPathComponent)
             } icon: {
                 Image(systemName: session.activeProjectURL == url
-                    ? "checkmark"
-                    : "folder")
+                    ? MenuIcons.projectSwitcherActive
+                    : MenuIcons.projectSwitcherProject)
             }
         }
         .disabled(session.isLaunchingAgent)

--- a/Pine/WindowChromePresentation.swift
+++ b/Pine/WindowChromePresentation.swift
@@ -1,0 +1,68 @@
+//
+//  WindowChromePresentation.swift
+//  Pine
+//
+//  Title-bar text for one project window: what the title says, and whether
+//  the project switcher repeats it.
+//
+
+import Foundation
+
+/// The two pieces of text a project window puts in its title bar, resolved
+/// together so the same string never appears twice in one strip.
+///
+/// The window title carries the active file, matching how Xcode splits the
+/// two surfaces: the switcher answers "which project", the title answers
+/// "which file". With no editor tab open there is nothing file-shaped to
+/// show, so the title falls back to the project — a window must stay
+/// identifiable in the Window menu, Mission Control, and window cycling, and
+/// an empty title is never an option.
+///
+/// That fallback is exactly when the switcher would echo the title, and it is
+/// not a rare state: a project with no restored session opens straight into a
+/// terminal (#1251), so it is the first thing a new project shows. Whenever
+/// the two would read identically the switcher drops its text and stays an
+/// icon; the name is still one click away and still in the title bar.
+///
+/// The comparison is on the resolved strings rather than on "is a file open",
+/// which keeps an agent worktree readable: its switcher reads
+/// `pine — feat/branch` while the title falls back to the repository name
+/// `pine`, so the branch — the one thing distinguishing that window — never
+/// gets suppressed as a duplicate.
+nonisolated struct WindowChromePresentation: Equatable {
+    /// Last-resort title. Pine is a brand name and stays untranslated.
+    static let fallbackTitle = "Pine"
+
+    /// Native window title.
+    let title: String
+
+    /// Text for the toolbar's project switcher, or `nil` when it would repeat
+    /// ``title`` and the switcher should render as an icon alone.
+    let switcherLabel: String?
+
+    init(
+        activeFileName: String?,
+        repositoryName: String,
+        switcherLabel: String
+    ) {
+        let resolvedTitle = Self.presentable(activeFileName)
+            ?? Self.presentable(repositoryName)
+            ?? Self.fallbackTitle
+        title = resolvedTitle
+
+        let resolvedLabel = Self.presentable(switcherLabel)
+        self.switcherLabel = resolvedLabel == resolvedTitle
+            ? nil
+            : resolvedLabel
+    }
+
+    /// A candidate is presentable when it survives trimming and is not a bare
+    /// path separator. `URL.lastPathComponent` returns "/" for the filesystem
+    /// root, and a lone slash reads as a glitch rather than a window name.
+    private static func presentable(_ candidate: String?) -> String? {
+        guard let candidate else { return nil }
+        let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != "/" else { return nil }
+        return trimmed
+    }
+}

--- a/PineTests/MenuIconTests.swift
+++ b/PineTests/MenuIconTests.swift
@@ -59,4 +59,44 @@ struct MenuIconTests {
             "SF Symbol '\(symbol)' used by '\(menuItem)' does not exist"
         )
     }
+
+    // MARK: - Project switcher icons (ProjectSwitcherView.swift, #1470)
+
+    // The switcher shipped with `folder.stack`, which is not an SF Symbol.
+    // It rendered as nothing and stayed unnoticed because a text label sat
+    // beside it. Its toolbar control can now be icon-only, so a missing
+    // symbol would leave a bare chevron.
+    @Test(arguments: [
+        (MenuIcons.projectSwitcher, "Project switcher toolbar control"),
+        (MenuIcons.projectSwitcherDisclosure, "Project switcher chevron"),
+        (MenuIcons.projectSwitcherNewAgent, "New Agent"),
+        (MenuIcons.projectSwitcherOpenFolder, "Open Folder (switcher menu)"),
+        (MenuIcons.projectSwitcherActive, "Active project checkmark"),
+        (MenuIcons.projectSwitcherProject, "Inactive project"),
+    ])
+    func projectSwitcherIconExists(_ symbol: String, _ element: String) {
+        #expect(
+            NSImage(systemSymbolName: symbol, accessibilityDescription: nil) != nil,
+            "SF Symbol '\(symbol)' used by '\(element)' does not exist"
+        )
+    }
+
+    // MARK: - Agent worktree state icons (ProjectSwitcherView.swift)
+
+    @Test(arguments: [
+        ("checkmark", "Active worktree"),
+        ("exclamationmark.circle.fill", "Worktree waiting for input"),
+        ("xmark.circle.fill", "Failed worktree"),
+        ("checkmark.circle", "Completed worktree"),
+        ("circle.fill", "Live worktree"),
+        ("circle", "Idle worktree"),
+    ])
+    func worktreeStateIconExists(_ symbol: String, _ state: String) {
+        // These encode agent state in the switcher menu. A missing symbol
+        // makes two different states look identical rather than merely blank.
+        #expect(
+            NSImage(systemSymbolName: symbol, accessibilityDescription: nil) != nil,
+            "SF Symbol '\(symbol)' used by '\(state)' does not exist"
+        )
+    }
 }

--- a/PineTests/WindowChromePresentationTests.swift
+++ b/PineTests/WindowChromePresentationTests.swift
@@ -1,0 +1,247 @@
+//
+//  WindowChromePresentationTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Window chrome presentation")
+struct WindowChromePresentationTests {
+    private func chrome(
+        file: String?,
+        repository: String = "pine",
+        switcher: String = "pine"
+    ) -> WindowChromePresentation {
+        WindowChromePresentation(
+            activeFileName: file,
+            repositoryName: repository,
+            switcherLabel: switcher
+        )
+    }
+
+    // MARK: - The duplication this type exists to remove
+
+    @Test("No string is ever printed twice in the title bar")
+    func titleAndSwitcherNeverMatch() {
+        // The invariant, stated once: whatever the inputs, the two title-bar
+        // surfaces never read identically.
+        let inputs: [(String?, String, String)] = [
+            ("ContentView.swift", "pine", "pine"),
+            (nil, "pine", "pine"),
+            (nil, "pine", "pine — feat/x"),
+            ("ContentView.swift", "pine", "pine — feat/x"),
+            ("pine", "pine", "pine"),
+            ("", "pine", "pine"),
+            ("  ", "  ", "  "),
+            (nil, "/", "/")
+        ]
+        for (file, repository, switcher) in inputs {
+            let resolved = WindowChromePresentation(
+                activeFileName: file,
+                repositoryName: repository,
+                switcherLabel: switcher
+            )
+            #expect(
+                resolved.switcherLabel != resolved.title,
+                "\(String(describing: file)) / \(repository) / \(switcher)"
+            )
+        }
+    }
+
+    @Test("An open file titles the window and the switcher keeps the project")
+    func openFileSplitsTheTwoSurfaces() {
+        let resolved = chrome(file: "ContentView.swift")
+        #expect(resolved.title == "ContentView.swift")
+        #expect(resolved.switcherLabel == "pine")
+    }
+
+    @Test("Without an editor tab the switcher drops its duplicate text")
+    func terminalOnlyWindowSuppressesSwitcherText() {
+        // A project with no restored session opens straight into a terminal
+        // (#1251), so this is the first screen of a new project — the one
+        // place the duplicate was most visible.
+        let resolved = chrome(file: nil)
+        #expect(resolved.title == "pine")
+        #expect(resolved.switcherLabel == nil)
+    }
+
+    // MARK: - Worktree windows keep their distinguishing text
+
+    @Test("A worktree keeps its branch label even with no file open")
+    func worktreeBranchIsNotSuppressed() {
+        // The branch is the only thing telling two windows of one repository
+        // apart. It shares a word with the title but is not the same string,
+        // so it must survive.
+        let resolved = chrome(
+            file: nil,
+            repository: "pine",
+            switcher: "pine — feat/multi-project"
+        )
+        #expect(resolved.title == "pine")
+        #expect(resolved.switcherLabel == "pine — feat/multi-project")
+    }
+
+    @Test("A worktree window never surfaces its hashed service directory")
+    func worktreeTitleUsesRepositoryName() {
+        // The worktree root is Application Support/Pine/AgentWorktrees/<hash>;
+        // the caller passes the repository name so no hash reaches the title.
+        #expect(chrome(file: nil, repository: "pine").title == "pine")
+    }
+
+    // MARK: - Fallback chain
+
+    @Test("No open tab falls back to the repository name")
+    func noTabFallsBack() {
+        #expect(
+            chrome(file: nil, repository: "acme", switcher: "acme").title
+                == "acme"
+        )
+    }
+
+    @Test("An untitled buffer with a display name titles the window")
+    func untitledBufferUsesItsDisplayName() {
+        #expect(chrome(file: "Untitled 2").title == "Untitled 2")
+    }
+
+    @Test(
+        "Blank file names fall through to the repository",
+        arguments: ["", " ", "\t", "\n", "   \n\t  "]
+    )
+    func blankFileNameFallsBack(blank: String) {
+        #expect(chrome(file: blank).title == "pine")
+    }
+
+    @Test(
+        "A window is never left nameless",
+        arguments: ["", " ", "/", "\n"]
+    )
+    func namelessWindowIsImpossible(blankRepository: String) {
+        // A window with an empty title disappears from the Window menu and
+        // Mission Control. Both text inputs degenerate at once here — the
+        // last resort must still produce something identifiable.
+        let resolved = chrome(
+            file: nil,
+            repository: blankRepository,
+            switcher: blankRepository
+        )
+        #expect(resolved.title == WindowChromePresentation.fallbackTitle)
+        #expect(!resolved.title.isEmpty)
+    }
+
+    @Test("A blank switcher label never renders as empty text")
+    func blankSwitcherLabelBecomesIconOnly() {
+        // An empty Text() would reserve layout width for nothing and reach
+        // the accessibility tree as a nameless string.
+        #expect(chrome(file: "main.swift", switcher: "   ").switcherLabel == nil)
+    }
+
+    @Test("A filesystem-root project does not title the window '/'")
+    func filesystemRootIsNotATitle() {
+        // URL(fileURLWithPath: "/").lastPathComponent is "/".
+        #expect(
+            chrome(file: nil, repository: "/", switcher: "/").title
+                == WindowChromePresentation.fallbackTitle
+        )
+    }
+
+    // MARK: - Hostile and unusual names
+
+    @Test("Surrounding whitespace is trimmed, inner spacing is preserved")
+    func trimsEdgesOnly() {
+        #expect(chrome(file: "  read me.swift \n").title == "read me.swift")
+    }
+
+    @Test("Whitespace differences alone do not defeat duplicate detection")
+    func duplicateDetectionComparesTrimmedText() {
+        // The switcher label and the title arrive from different call sites;
+        // padding on one of them must not smuggle the duplicate back in.
+        #expect(
+            chrome(file: nil, repository: "pine", switcher: "  pine  ")
+                .switcherLabel == nil
+        )
+    }
+
+    @Test(
+        "Unicode file names survive verbatim",
+        arguments: [
+            "Ünïcödé.swift",
+            "файл.swift",
+            "日本語.swift",
+            "🌲.swift",
+            "ملف.swift",
+            "e\u{0301}xotic.swift"  // combining acute, not precomposed
+        ]
+    )
+    func unicodeIsNotMangled(name: String) {
+        // No normalization, no transliteration: the title must match the name
+        // the user sees in Finder.
+        #expect(chrome(file: name).title == name)
+    }
+
+    @Test("Canonically equivalent spellings still count as duplicates")
+    func unicodeEquivalenceIsTreatedAsDuplicate() {
+        // Swift string comparison is canonical, so a precomposed title and a
+        // decomposed switcher label are equal — and must not both render.
+        let resolved = WindowChromePresentation(
+            activeFileName: nil,
+            repositoryName: "Cafe\u{0301}",     // decomposed
+            switcherLabel: "Caf\u{00E9}"        // precomposed
+        )
+        #expect(resolved.switcherLabel == nil)
+    }
+
+    @Test(
+        "Structurally odd but legal POSIX names pass through",
+        arguments: [
+            ".env",
+            "no-extension",
+            "archive.tar.gz",
+            "weird name with  double  spaces.txt",
+            "file:with:colons.swift",
+            "-leading-dash.swift"
+        ]
+    )
+    func oddNamesPassThrough(name: String) {
+        #expect(chrome(file: name).title == name)
+    }
+
+    @Test("An embedded newline is preserved rather than silently rewritten")
+    func embeddedNewlineIsPreserved() {
+        // POSIX allows newlines inside file names. Trimming is an edge
+        // operation only — rewriting the interior would misreport which file
+        // is open.
+        #expect(chrome(file: "two\nlines.swift").title == "two\nlines.swift")
+    }
+
+    @Test("A pathological file name is not truncated by this layer")
+    func longNameIsNotTruncated() {
+        // Layout truncation belongs to AppKit, which knows the title bar
+        // width. Truncating here would bake a wrong ellipsis into the value
+        // the Window menu and accessibility tree read.
+        let long = String(repeating: "a", count: 4096) + ".swift"
+        #expect(chrome(file: long).title == long)
+    }
+
+    @Test("A file named like its project keeps the title, hides the label")
+    func fileMatchingProjectNameCollapsesToOneSurface() {
+        // Opening a file called `pine` inside project `pine` is a genuine
+        // coincidence: the title still reports the open file, and the
+        // switcher — which would print the same word — goes icon-only.
+        let resolved = chrome(file: "pine")
+        #expect(resolved.title == "pine")
+        #expect(resolved.switcherLabel == nil)
+    }
+
+    // MARK: - Value semantics
+
+    @Test("Equal inputs produce equal values")
+    func equatableByResolvedFields() {
+        let lhs = chrome(file: "  main.swift  ")
+        let rhs = chrome(file: "main.swift")
+        #expect(lhs == rhs)
+        #expect(lhs != chrome(file: nil))
+    }
+}

--- a/PineUITests/EditorWindowTests.swift
+++ b/PineUITests/EditorWindowTests.swift
@@ -364,6 +364,55 @@ final class EditorWindowTests: PineUITestCase {
         XCTAssertTrue(revealProject.exists, "View menu should contain 'Reveal Project in Finder'")
     }
 
+    // MARK: - Window title does not repeat the project switcher label
+
+    /// The toolbar's project switcher already names the project. The native
+    /// title showed that same name again, printing one word twice in a single
+    /// strip; it now carries the active file and falls back to the project
+    /// only when no editor tab is open.
+    func testWindowTitleShowsActiveFileInsteadOfRepeatingProjectName() throws {
+        let namedProject = try createTempProject(
+            files: [
+                "main.swift": "let greeting = \"Hello\"\n",
+                "utils.swift": "func helper() {}\n"
+            ],
+            projectName: "TitleFixture"
+        )
+        defer { cleanupProject(namedProject) }
+
+        launchWithProject(namedProject)
+
+        XCTAssertTrue(
+            waitForExistence(app.windows["TitleFixture"], timeout: 10),
+            "With no editor tab open the window keeps the project name"
+        )
+
+        openFile("main.swift")
+        XCTAssertTrue(
+            waitForExistence(app.windows["main.swift"], timeout: 5),
+            "An open file should title the window"
+        )
+        XCTAssertTrue(
+            app.windows["TitleFixture"].waitForNonExistence(timeout: 5),
+            "The project name must leave the title bar while a file is open "
+                + "— the project switcher is the one place that shows it"
+        )
+
+        openFile("utils.swift")
+        XCTAssertTrue(
+            waitForExistence(app.windows["utils.swift"], timeout: 5),
+            "Activating another tab should retitle the window"
+        )
+
+        let close = editorTabCloseButton("utils.swift")
+        XCTAssertTrue(waitForExistence(close, timeout: 5))
+        close.click()
+        XCTAssertTrue(
+            waitForExistence(app.windows["main.swift"], timeout: 5),
+            "Closing the active tab should retitle to the next active file"
+        )
+    }
+
     // MARK: - Sidebar context menu has Reveal in Finder
 
     func testSidebarContextMenuRevealInFinder() throws {


### PR DESCRIPTION
## Summary

- The project name stopped appearing twice in the title bar. The window title now carries the **active file**; the toolbar switcher keeps the **project**. With no editor tab open the title falls back to the project and the switcher drops its duplicate text, keeping its icon.
- Duplicate detection compares the resolved strings, not "is a file open", so an agent worktree keeps its `pine — feat/branch` label beside a `pine` title — the branch is the only thing telling two windows of one repository apart.
- Fixed a second defect found on screen: the switcher asked for `folder.stack`, which is **not an SF Symbol** and rendered as nothing. Invisible while a label sat beside it; a bare chevron once the label could be suppressed.

### Why the empty-tab state mattered

A project with no restored session opens straight into a terminal (#1251) — no editor tab, so the title fell back to the project name while the switcher already showed it. That is the first screen of every newly opened project, which is exactly where the duplicate was most visible. The screenshots below are that state, before and after.

| | Title bar |
|---|---|
| Before | `⌄  TitleFixture` — switcher label suppressed nothing, and the missing `folder.stack` left a bare chevron |
| After (no tab) | `[▣] ⌄` + title `TitleFixture` |
| After (file open) | `[▣] TitleFixture ⌄` + title `ContentView.swift` |

### Where the logic lives

`WindowChromePresentation` (new, `nonisolated`, no UI dependencies) resolves title and switcher label together. It also guards the degenerate inputs: blank names, a `/` repository (`URL.lastPathComponent` of the filesystem root), and a final `"Pine"` fallback — a window with an empty title disappears from the Window menu and Mission Control.

Switcher SF Symbols moved into `MenuIcons` so `MenuIconTests` proves they resolve, and the switcher keeps an explicit `accessibilityLabel` so the icon-only form never reaches VoiceOver as an unnamed button.

## Related issue

N/A — reported directly during review of the 2.4.0 release PR (#1471).

## Test plan

- [x] Unit tests added/updated
- [x] UI tests added/updated (if applicable)

**Unit — 20 tests in `WindowChromePresentationTests`**, including the invariant "no string is ever printed twice" over eight input shapes, plus the negative and hostile paths: blank/whitespace-only names, filesystem-root `/`, both inputs degenerate at once, canonically-equivalent Unicode spellings (precomposed vs decomposed) treated as duplicates, embedded newlines preserved rather than rewritten, a 4096-character name left untruncated, and a file named exactly like its project.

**Unit — 10 new cases in `MenuIconTests`** covering every switcher and worktree-state symbol, so a non-existent name fails a test instead of silently rendering blank.

**UI — `EditorWindowTests.testWindowTitleShowsActiveFileInsteadOfRepeatingProjectName`**: asserts the window is addressable as `TitleFixture` with no tab open, becomes `main.swift` once a file is opened, that `TitleFixture` no longer exists as a window title at that point, retitles on tab switch, and retitles again on tab close.

Local runs (macOS 27):
- `WindowChromePresentationTests` + `MenuIconTests` — 24 tests, pass
- Full `PineTests` — 754 tests; 4 `AgentInboxToolbarButtonSnapshotTests` failures and intermittent `TabTransferSafetyTests` / `ApplicationLifecycleProcessTests` timeouts. **Both reproduce on unmodified `main`** — the snapshot baselines are recorded on macOS 26 CI, and the timeouts are load-sensitive. Re-run of those suites with this change, isolated: 71 tests, pass.
- UI tests were **not** run locally: they launch with `--reset-state`, which clears saved sessions, and a working Pine with live agent sessions was running on the machine. macOS 26 CI is the execution gate.
- SwiftLint — clean on all changed files.
- `check_ui_test_shards.py --max-delta 3` — 40 classes, 232 tests, delta 2. Stale shard counts in `ci.yml` comments updated to match.

## Compatibility matrix

- macOS 26: Not tested locally — macOS 26 GitHub CI is required before merge
- macOS 27 beta: Tested — macOS 27.0 build 26A5406e
- Xcode: Xcode 27.0 build 27A5218g
- macOS SDK: 27.0 build 26A5406c

Complete environment output:

```
ProductName:		macOS
ProductVersion:		27.0
BuildVersion:		26A5406e
Xcode 27.0
Build version 27A5218g
27.0
26A5406c
```

### Terminal renderer coverage

- Default path (Metal when available): N/A — no terminal code touched; the change is title-bar text
- CoreGraphics (`--disable-metal`): N/A

## Manual testing checklist

- [x] Verified the change works as expected
- [x] No regressions in related features

Verified by running the built app against a fixture project and reading the title bar in both states — with a restored editor tab (`TitleFixture ⌄` + `ContentView.swift`) and with none (`⌄` icon only + `TitleFixture`). The missing `folder.stack` symbol was found this way and not from the diff.

Not verified by hand: light appearance (no colors changed, only which text renders), the Window menu entry for a retitled window, and switching between two projects in one window — all covered by CI or unchanged code paths.
