### PR TITLE
fix: tell same-named projects apart in the switcher

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -70,9 +70,7 @@ struct ContentView: View {
     var windowChrome: WindowChromePresentation {
         WindowChromePresentation(
             activeFileName: activeTab?.fileName,
-            repositoryName: projectWindowSession
-                .activeRepositoryURL
-                .lastPathComponent,
+            repositoryName: projectWindowSession.activeProjectDisplayName,
             switcherLabel: projectWindowSession.activeDisplayName
         )
     }

--- a/Pine/ProjectDisplayNames.swift
+++ b/Pine/ProjectDisplayNames.swift
@@ -1,0 +1,111 @@
+//
+//  ProjectDisplayNames.swift
+//  Pine
+//
+//  Telling apart project roots that share a folder name.
+//
+
+import Foundation
+
+/// Names for a set of project roots, each shortened to the fewest trailing
+/// path components that still tell it apart from every other root in the set.
+///
+/// A folder name alone stops identifying a project the moment one window holds
+/// two of them: `project1/infra` and `project2/infra` both reach the switcher
+/// as `infra`, and picking one becomes guesswork. Spelling out whole paths
+/// fixes that and costs far more than it buys — the common prefix repeats on
+/// every row, crowding out the one component that actually differs.
+///
+/// So each root grows only as far as it has to. A name nothing collides with
+/// stays a bare folder name; colliding names take one parent at a time until
+/// they read differently. In a window holding `pine`, `project1/infra`,
+/// `project2/infra` and `project1/backend`, only the two `infra` roots carry a
+/// parent — `pine` and `backend` are already unambiguous and stay short.
+///
+/// A root that runs out of components without separating — it is the ancestor
+/// of another entry, so every component it has is shared — falls back to its
+/// absolute path, which is both unambiguous and visibly different in kind.
+nonisolated enum ProjectDisplayNames {
+    /// Separator between path components. Not localized: it is filesystem
+    /// syntax, and the strings it joins are literal directory names.
+    private static let separator = "/"
+
+    /// Shown when a URL has no nameable component — the filesystem root.
+    private static let rootName = "/"
+
+    /// Display names keyed by the standardized form of each input URL.
+    ///
+    /// Look results up with ``URL/standardizedFileURL``; callers holding
+    /// already-standardized URLs — the window session stores them that way —
+    /// can subscript directly.
+    static func resolve(for urls: [URL]) -> [URL: String] {
+        var components: [URL: [String]] = [:]
+        var depths: [URL: Int] = [:]
+        for url in urls {
+            let standardized = url.standardizedFileURL
+            components[standardized] = nameableComponents(of: standardized)
+            depths[standardized] = 1
+        }
+
+        // Grow every colliding root by one parent, then re-check: a parent can
+        // itself be shared, so `a/x/infra` versus `b/x/infra` only separates at
+        // the third component. Depth rises monotonically and is capped at the
+        // component count, so this terminates even for two identical entries,
+        // which can never separate.
+        var didGrow = true
+        while didGrow {
+            didGrow = false
+            var buckets: [String: [URL]] = [:]
+            for (url, depth) in depths {
+                // Bucketing on the rendered label, not on the components, is
+                // what makes canonically equivalent names collide: `String`
+                // equality is canonical, so a folder stored decomposed and one
+                // stored precomposed land in the same bucket — which is right,
+                // because they draw identically and are exactly the pair a
+                // reader could not tell apart.
+                buckets[label(components[url] ?? [], depth: depth), default: []]
+                    .append(url)
+            }
+            for bucket in buckets.values where bucket.count > 1 {
+                for url in bucket
+                where depths[url, default: 0] < (components[url]?.count ?? 0) {
+                    depths[url, default: 0] += 1
+                    didGrow = true
+                }
+            }
+        }
+
+        return depths.reduce(into: [:]) { result, entry in
+            result[entry.key] = label(
+                components[entry.key] ?? [],
+                depth: entry.value
+            )
+        }
+    }
+
+    /// Display name for one root among its peers. `url` need not appear in
+    /// `peers` — a root that is absent simply has nothing to collide with.
+    static func name(for url: URL, among peers: [URL]) -> String {
+        let standardized = url.standardizedFileURL
+        return resolve(for: peers + [standardized])[standardized]
+            ?? label(nameableComponents(of: standardized), depth: 1)
+    }
+
+    /// Path components that can carry a name. The leading `/` that
+    /// `pathComponents` reports for an absolute URL is punctuation rather than
+    /// a folder, and joining it back in would produce a doubled `//Users`.
+    private static func nameableComponents(of url: URL) -> [String] {
+        url.pathComponents.filter { $0 != separator }
+    }
+
+    private static func label(_ components: [String], depth: Int) -> String {
+        guard !components.isEmpty else { return rootName }
+        let clamped = min(max(depth, 1), components.count)
+        let joined = components.suffix(clamped).joined(separator: separator)
+        // At full depth the name *is* the path, so lead with the root slash: it
+        // reads as absolute rather than as a suspiciously long relative name,
+        // and it separates an ancestor from the descendant that shares every
+        // component it has.
+        return clamped == components.count ? separator + joined : joined
+    }
+}

--- a/Pine/ProjectSwitcherView.swift
+++ b/Pine/ProjectSwitcherView.swift
@@ -18,8 +18,12 @@ struct ProjectSwitcherView: View {
 
     var body: some View {
         Menu {
-            ForEach(Array(session.groups.enumerated()), id: \.element.id) { index, group in
-                if index > 0 {
+            let groups = session.groups
+            ForEach(Array(groups.enumerated()), id: \.element.id) { index, group in
+                if ProjectSwitcherMenuLayout.needsDivider(
+                    before: index,
+                    in: groups
+                ) {
                     Divider()
                 }
                 projectButton(group.projectURL)
@@ -110,7 +114,7 @@ struct ProjectSwitcherView: View {
             }
         } label: {
             Label {
-                Text(url.lastPathComponent)
+                Text(session.displayName(for: url))
             } icon: {
                 Image(systemName: session.activeProjectURL == url
                     ? MenuIcons.projectSwitcherActive
@@ -118,8 +122,12 @@ struct ProjectSwitcherView: View {
             }
         }
         .disabled(session.isLaunchingAgent)
+        // Identified by the disambiguated name, not the folder name: two roots
+        // called `infra` would otherwise answer to the same identifier, and
+        // both VoiceOver and XCUITest would only ever reach the first one.
+        // With no collision the two strings are identical, so this is stable.
         .accessibilityIdentifier(
-            AccessibilityID.projectSwitcherProject(url.lastPathComponent)
+            AccessibilityID.projectSwitcherProject(session.displayName(for: url))
         )
     }
 
@@ -149,6 +157,24 @@ struct ProjectSwitcherView: View {
         .accessibilityIdentifier(
             AccessibilityID.projectSwitcherWorktree(worktree.taskID)
         )
+    }
+}
+
+/// Where the switcher menu draws separators.
+///
+/// A divider earns its place by grouping something: a project and the agent
+/// worktrees hanging off it read as one block, and the rule separates that
+/// block from what surrounds it. Between two plain projects it groups nothing
+/// and only spreads four rows across four sections, which is why a window with
+/// no agent worktrees — the common case — now shows an unbroken list.
+nonisolated enum ProjectSwitcherMenuLayout {
+    static func needsDivider(
+        before index: Int,
+        in groups: [ProjectWindowGroup]
+    ) -> Bool {
+        guard index > 0, index < groups.count else { return false }
+        return !groups[index].worktrees.isEmpty
+            || !groups[index - 1].worktrees.isEmpty
     }
 }
 

--- a/Pine/ProjectWindowSession.swift
+++ b/Pine/ProjectWindowSession.swift
@@ -122,8 +122,29 @@ final class ProjectWindowSession {
             ?? activeProjectURL
     }
 
+    /// Display name per project root, each shortened to the least path that
+    /// still tells it apart from the others in this window. Two checkouts
+    /// named `infra` are ordinary in a monorepo-per-client layout, and the
+    /// switcher has to be readable in that case, not just in the easy one.
+    var projectDisplayNames: [URL: String] {
+        ProjectDisplayNames.resolve(for: projectURLs)
+    }
+
+    /// Name for one root of this window. A URL the window does not hold —
+    /// a worktree root, or a project already removed — keeps its folder name:
+    /// there is nothing here for it to collide with.
+    func displayName(for url: URL) -> String {
+        projectDisplayNames[url.standardizedFileURL] ?? url.lastPathComponent
+    }
+
+    /// The active repository alone, with no branch suffix. This is what the
+    /// window title falls back to when no file is open.
+    var activeProjectDisplayName: String {
+        displayName(for: activeRepositoryURL)
+    }
+
     var activeDisplayName: String {
-        let projectName = activeRepositoryURL.lastPathComponent
+        let projectName = activeProjectDisplayName
         guard let worktree = managedWorktrees[activeProjectURL] else {
             return projectName
         }

--- a/PineTests/ProjectDisplayNamesTests.swift
+++ b/PineTests/ProjectDisplayNamesTests.swift
@@ -1,0 +1,195 @@
+//
+//  ProjectDisplayNamesTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Project Display Names")
+struct ProjectDisplayNamesTests {
+    private func directory(_ path: String) -> URL {
+        URL(fileURLWithPath: path, isDirectory: true)
+    }
+
+    private func names(_ paths: [String]) -> [String: String] {
+        let urls = paths.map(directory)
+        let resolved = ProjectDisplayNames.resolve(for: urls)
+        return zip(paths, urls).reduce(into: [:]) { result, pair in
+            result[pair.0] = resolved[pair.1.standardizedFileURL]
+        }
+    }
+
+    @Test("a name nothing collides with stays a bare folder name")
+    func uniqueNamesStayShort() {
+        let resolved = names(["/Users/f/pine", "/Users/f/backend"])
+
+        #expect(resolved["/Users/f/pine"] == "pine")
+        #expect(resolved["/Users/f/backend"] == "backend")
+    }
+
+    @Test("colliding names take the nearest parent, and only that parent")
+    func collisionTakesOneParent() {
+        let resolved = names([
+            "/Users/f/project1/infra",
+            "/Users/f/project2/infra",
+        ])
+
+        #expect(resolved["/Users/f/project1/infra"] == "project1/infra")
+        #expect(resolved["/Users/f/project2/infra"] == "project2/infra")
+    }
+
+    @Test("a shared parent keeps growing until the names separate")
+    func sharedParentGrowsFurther() {
+        let resolved = names(["/a/x/infra", "/b/x/infra"])
+
+        // `x/infra` is still ambiguous, so both reach full depth — where the
+        // name is the whole path and is spelled as one.
+        #expect(resolved["/a/x/infra"] == "/a/x/infra")
+        #expect(resolved["/b/x/infra"] == "/b/x/infra")
+    }
+
+    @Test("only the colliding roots grow; their neighbours stay short")
+    func growthIsLocalToTheCollision() {
+        let resolved = names([
+            "/Users/f/pine",
+            "/Users/f/project1/infra",
+            "/Users/f/project2/infra",
+            "/Users/f/project1/backend",
+        ])
+
+        #expect(resolved["/Users/f/pine"] == "pine")
+        #expect(resolved["/Users/f/project1/infra"] == "project1/infra")
+        #expect(resolved["/Users/f/project2/infra"] == "project2/infra")
+        #expect(resolved["/Users/f/project1/backend"] == "backend")
+    }
+
+    @Test("the user's layout: four roots, two names, four readable rows")
+    func twoNamesAcrossTwoParents() {
+        let resolved = names([
+            "/Users/f/project1/infra",
+            "/Users/f/project2/infra",
+            "/Users/f/project1/backend",
+            "/Users/f/project2/backend",
+        ])
+
+        #expect(resolved["/Users/f/project1/infra"] == "project1/infra")
+        #expect(resolved["/Users/f/project2/infra"] == "project2/infra")
+        #expect(resolved["/Users/f/project1/backend"] == "project1/backend")
+        #expect(resolved["/Users/f/project2/backend"] == "project2/backend")
+    }
+
+    @Test("a root nested under its own sibling still separates")
+    func nestedSiblingSeparates() {
+        let resolved = names(["/Users/f/p", "/Users/f/p/p"])
+
+        #expect(resolved["/Users/f/p"] == "f/p")
+        #expect(resolved["/Users/f/p/p"] == "p/p")
+        #expect(resolved["/Users/f/p"] != resolved["/Users/f/p/p"])
+    }
+
+    @Test("a root directly under the filesystem root reads as absolute")
+    func topLevelRootIsAbsolute() {
+        let resolved = names(["/infra", "/Users/f/infra"])
+
+        // `/infra` has one component and cannot grow, so it is spelled as the
+        // absolute path it is — which also tells it apart from the other.
+        #expect(resolved["/infra"] == "/infra")
+        #expect(resolved["/Users/f/infra"] == "infra")
+    }
+
+    @Test("the filesystem root itself is still named")
+    func filesystemRootIsNamed() {
+        #expect(names(["/"])["/"] == "/")
+    }
+
+    @Test("an empty set resolves to no names")
+    func emptyInput() {
+        #expect(ProjectDisplayNames.resolve(for: []).isEmpty)
+    }
+
+    @Test("a repeated URL collapses instead of looping forever")
+    func repeatedURLTerminates() {
+        let url = directory("/Users/f/project1/infra")
+
+        let resolved = ProjectDisplayNames.resolve(for: [url, url, url])
+
+        #expect(resolved.count == 1)
+        #expect(resolved[url.standardizedFileURL] == "infra")
+    }
+
+    @Test("paths are standardized before they are compared")
+    func standardizesBeforeComparing() {
+        let messy = directory("/Users/f/project1/../project2/infra")
+        let plain = directory("/Users/f/project2/infra")
+
+        let resolved = ProjectDisplayNames.resolve(for: [messy, plain])
+
+        // The two spell the same directory, so this is one root, not a
+        // collision to disambiguate.
+        #expect(resolved.count == 1)
+        #expect(resolved[plain.standardizedFileURL] == "infra")
+    }
+
+    @Test("canonically equivalent Unicode names count as a collision")
+    func unicodeEquivalentNamesCollide() {
+        let composed = "\u{0439}"
+        let decomposed = "\u{0438}\u{0306}"
+        // Two different encodings of one glyph, which `String` equality — and
+        // therefore the bucketing — already treats as the same name.
+        #expect(composed.unicodeScalars.count != decomposed.unicodeScalars.count)
+
+        let resolved = names([
+            "/Users/f/project1/\(composed)",
+            "/Users/f/project2/\(decomposed)",
+        ])
+
+        // Identical on screen, so both must carry a parent — comparing the
+        // raw code units would have called them distinct and shown two
+        // indistinguishable rows.
+        #expect(
+            resolved["/Users/f/project1/\(composed)"]
+                == "project1/\(composed)"
+        )
+        #expect(
+            resolved["/Users/f/project2/\(decomposed)"]
+                == "project2/\(decomposed)"
+        )
+    }
+
+    @Test("many identically named roots all end up distinguishable")
+    func manyCollisionsAllSeparate() {
+        let paths = (0..<200).map { "/Users/f/client\($0)/infra" }
+
+        let resolved = names(paths)
+
+        #expect(resolved.count == paths.count)
+        let rendered = paths.compactMap { resolved[$0] }
+        #expect(rendered.count == paths.count)
+        #expect(Set(rendered).count == paths.count)
+        #expect(resolved["/Users/f/client7/infra"] == "client7/infra")
+    }
+
+    @Test("a root outside the peer set is named against it anyway")
+    func nameAmongPeers() {
+        let target = directory("/Users/f/project1/infra")
+
+        #expect(
+            ProjectDisplayNames.name(
+                for: target,
+                among: [directory("/Users/f/project2/infra")]
+            ) == "project1/infra"
+        )
+        #expect(
+            ProjectDisplayNames.name(for: target, among: []) == "infra"
+        )
+        #expect(
+            ProjectDisplayNames.name(
+                for: target,
+                among: [directory("/Users/f/pine")]
+            ) == "infra"
+        )
+    }
+}

--- a/PineTests/ProjectSwitcherMenuTests.swift
+++ b/PineTests/ProjectSwitcherMenuTests.swift
@@ -1,0 +1,196 @@
+//
+//  ProjectSwitcherMenuTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Project Switcher Menu Layout")
+struct ProjectSwitcherMenuLayoutTests {
+    private func group(
+        _ path: String,
+        worktrees: Int = 0
+    ) -> ProjectWindowGroup {
+        let root = URL(fileURLWithPath: path, isDirectory: true)
+        let proof = RecentAgentTaskRepositoryProof(
+            commonDirectoryDevice: 1,
+            commonDirectoryInode: 2,
+            commonDirectoryGeneration: 3,
+            commonDirectoryBirthSeconds: 4,
+            commonDirectoryBirthNanoseconds: 5
+        )
+        return ProjectWindowGroup(
+            projectURL: root,
+            worktrees: (0..<worktrees).map { index in
+                AgentManagedWorktree(
+                    taskID: UUID(),
+                    repositoryRoot: root,
+                    managedRoot: root.appendingPathComponent("managed"),
+                    worktreeRoot: root
+                        .appendingPathComponent("managed/\(index)"),
+                    branchName: "pine/agent/codex/\(index)",
+                    baseCommit: String(repeating: "a", count: 40),
+                    repositoryProof: proof
+                )
+            }
+        )
+    }
+
+    @Test("the first group never draws a leading divider")
+    func firstGroupHasNoDivider() {
+        let groups = [group("/a", worktrees: 2), group("/b", worktrees: 2)]
+
+        #expect(
+            ProjectSwitcherMenuLayout.needsDivider(before: 0, in: groups)
+                == false
+        )
+    }
+
+    @Test("plain projects run together with no dividers between them")
+    func plainProjectsAreNotSeparated() {
+        let groups = [group("/a"), group("/b"), group("/c"), group("/d")]
+
+        for index in groups.indices {
+            #expect(
+                ProjectSwitcherMenuLayout.needsDivider(
+                    before: index,
+                    in: groups
+                ) == false
+            )
+        }
+    }
+
+    @Test("a group with worktrees is fenced off on both sides")
+    func worktreeGroupIsFenced() {
+        let groups = [group("/a"), group("/b", worktrees: 1), group("/c")]
+
+        // Before the worktree group, because it is about to open a block.
+        #expect(ProjectSwitcherMenuLayout.needsDivider(before: 1, in: groups))
+        // And before what follows it, because that block just closed.
+        #expect(ProjectSwitcherMenuLayout.needsDivider(before: 2, in: groups))
+    }
+
+    @Test("adjacent worktree groups stay separated from each other")
+    func adjacentWorktreeGroupsAreSeparated() {
+        let groups = [
+            group("/a", worktrees: 1),
+            group("/b", worktrees: 3),
+        ]
+
+        #expect(ProjectSwitcherMenuLayout.needsDivider(before: 1, in: groups))
+    }
+
+    @Test("out-of-range indices ask for nothing")
+    func outOfRangeIndicesAreSafe() {
+        let groups = [group("/a", worktrees: 1), group("/b", worktrees: 1)]
+
+        #expect(
+            ProjectSwitcherMenuLayout.needsDivider(before: 2, in: groups)
+                == false
+        )
+        #expect(
+            ProjectSwitcherMenuLayout.needsDivider(before: 99, in: groups)
+                == false
+        )
+        #expect(
+            ProjectSwitcherMenuLayout.needsDivider(before: -1, in: groups)
+                == false
+        )
+        #expect(
+            ProjectSwitcherMenuLayout.needsDivider(before: 0, in: [])
+                == false
+        )
+    }
+}
+
+@Suite("Project Switcher Naming", .serialized)
+@MainActor
+struct ProjectSwitcherNamingTests {
+    private static let noOpProcessRunner: ProcessRunner = { _, _, _, _ in
+        ProcessRunResult(
+            stdout: "",
+            stderr: "",
+            exitCode: 0,
+            timedOut: false
+        )
+    }
+
+    @Test("two same-named checkouts in one window read differently")
+    func sameNamedProjectsAreDistinguishable() async throws {
+        // Resolve `/var` → `/private/var` up front: `openProject` canonicalizes
+        // through `resolvingSymlinksInPath`, and the session would then key its
+        // names by paths the test never mentions.
+        let root = FileManager.default.temporaryDirectory
+            .resolvingSymlinksInPath()
+            .appendingPathComponent(
+                "Pine-SwitcherNaming-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        let first = root.appendingPathComponent(
+            "project1/infra",
+            isDirectory: true
+        )
+        let second = root.appendingPathComponent(
+            "project2/infra",
+            isDirectory: true
+        )
+        let solo = root.appendingPathComponent(
+            "project1/backend",
+            isDirectory: true
+        )
+        for url in [first, second, solo] {
+            try FileManager.default.createDirectory(
+                at: url,
+                withIntermediateDirectories: true
+            )
+        }
+        let suiteName = "ProjectSwitcherNamingTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+            try? FileManager.default.removeItem(at: root)
+        }
+        let registry = ProjectRegistry(
+            defaults: defaults,
+            agentDetectionProcessRunner: Self.noOpProcessRunner,
+            agentDetectionPollInterval: 3_600,
+            backgroundReclamationInterval: .seconds(3_600)
+        )
+
+        let session = ProjectWindowSession(
+            initialProjectURL: first,
+            defaults: defaults
+        )
+
+        // One project in the window: nothing to disambiguate against.
+        #expect(session.displayName(for: first) == "infra")
+        #expect(session.activeProjectDisplayName == "infra")
+
+        await session.openProject(second, registry: registry)
+        await session.openProject(solo, registry: registry)
+
+        #expect(session.displayName(for: first) == "project1/infra")
+        #expect(session.displayName(for: second) == "project2/infra")
+        // The uncontested name stays short even while its neighbours grow.
+        #expect(session.displayName(for: solo) == "backend")
+        // The title bar follows the switcher, so the window is identifiable in
+        // the Window menu and Mission Control too.
+        #expect(session.activeProjectDisplayName == "backend")
+
+        await session.activate(second, registry: registry)
+
+        #expect(session.activeProjectDisplayName == "project2/infra")
+        #expect(session.activeDisplayName == "project2/infra")
+
+        // A URL this window does not hold has nothing to collide with.
+        #expect(
+            session.displayName(
+                for: root.appendingPathComponent("elsewhere/infra")
+            ) == "infra"
+        )
+    }
+}


