### PR TITLE
fix: give the project switcher the toolbar's own chrome

### DIFF
--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -113,7 +113,6 @@ nonisolated enum MenuIcons {
     static let projectSwitcher = "square.stack"
     static let projectSwitcherNewAgent = "sparkles"
     static let projectSwitcherOpenFolder = "folder.badge.plus"
-    static let projectSwitcherDisclosure = "chevron.down"
     static let projectSwitcherActive = "checkmark"
     static let projectSwitcherProject = "folder"
 }

--- a/Pine/ProjectSwitcherView.swift
+++ b/Pine/ProjectSwitcherView.swift
@@ -80,13 +80,20 @@ struct ProjectSwitcherView: View {
                     Text(label)
                         .lineLimit(1)
                 }
-                Image(systemName: MenuIcons.projectSwitcherDisclosure)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
             }
         }
-        .menuStyle(.borderlessButton)
-        .fixedSize(horizontal: true, vertical: false)
+        // No `menuStyle` and no hand-drawn chevron: the toolbar's own style
+        // is what sizes the item chrome and draws the disclosure indicator.
+        // `.borderlessButton` opted out of both and pinned the control to a
+        // chrome narrower than the round items beside it while holding two
+        // glyphs instead of one, so the icon and the chevron sat flush
+        // against the capsule with no breathing room. It also kept the label
+        // full-strength white while every neighbour, and the window title,
+        // dimmed with an inactive window. Measured on macOS 27 beta at 2×:
+        // 33pt beside 35pt neighbours before, 41.5pt after. The exact metric
+        // moves with the OS and the display scale; the relationship — a
+        // busier control is never the narrowest one on the strip — does not,
+        // which is what `EditorWindowTests` asserts.
         .help(Strings.projectSwitcherTooltip)
         // Spoken name stays the project even when the visible text is
         // suppressed as a duplicate — an icon-only control must not reach

