### PR TITLE
fix: route Inbox tasks into the window that already holds the project

### DIFF
--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -572,8 +572,12 @@ extension ContentView {
     /// tree whose initial load may have been cancelled just before activation.
     func reconcileKeyProjectPresentation() {
         let wasSuspended = workspace.isSuspended
-        guard controlActiveState == .key,
-              registry.reconcileKeyProjectPresentation(projectManager) else {
+        guard controlActiveState == .key else { return }
+        // Becoming key is what makes this the window a user means by "here",
+        // and it is the signal a project with no window of its own is routed
+        // by. Record it whether or not the reconcile below finds work.
+        registry.noteKeyWindowSession(projectWindowSession)
+        guard registry.reconcileKeyProjectPresentation(projectManager) else {
             return
         }
         if !wasSuspended,

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -194,7 +194,14 @@ private struct ProjectWindowView: View {
             }
         }
         .task {
+            // Announce the window before restoring it: routing that arrives
+            // mid-restore should still find this window rather than open a
+            // second one for a project this window is about to show.
+            registry.registerWindowSession(windowSession)
             await windowSession.restoreIfNeeded(registry: registry)
+        }
+        .onDisappear {
+            registry.unregisterWindowSession(windowSession)
         }
         .alert(
             Strings.projectSwitcherErrorTitle,

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -1123,6 +1123,26 @@ final class ProjectRegistry: LSPSettingsObserver {
     @ObservationIgnored
     weak var quickTerminalAgentRouter: (any QuickTerminalAgentRouting)?
 
+    /// Live window sessions, weakly held. A window session belongs to its
+    /// SwiftUI scene and dies with it; the registry only needs to be able to
+    /// ask "which window already holds this project?", and a strong reference
+    /// here would keep closed windows answering that question forever.
+    ///
+    /// Released entries are compacted on every read, so a missed
+    /// ``unregisterWindowSession(_:)`` costs one empty box, not a leak.
+    @ObservationIgnored
+    private var windowSessionRefs: [WeakWindowSession] = []
+
+    /// The window session that most recently became key. This is the window a
+    /// user means by "here" — where a project with no window of its own should
+    /// open rather than in a new window.
+    @ObservationIgnored
+    private weak var keyWindowSessionRef: ProjectWindowSession?
+
+    private struct WeakWindowSession {
+        weak var session: ProjectWindowSession?
+    }
+
     private static let recentProjectsKey = "recentProjectPaths"
     private static let recentProjectAgentIdentitiesKey =
         "recentProjectAgentTaskIdentities"
@@ -2649,12 +2669,12 @@ final class ProjectRegistry: LSPSettingsObserver {
             // A previously unknown durable project is admitted by lookup but
             // still has no window. Keep that new manager transactional too.
             manager.prepareForWindowPresentation()
-            closeProjectWindow(
+            guard await routeToWindow(
                 projectURL,
-                expectedManager: manager,
-                expectedWindowGeneration: nil
-            )
-            openProjectWindow(projectURL)
+                task: task,
+                manager: manager,
+                openProjectWindow: openProjectWindow
+            ) else { return nil }
         }
         let presentationReported: Bool
         if let waitUntilPresented {
@@ -2703,6 +2723,84 @@ final class ProjectRegistry: LSPSettingsObserver {
         )
         transfersAuthorization = true
         return authorization
+    }
+
+    /// Puts one Inbox project on screen, and reports whether the caller's
+    /// transaction survived doing so.
+    ///
+    /// Multi-project windows are why this is not a bare `openProjectWindow`.
+    /// A project sitting behind its neighbour in an existing window is
+    /// suspended, so `isWindowOpen` reports no window at all and the direct
+    /// path opens a second one — the Inbox spawning windows for projects that
+    /// were open the whole time. Ask the windows first: whichever one owns the
+    /// project switches to it, and opening its *scene* URL raises that window
+    /// instead of creating another.
+    ///
+    /// A project no window owns goes to the key window, for the same reason a
+    /// user opened several projects in one window to begin with. Only when
+    /// there is no window at all does this fall back to opening one.
+    private func routeToWindow(
+        _ projectURL: URL,
+        task: AgentTask,
+        manager: ProjectManager,
+        openProjectWindow: @escaping @MainActor (URL) -> Void
+    ) async -> Bool {
+        if let session = windowSession(owning: projectURL) {
+            await session.activate(projectURL, registry: self)
+            guard agentInboxTransactionHolds(
+                projectURL,
+                task: task,
+                manager: manager
+            ) else { return false }
+            openProjectWindow(session.sceneProjectURL)
+            return true
+        }
+
+        if let session = keyWindowSession() {
+            await session.openProject(
+                projectURL,
+                registry: self,
+                allowAlreadyOpenTarget: true
+            )
+            guard agentInboxTransactionHolds(
+                projectURL,
+                task: task,
+                manager: manager
+            ) else { return false }
+            // The window can refuse — the directory may have gone missing
+            // between admission and here, and the session drops targets it
+            // cannot activate. Only claim the window if it took the project.
+            if session.contains(canonicalProjectURL(projectURL)) {
+                openProjectWindow(session.sceneProjectURL)
+                return true
+            }
+        }
+
+        closeProjectWindow(
+            projectURL,
+            expectedManager: manager,
+            expectedWindowGeneration: nil
+        )
+        openProjectWindow(projectURL)
+        return true
+    }
+
+    /// What must still hold after routing suspends: the project binding and
+    /// the manager this presentation authorized are the ones in effect.
+    ///
+    /// Deliberately not the task value. Presenting a project marks its window
+    /// open, which rewrites the very task being routed to — comparing against
+    /// the pre-presentation snapshot would reject every success. Task freshness
+    /// is re-established by the caller after presentation, against the route it
+    /// is about to focus.
+    private func agentInboxTransactionHolds(
+        _ projectURL: URL,
+        task: AgentTask,
+        manager: ProjectManager
+    ) -> Bool {
+        !Task.isCancelled
+            && openProjects[projectURL] === manager
+            && agentTaskProjectsByRoot[projectURL] == task.project
     }
 
     private func presentationIsCurrent(
@@ -3137,6 +3235,64 @@ final class ProjectRegistry: LSPSettingsObserver {
     func isWindowOpen(_ url: URL) -> Bool {
         let canonical = canonicalProjectURL(url)
         return openProjects[canonical] != nil && !backgroundProjects.contains(canonical)
+    }
+
+    // MARK: - Window sessions
+
+    /// Announces a window session while its scene is alive. Idempotent: SwiftUI
+    /// re-runs a scene's task on restoration, and the same session must not be
+    /// counted twice.
+    func registerWindowSession(_ session: ProjectWindowSession) {
+        compactWindowSessions()
+        guard !windowSessionRefs.contains(where: { $0.session === session })
+        else { return }
+        windowSessionRefs.append(WeakWindowSession(session: session))
+    }
+
+    func unregisterWindowSession(_ session: ProjectWindowSession) {
+        windowSessionRefs.removeAll {
+            $0.session == nil || $0.session === session
+        }
+        if keyWindowSessionRef === session {
+            keyWindowSessionRef = nil
+        }
+    }
+
+    /// Records the window the user is looking at. Called when a project scene
+    /// becomes key, which is the only evidence of "current window" that does
+    /// not depend on AppKit window ordering being settled.
+    func noteKeyWindowSession(_ session: ProjectWindowSession) {
+        registerWindowSession(session)
+        keyWindowSessionRef = session
+    }
+
+    /// The window holding `url`, if any — including as an agent worktree.
+    ///
+    /// A project belongs to at most one window: ``ProjectWindowSession``
+    /// refuses to open a project another window already shows, so the first
+    /// match is the only match.
+    func windowSession(owning url: URL) -> ProjectWindowSession? {
+        let canonical = canonicalProjectURL(url)
+        compactWindowSessions()
+        return windowSessionRefs.lazy
+            .compactMap(\.session)
+            .first { $0.contains(canonical) }
+    }
+
+    /// The window a project with no window of its own should open into.
+    ///
+    /// Falls back to the most recently registered live session when nothing
+    /// has been key yet — at launch the first window may be routed to before
+    /// it ever reports key, and putting the project there still beats opening
+    /// a second window.
+    func keyWindowSession() -> ProjectWindowSession? {
+        compactWindowSessions()
+        if let keyWindowSessionRef { return keyWindowSessionRef }
+        return windowSessionRefs.last?.session
+    }
+
+    private func compactWindowSessions() {
+        windowSessionRefs.removeAll { $0.session == nil }
     }
 
     /// Repairs a retained manager when AppKit makes its SwiftUI project scene

--- a/Pine/ProjectWindowSession.swift
+++ b/Pine/ProjectWindowSession.swift
@@ -117,6 +117,26 @@ final class ProjectWindowSession {
         }
     }
 
+    /// Whether this window holds `url` — as one of its projects, or as an
+    /// agent worktree hanging off one. Callers routing to a project (the Agent
+    /// Inbox, a notification) ask this to find the window that already owns it
+    /// instead of opening a second one.
+    ///
+    /// Expects an already-canonical URL: the window stores standardized paths,
+    /// and resolving symlinks here would suspend a synchronous lookup.
+    func contains(_ url: URL) -> Bool {
+        let target = url.standardizedFileURL
+        return projectURLs.contains(target) || managedWorktrees[target] != nil
+    }
+
+    #if DEBUG
+    /// Seeds a managed worktree without running the real create/launch path,
+    /// so membership lookups can be tested without a git repository.
+    func adoptWorktreeForTesting(_ worktree: AgentManagedWorktree) {
+        managedWorktrees[worktree.worktreeRoot.standardizedFileURL] = worktree
+    }
+    #endif
+
     var activeRepositoryURL: URL {
         managedWorktrees[activeProjectURL]?.repositoryRoot
             ?? activeProjectURL

--- a/PineTests/AgentInboxWindowRoutingTests.swift
+++ b/PineTests/AgentInboxWindowRoutingTests.swift
@@ -1,0 +1,457 @@
+//
+//  AgentInboxWindowRoutingTests.swift
+//  PineTests
+//
+//  Routing an Inbox task into the window that already holds its project.
+//
+
+import AppKit
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Window session registry", .serialized)
+@MainActor
+struct WindowSessionRegistryTests {
+    @Test("a window is found by any project it holds")
+    func findsOwningWindow() throws {
+        let fixture = try RoutingFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        let session = fixture.makeSession(initial: fixture.projectA)
+
+        registry.registerWindowSession(session)
+
+        #expect(registry.windowSession(owning: fixture.projectA) === session)
+        #expect(registry.windowSession(owning: fixture.projectB) == nil)
+    }
+
+    @Test("registration is idempotent and reversible")
+    func registrationLifecycle() throws {
+        let fixture = try RoutingFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        let session = fixture.makeSession(initial: fixture.projectA)
+
+        registry.registerWindowSession(session)
+        registry.registerWindowSession(session)
+        #expect(registry.windowSession(owning: fixture.projectA) === session)
+
+        registry.unregisterWindowSession(session)
+        #expect(registry.windowSession(owning: fixture.projectA) == nil)
+        #expect(registry.keyWindowSession() == nil)
+    }
+
+    @Test("a released window stops answering for its projects")
+    func releasedWindowDisappears() throws {
+        let fixture = try RoutingFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+
+        do {
+            let session = fixture.makeSession(initial: fixture.projectA)
+            registry.noteKeyWindowSession(session)
+            #expect(registry.keyWindowSession() === session)
+        }
+
+        // The registry holds windows weakly: a closed window that never
+        // unregistered must not keep claiming projects, or routing would send
+        // a task to a window nobody can see.
+        #expect(registry.windowSession(owning: fixture.projectA) == nil)
+        #expect(registry.keyWindowSession() == nil)
+    }
+
+    @Test("the key window is the one that most recently became key")
+    func keyWindowTracksActivation() throws {
+        let fixture = try RoutingFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        let first = fixture.makeSession(initial: fixture.projectA)
+        let second = fixture.makeSession(initial: fixture.projectB)
+
+        registry.registerWindowSession(first)
+        registry.registerWindowSession(second)
+        // Nothing has been key yet, so the newest window is the best guess.
+        #expect(registry.keyWindowSession() === second)
+
+        registry.noteKeyWindowSession(first)
+        #expect(registry.keyWindowSession() === first)
+
+        registry.unregisterWindowSession(first)
+        #expect(registry.keyWindowSession() === second)
+    }
+
+    @Test("an agent worktree is found through the window that hosts it")
+    func findsWorktreeOwner() throws {
+        let fixture = try RoutingFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        let session = fixture.makeSession(initial: fixture.projectA)
+        let worktreeRoot = fixture.root
+            .appendingPathComponent("managed/agent", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: worktreeRoot,
+            withIntermediateDirectories: true
+        )
+        session.adoptWorktreeForTesting(fixture.makeWorktree(
+            repositoryRoot: fixture.projectA,
+            worktreeRoot: worktreeRoot
+        ))
+        registry.registerWindowSession(session)
+
+        // An Inbox task points at the worktree it runs in, never at the
+        // repository root, so membership has to cover both.
+        #expect(registry.windowSession(owning: worktreeRoot) === session)
+    }
+
+    @Test("a path is matched through symlinks, not by spelling")
+    func matchesCanonicalPaths() throws {
+        let fixture = try RoutingFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        let session = fixture.makeSession(initial: fixture.projectA)
+        registry.registerWindowSession(session)
+
+        let messy = fixture.root
+            .appendingPathComponent("projectB", isDirectory: true)
+            .appendingPathComponent("../projectA", isDirectory: true)
+
+        #expect(registry.windowSession(owning: messy) === session)
+    }
+}
+
+@Suite("Agent inbox window routing", .serialized)
+@MainActor
+struct AgentInboxWindowRoutingTests {
+    @Test("a project sitting behind its neighbour reuses its own window")
+    func backgroundProjectReusesItsWindow() async throws {
+        let fixture = try RoutingFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        let session = fixture.makeSession(initial: fixture.projectA)
+        registry.registerWindowSession(session)
+
+        // Window holds A and B, and ends up showing A — so B is suspended,
+        // which is exactly the state that used to read as "this project has
+        // no window" and opened a second one. The task is staged while B is
+        // still active, because looking a project up reopens it.
+        await session.openProject(fixture.projectB, registry: registry)
+        let task = try fixture.stageAgentTask(
+            in: fixture.projectB,
+            registry: registry,
+            seed: 70
+        )
+        await session.activate(fixture.projectA, registry: registry)
+        let canonicalB = registry.canonicalProjectURL(fixture.projectB)
+        #expect(registry.backgroundProjects.contains(canonicalB))
+
+        var opened: [URL] = []
+        let result = await registry.navigateToAgentTaskFromInbox(
+            task.taskID,
+            openProjectWindow: { opened.append($0) },
+            waitUntilPresented: { fixture.present($0) },
+            activateApplication: { _ in }
+        )
+
+        #expect(result == .focused(task.route))
+        // The window was raised by its scene identity, and no window was
+        // asked for the project itself.
+        #expect(opened == [session.sceneProjectURL])
+        #expect(session.activeProjectURL == canonicalB)
+        #expect(!registry.backgroundProjects.contains(canonicalB))
+    }
+
+    @Test("a project no window holds lands in the key window")
+    func unheldProjectJoinsKeyWindow() async throws {
+        let fixture = try RoutingFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        let session = fixture.makeSession(initial: fixture.projectA)
+        registry.noteKeyWindowSession(session)
+
+        let task = try fixture.stageAgentTask(
+            in: fixture.projectB,
+            registry: registry,
+            seed: 71
+        )
+        let canonicalB = registry.canonicalProjectURL(fixture.projectB)
+        registry.closeProjectWindow(canonicalB)
+        #expect(session.contains(canonicalB) == false)
+
+        var opened: [URL] = []
+        let result = await registry.navigateToAgentTaskFromInbox(
+            task.taskID,
+            openProjectWindow: { opened.append($0) },
+            waitUntilPresented: { fixture.present($0) },
+            activateApplication: { _ in }
+        )
+
+        #expect(result == .focused(task.route))
+        #expect(opened == [session.sceneProjectURL])
+        #expect(session.contains(canonicalB))
+        #expect(session.activeProjectURL == canonicalB)
+    }
+
+    @Test("with no window at all, the project still gets one")
+    func noWindowsFallsBackToOpening() async throws {
+        let fixture = try RoutingFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+
+        let task = try fixture.stageAgentTask(
+            in: fixture.projectB,
+            registry: registry,
+            seed: 72
+        )
+        let canonicalB = registry.canonicalProjectURL(fixture.projectB)
+        registry.closeProjectWindow(canonicalB)
+
+        var opened: [URL] = []
+        let result = await registry.navigateToAgentTaskFromInbox(
+            task.taskID,
+            openProjectWindow: { opened.append($0) },
+            waitUntilPresented: { fixture.present($0) },
+            activateApplication: { _ in }
+        )
+
+        #expect(
+            result == .focused(task.route),
+            "actual: \(String(describing: result)) route: \(task.route)"
+        )
+        // Nothing to route into, so this is the pre-existing behaviour: a
+        // window for the project itself.
+        #expect(opened == [canonicalB])
+    }
+
+    @Test("a released window does not capture the routing")
+    func releasedWindowIsNotUsed() async throws {
+        let fixture = try RoutingFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        do {
+            let session = fixture.makeSession(initial: fixture.projectA)
+            registry.noteKeyWindowSession(session)
+        }
+
+        let task = try fixture.stageAgentTask(
+            in: fixture.projectB,
+            registry: registry,
+            seed: 73
+        )
+        let canonicalB = registry.canonicalProjectURL(fixture.projectB)
+        registry.closeProjectWindow(canonicalB)
+
+        var opened: [URL] = []
+        let result = await registry.navigateToAgentTaskFromInbox(
+            task.taskID,
+            openProjectWindow: { opened.append($0) },
+            waitUntilPresented: { fixture.present($0) },
+            activateApplication: { _ in }
+        )
+
+        #expect(result == .focused(task.route))
+        #expect(opened == [canonicalB])
+    }
+
+    @Test("a task that dies during presentation is not focused")
+    func staleTaskDuringPresentationIsRejected() async throws {
+        let fixture = try RoutingFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        let session = fixture.makeSession(initial: fixture.projectA)
+        registry.registerWindowSession(session)
+        await session.openProject(fixture.projectB, registry: registry)
+        let task = try fixture.stageAgentTask(
+            in: fixture.projectB,
+            registry: registry,
+            seed: 74
+        )
+        await session.activate(fixture.projectA, registry: registry)
+
+        let result = await registry.navigateToAgentTaskFromInbox(
+            task.taskID,
+            openProjectWindow: { _ in },
+            waitUntilPresented: { manager in
+                // The run ends while the window is being presented. Routing
+                // must not focus a terminal whose agent is already gone —
+                // even though the window itself came up fine.
+                task.session.applyLiveness(.terminated)
+                return fixture.present(manager)
+            },
+            activateApplication: { _ in }
+        )
+
+        #expect(result == .routeStale)
+    }
+}
+
+// MARK: - Fixture
+
+@MainActor
+private final class RoutingFixture {
+    let root: URL
+    let projectA: URL
+    let projectB: URL
+    private let suiteName: String
+    private let defaults: UserDefaults
+    private var windows: [NSWindow] = []
+    private var boundWindows: [(ProjectManager, NSWindow)] = []
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory
+            .resolvingSymlinksInPath()
+            .appendingPathComponent(
+                "PineInboxRouting-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        projectA = root.appendingPathComponent("projectA", isDirectory: true)
+        projectB = root.appendingPathComponent("projectB", isDirectory: true)
+        for url in [projectA, projectB] {
+            try FileManager.default.createDirectory(
+                at: url,
+                withIntermediateDirectories: true
+            )
+        }
+        suiteName = "AgentInboxWindowRoutingTests.\(UUID().uuidString)"
+        defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    func makeRegistry() -> ProjectRegistry {
+        ProjectRegistry(
+            defaults: defaults,
+            agentTasks: AgentTaskRegistry(
+                accuracyPolicy: AgentLifecycleAccuracyPolicy { _ in
+                    .verifiedLifecycleTransitions
+                }
+            ),
+            // No `ps` polling: these tests are about routing, and the real
+            // detector would fork on every pass for nothing.
+            agentDetectionProcessRunner: { _, _, _, _ in
+                ProcessRunResult(
+                    stdout: "",
+                    stderr: "",
+                    exitCode: 0,
+                    timedOut: false
+                )
+            },
+            agentDetectionPollInterval: 3_600,
+            agentDetectionInitialPollDelay: 3_600
+        )
+    }
+
+    func makeSession(initial: URL) -> ProjectWindowSession {
+        ProjectWindowSession(
+            initialProjectURL: initial,
+            defaults: defaults
+        )
+    }
+
+    func makeWorktree(
+        repositoryRoot: URL,
+        worktreeRoot: URL
+    ) -> AgentManagedWorktree {
+        AgentManagedWorktree(
+            taskID: UUID(),
+            repositoryRoot: repositoryRoot.standardizedFileURL,
+            managedRoot: worktreeRoot.deletingLastPathComponent(),
+            worktreeRoot: worktreeRoot.standardizedFileURL,
+            branchName: "pine/agent/codex/routing",
+            baseCommit: String(repeating: "a", count: 40),
+            repositoryProof: RecentAgentTaskRepositoryProof(
+                commonDirectoryDevice: 1,
+                commonDirectoryInode: 2,
+                commonDirectoryGeneration: 3,
+                commonDirectoryBirthSeconds: 4,
+                commonDirectoryBirthNanoseconds: 5
+            )
+        )
+    }
+
+    /// Puts a live, unread agent task in `project` and binds an eligible
+    /// window to its manager, which is what the presentation path requires
+    /// before it will hand back a route.
+    func stageAgentTask(
+        in project: URL,
+        registry: ProjectRegistry,
+        seed: Int
+    ) throws -> StagedTask {
+        let manager = try #require(registry.projectManager(for: project))
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: project
+        )
+        let state = try #require(manager.paneManager.terminalState(for: pane))
+        let tab = try #require(state.terminalTabs.first)
+        let session = AgentSession(
+            agentType: .codex,
+            state: .waitingInput,
+            lifecycleAccuracy: .verifiedLifecycleTransitions,
+            startedAt: Date(timeIntervalSince1970: TimeInterval(seed))
+        )
+        _ = session.bindProcessEvidence(AgentProcessEvidence(
+            processIdentifier: Int32(1_000 + seed),
+            processGeneration: UInt64(seed),
+            startIdentifier: "routing-session-\(seed)",
+            observedStartedAt: Date(timeIntervalSince1970: TimeInterval(seed)),
+            startIsAuthoritative: true
+        ))
+        manager.terminal.bridgeAgentSession(session, replacing: nil, in: tab)
+        tab.agentSession = session
+        let taskID = try #require(
+            registry.agentTasks.taskID(forSessionID: session.id)
+        )
+        return StagedTask(
+            taskID: taskID,
+            session: session,
+            route: AgentTaskRoute(
+                paneID: pane.id,
+                tabID: tab.id,
+                terminalID: tab.id
+            )
+        )
+    }
+
+    /// Stands in for the window a presented project acquires. Binding has to
+    /// happen here rather than up front: suspending a project drops its dialog
+    /// owner, so a window bound before the project went to the background is
+    /// gone by the time presentation is checked.
+    func present(_ manager: ProjectManager) -> Bool {
+        let window = makeEligibleWindow()
+        manager.bindDialogOwnerWindow(window)
+        boundWindows.append((manager, window))
+        return true
+    }
+
+    private func makeEligibleWindow() -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 480),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = NSView(
+            frame: window.contentRect(forFrameRect: window.frame)
+        )
+        window.makeKeyAndOrderFront(nil)
+        windows.append(window)
+        return window
+    }
+
+    func cleanup() {
+        for (manager, window) in boundWindows {
+            manager.unbindDialogOwnerWindow(window)
+        }
+        boundWindows.removeAll()
+        for window in windows { window.orderOut(nil) }
+        windows.removeAll()
+        defaults.removePersistentDomain(forName: suiteName)
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    struct StagedTask {
+        let taskID: UUID
+        let session: AgentSession
+        let route: AgentTaskRoute
+    }
+}


### PR DESCRIPTION
## Problem

Reported from daily use of 2.4.0: opening an agent Inbox entry and clicking
the project opens a **new window**, even when that project is already open —
which undoes the whole point of multi-project windows.

Two causes:

1. `isWindowOpen` (`Pine/ProjectRegistry.swift`) requires the project **not**
   to be in `backgroundProjects`. A project sitting behind its neighbour in a
   multi-project window is suspended and therefore always in that set, so
   `requiresPresentation` reads as "this project has no window" and the path
   asks SwiftUI for a scene keyed by the project URL. No such scene exists →
   a new window.
2. Nothing could answer *which window holds this project*. `ProjectWindowSession`
   lives in `@State` inside the scene and was never announced anywhere.

## Change

**Window session registry.** `ProjectRegistry` now tracks live sessions weakly
(`registerWindowSession` / `unregisterWindowSession` / `noteKeyWindowSession`),
compacting released entries on every read, so a missed unregister costs an
empty box rather than a window that keeps claiming projects forever. Two
lookups sit on top: `windowSession(owning:)` (checks both `projectURLs` and
`managedWorktrees`, since an agent task points at its worktree, not the repo
root) and `keyWindowSession()`.

**Routing.** `routeToWindow` replaces the unconditional `openProjectWindow`:

| Situation | Behaviour |
|---|---|
| A window holds the project | That window switches to it and is raised by its **scene** URL |
| No window holds it | It joins the key window |
| No windows at all | Unchanged — a window is opened for the project |

Raising by `session.sceneProjectURL` is what makes this work without new API:
that value already keys an existing scene, so SwiftUI raises it instead of
creating one.

Recovery (`recoverAgentTaskFromInbox`) and agent notification clicks share this
path and are fixed with it. CLI and Open Recent are untouched — there "new
window" is what was explicitly asked for.

**Invariant note.** The post-suspension check deliberately omits the task
value: presenting a project marks its window open, which rewrites the very
task being routed to, so comparing against the pre-presentation snapshot would
reject every success. Task freshness is re-established afterwards by
`navigateToAgentTaskFromInbox` against the route it is about to focus. (This
was a real bug during development — the first version of the check rejected
its own successful routing.)

## Tests

11 new tests, all passing.

`WindowSessionRegistryTests` — lookup by any held project, idempotent
registration, unregister, released windows dropping out, key-window tracking
with fallback, agent worktree membership, symlink/`..` canonicalization.

`AgentInboxWindowRoutingTests` — end-to-end through `navigateToAgentTaskFromInbox`:

- project suspended behind its neighbour → `openProjectWindow` receives the
  **scene** URL, the session switches to the project, and it leaves the
  background set
- project no window holds → joins the key window
- no windows → previous behaviour preserved
- released window → not used for routing
- run dies mid-presentation → `.routeStale`, not a focus

## Verification

- `swiftlint` clean.
- 121 tests across the affected suites (`AgentInboxTests`, `ProjectRegistryTests`,
  `ProjectWindowSessionTests`, `BackgroundProjectLifecycleTests`,
  `WindowLifecycleTests`) pass.
- The full `PineTests` run shows failures in `AgentInboxToolbarButtonSnapshotTests`
  (snapshot baselines are recorded on CI macOS 26; this machine is macOS 27) —
  these fail identically on unmodified `main`. Other full-run failures
  (`AgentAdapterRegistryTests` time limits, `TabTransferSafetyTests`,
  `ApplicationLifecycleProcessTests`) pass when run without the parallel load.
- App built and launched clean with the change in place.

**Not verified by hand:** the actual click-through in the running app. This
machine has no TCC automation rights, so the Inbox cannot be driven
programmatically, and the behaviour is covered by the integration tests above
rather than by eye.