### PR DESCRIPTION
## Problem

Two observations from daily use of 2.4.0's multi-project workspaces:

1. **Same-named projects are indistinguishable.** A `project1/infra` and a
   `project2/infra` both reach the switcher — and the title bar — as `infra`.
   With one repo layout per client this is the normal case, not an edge case,
   and picking the right row becomes guesswork.
2. **Dividers separate everything from everything.** The menu drew a rule
   between every pair of groups, so four plain projects rendered as four
   sections. The list read as far more spread out than it is.

## Change

`ProjectDisplayNames` shortens each project root to the fewest trailing path
components that still tell it apart from the others **in that window**:

| Window holds | Switcher shows |
|---|---|
| `pine`, `backend` | `pine`, `backend` |
| `project1/infra`, `project2/infra` | `project1/infra`, `project2/infra` |
| `project1/infra`, `project2/infra`, `project1/backend` | `project1/infra`, `project2/infra`, `backend` |

A name nothing collides with stays bare, so the common case does not get
noisier. Roots that share a parent keep growing until they separate; one that
runs out of components falls back to its absolute path.

The window title uses the same name (`activeProjectDisplayName`), so a window
stays identifiable in the Window menu and Mission Control. The accessibility
identifier follows too — two `infra` rows previously answered to the same
identifier, and VoiceOver and XCUITest could only ever reach the first.

`ProjectSwitcherMenuLayout.needsDivider` now draws a rule only where it
groups something: around a project that has agent worktrees. Between two
plain projects there is nothing to fence off.

## Tests

20 new tests, all passing:

- `ProjectDisplayNamesTests` — unique names stay short, collisions take one
  parent, shared parents keep growing, growth stays local to the collision,
  filesystem root, empty input, repeated URLs terminate instead of looping,
  paths standardize before comparison, canonically equivalent Unicode names
  collide, 200 same-named roots all separate.
- `ProjectSwitcherMenuLayoutTests` — first group, plain runs, fencing on both
  sides of a worktree group, adjacent worktree groups, out-of-range indices.
- `ProjectSwitcherNamingTests` — end-to-end through `ProjectWindowSession`:
  opening a second `infra` renames both, the uncontested neighbour stays
  short, and the title bar follows.

## Verification

Built and run with a window holding `project1/infra` and `project2/infra`:
the toolbar reads `project2/infra`.