--- a/PineTests/MenuIconTests.swift
+++ b/PineTests/MenuIconTests.swift
@@ -65,10 +65,10 @@ struct MenuIconTests {
     // The switcher shipped with `folder.stack`, which is not an SF Symbol.
     // It rendered as nothing and stayed unnoticed because a text label sat
     // beside it. Its toolbar control can now be icon-only, so a missing
-    // symbol would leave a bare chevron.
+    // symbol would leave an empty capsule holding nothing but the toolbar's
+    // own disclosure chevron.
     @Test(arguments: [
         (MenuIcons.projectSwitcher, "Project switcher toolbar control"),
-        (MenuIcons.projectSwitcherDisclosure, "Project switcher chevron"),
         (MenuIcons.projectSwitcherNewAgent, "New Agent"),
         (MenuIcons.projectSwitcherOpenFolder, "Open Folder (switcher menu)"),
         (MenuIcons.projectSwitcherActive, "Active project checkmark"),

--- a/PineUITests/EditorWindowTests.swift
+++ b/PineUITests/EditorWindowTests.swift
@@ -413,6 +413,57 @@ final class EditorWindowTests: PineUITestCase {
         )
     }
 
+    // MARK: - Project switcher is not narrower than its toolbar neighbours
+
+    /// The switcher opted out of the toolbar's own control style, which
+    /// pinned it to a chrome narrower than the round items beside it while it
+    /// holds two glyphs — an icon and a disclosure chevron — instead of one.
+    /// Both sat flush against the capsule and the control read as squashed.
+    ///
+    /// The assertion is relative rather than a hardcoded point size: the
+    /// toolbar metric differs between macOS 26 and 27 and between display
+    /// scales, but a control holding more content than its neighbour must
+    /// never come out narrower than it on the same strip.
+    func testProjectSwitcherIsWiderThanSingleGlyphToolbarButtons() throws {
+        let metricsProject = try createTempProject(
+            files: ["main.swift": "let greeting = \"Hello\"\n"],
+            projectName: "SwitcherMetrics"
+        )
+        defer { cleanupProject(metricsProject) }
+
+        launchWithProject(metricsProject)
+
+        let switcher = app.descendants(matching: .any)[
+            "projectSwitcher"
+        ].firstMatch
+        XCTAssertTrue(
+            waitForExistence(switcher, timeout: 10),
+            "The project switcher should be visible in the toolbar"
+        )
+
+        let openFolder = app.descendants(matching: .any)[
+            "openFolderToolbarButton"
+        ].firstMatch
+        XCTAssertTrue(
+            waitForExistence(openFolder, timeout: 5),
+            "The sidebar's Open Folder button should be visible"
+        )
+
+        let neighbourWidth = openFolder.frame.width
+        XCTAssertGreaterThan(
+            neighbourWidth,
+            0,
+            "A visible toolbar button must report a real frame"
+        )
+        XCTAssertGreaterThan(
+            switcher.frame.width,
+            neighbourWidth,
+            "The switcher carries an icon and a disclosure chevron, so its "
+                + "chrome must be wider than a single-glyph toolbar button "
+                + "(\(switcher.frame.width) vs \(neighbourWidth))"
+        )
+    }
+
     // MARK: - Sidebar context menu has Reveal in Finder
 
     func testSidebarContextMenuRevealInFinder() throws {


### PR DESCRIPTION
## Проблема

Кнопка переключателя проектов (#1470) отключала стандартный стиль тулбара через `.menuStyle(.borderlessButton)` и рисовала собственный шеврон. Из-за этого её хрома фиксировалась уже соседних круглых кнопок — 33pt против 35pt (macOS 27 beta, 2×) — при том, что внутри два глифа вместо одного. Иконка и шеврон упирались в края капсулы, кнопка читалась сплюснутой.

Это состояние по умолчанию для обычного проекта: без открытой вкладки лейбл подавляется как дубль заголовка (#1474), и самая узкая хрома несёт самое плотное содержимое.

| до | после |
|---|---|
| иконка + шеврон вплотную к краям, 33pt | 41.5pt, воздух по бокам |

## Решение

Убраны `menuStyle`, `fixedSize` и ручной шеврон — размер и индикатор раскрытия отдаются самому тулбару:

- хрома подстраивается под содержимое (41.5pt в icon-only состоянии);
- шеврон рисует система, поэтому свой пришлось убрать — иначе их было бы два (проверено на экране);
- `fixedSize` больше не нужен: тулбар раскладывает лейбл целиком, включая длинные `проект — ветка` для воркtree-окон;
- контрол приглушается вместе с соседями и заголовком в неактивном окне — раньше он оставался белым.

Padding не помогает и в PR его нет: внутри лейбла borderless-контрол его игнорирует (замеры 0/6/8/10pt дали одинаковые 33pt), снаружи меню он растягивает капсулу за пределы самого контрола.

## Проверка

- Собран Debug-билд, окно снято с экрана и замерено по пикселям: 33pt → 41.5pt при 35pt у соседних кнопок.
- Прогоны с вариантами (borderless+padding, стандартная хрома, двойной шеврон, длинные лейблы) сравнивались в одном тулбаре.
- `swiftlint` — чисто, `PineTests/MenuIconTests` — зелёные, `build-for-testing` для UI-таргета проходит.
- Локальный прогон UI-тестов недоступен (нет TCC-разрешения на UI-автоматизацию), новый тест `testProjectSwitcherIsWiderThanSingleGlyphToolbarButtons` впервые исполнится на CI.

## Тесты

- `PineUITests/EditorWindowTests`: новый тест сравнивает ширину переключателя с однокнопочным соседом — относительное утверждение, а не зашитая метрика, так как она зависит от версии macOS и масштаба экрана.
- `PineTests/MenuIconTests`: удалена строка для `projectSwitcherDisclosure` вместе с самой константой.