### PR TITLE
fix: restore project windows without duplicates

### DIFF
--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -148,6 +148,7 @@ private struct ProjectWindowView: View {
     let appDelegate: AppDelegate
     @State private var windowSession: ProjectWindowSession
     @Environment(\.openWindow) var openWindow
+    @Environment(\.dismissWindow) var dismissWindow
 
     init(
         projectURL: URL,
@@ -191,6 +192,13 @@ private struct ProjectWindowView: View {
                             windowSession: windowSession
                         )
                     }
+            } else {
+                // EmptyView does not enter the rendered hierarchy, so a task
+                // attached to an otherwise empty Group never gets a chance to
+                // admit a cold-restored project. Keep a real view mounted
+                // until restoration either supplies ContentView or fails.
+                ProgressView(Strings.progressLoadingProject)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
         .task {
@@ -198,7 +206,13 @@ private struct ProjectWindowView: View {
             // mid-restore should still find this window rather than open a
             // second one for a project this window is about to show.
             registry.registerWindowSession(windowSession)
-            await windowSession.restoreIfNeeded(registry: registry)
+            let result = await windowSession.restoreIfNeeded(
+                registry: registry
+            )
+            guard result == .unavailable else { return }
+            registry.unregisterWindowSession(windowSession)
+            dismissWindow(value: projectURL)
+            appDelegate.showWelcome()
         }
         .onDisappear {
             registry.unregisterWindowSession(windowSession)
@@ -1845,6 +1859,28 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
            ) {
             window.makeKeyAndOrderFront(nil)
             NSApp.activate()
+            hideWelcome()
+            return true
+        }
+
+        // A cold-restored multi-project scene can own this project before it
+        // has installed a CloseDelegate. Raise that scene by its stable anchor
+        // instead of opening the active project URL as a second WindowGroup
+        // value. Once activated, the restored scene observes the admitted
+        // manager and replaces its loading placeholder with ContentView.
+        if let windowSession = targetRegistry.windowSession(
+            owning: canonical
+        ) {
+            await windowSession.activate(
+                canonical,
+                registry: targetRegistry
+            )
+            guard windowSession.activeProjectURL == canonical,
+                  let openProjectWindow = self.openProjectWindow
+                    ?? fallbackOpenProjectWindow else {
+                return false
+            }
+            openProjectWindow(windowSession.sceneProjectURL)
             hideWelcome()
             return true
         }

--- a/Pine/ProjectWindowSession.swift
+++ b/Pine/ProjectWindowSession.swift
@@ -31,6 +31,12 @@ nonisolated struct ProjectWindowGroup: Identifiable, Equatable, Sendable {
     var id: URL { projectURL }
 }
 
+enum ProjectWindowRestorationResult: Equatable {
+    case restored
+    case unavailable
+    case alreadyRestored
+}
+
 @MainActor
 @Observable
 final class ProjectWindowSession {
@@ -124,6 +130,10 @@ final class ProjectWindowSession {
             projectURLs = [initial]
             managedWorktrees = [:]
             activeProjectURL = initial
+            // A restored SwiftUI WindowGroup scene starts with a fresh
+            // ProjectRegistry. Treat its scene value as restoration work even
+            // when this window never wrote multi-project state of its own.
+            pendingRestoredActiveURL = initial
         }
     }
 
@@ -230,12 +240,19 @@ final class ProjectWindowSession {
         }
     }
 
-    func restoreIfNeeded(registry: ProjectRegistry) async {
-        guard !didRestore else { return }
+    func restoreIfNeeded(
+        registry: ProjectRegistry
+    ) async -> ProjectWindowRestorationResult {
+        guard !didRestore else { return .alreadyRestored }
         didRestore = true
-        guard let target = pendingRestoredActiveURL else { return }
+        guard let target = pendingRestoredActiveURL else {
+            return .unavailable
+        }
         pendingRestoredActiveURL = nil
         await activate(target, registry: registry, reportFailure: false)
+        return registry.projectManagerIfAdmitted(for: activeProjectURL) == nil
+            ? .unavailable
+            : .restored
     }
 
     func openProject(

--- a/PineTests/NativeFileWindowMenuTests.swift
+++ b/PineTests/NativeFileWindowMenuTests.swift
@@ -690,6 +690,55 @@ struct NativeFileWindowMenuTests {
         #expect(delegate.registry.openProjects[canonical] != nil)
     }
 
+    @Test("Open Recent raises the scene that already owns the project")
+    func openRecentRaisesOwningScene() async throws {
+        let root = try makeTemporaryDirectory(
+            prefix: "pine-recent-owning-scene"
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+        let first = root.appendingPathComponent("First", isDirectory: true)
+        let second = root.appendingPathComponent("Second", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: first,
+            withIntermediateDirectories: false
+        )
+        try FileManager.default.createDirectory(
+            at: second,
+            withIntermediateDirectories: false
+        )
+        let defaults = makeIsolatedDefaults()
+        let registry = ProjectRegistry(
+            lspSettings: LSPSettings(defaults: defaults),
+            defaults: defaults,
+            clearRecentProjects: false
+        )
+        _ = try #require(registry.projectManager(for: first))
+        let session = ProjectWindowSession(
+            initialProjectURL: first,
+            defaults: defaults
+        )
+        await session.openProject(second, registry: registry)
+        session.windowDidClose(registry: registry)
+        registry.closeProjectWindow(second)
+        registry.registerWindowSession(session)
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        delegate.openProjectWindow = nil
+        var openedURL: URL?
+
+        let didOpen = await delegate.openRecentProject(
+            second,
+            fallbackOpenProjectWindow: { openedURL = $0 }
+        )
+
+        #expect(didOpen)
+        #expect(openedURL == session.sceneProjectURL)
+        #expect(
+            session.activeProjectURL
+                == registry.canonicalProjectURL(second)
+        )
+    }
+
     @Test("Deferred Open Recent retains the Welcome fallback")
     func deferredOpenRecentUsesWelcomeFallback() async throws {
         let directory = try makeTemporaryDirectory(

--- a/PineTests/ProjectWindowSessionTests.swift
+++ b/PineTests/ProjectWindowSessionTests.swift
@@ -21,6 +21,89 @@ struct ProjectWindowSessionTests {
         )
     }
 
+    @Test("a fresh restored scene admits its initial project exactly once")
+    func freshSceneRestoration() async throws {
+        let fixture = try ProjectWindowSessionFixture()
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        let session = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+
+        #expect(
+            registry.projectManagerIfAdmitted(for: fixture.firstProject) == nil
+        )
+        #expect(
+            await session.restoreIfNeeded(registry: registry) == .restored
+        )
+        let manager = try #require(
+            registry.projectManagerIfAdmitted(for: fixture.firstProject)
+        )
+
+        session.windowDidClose(registry: registry)
+        registry.closeProjectWindow(fixture.firstProject)
+        #expect(
+            await session.restoreIfNeeded(registry: registry)
+                == .alreadyRestored
+        )
+        #expect(
+            registry.projectManagerIfAdmitted(for: fixture.firstProject)
+                === manager
+        )
+        #expect(!registry.isWindowOpen(fixture.firstProject))
+    }
+
+    @Test("cold restoration keeps a closed anchor closed")
+    func closedAnchorColdRestoration() async throws {
+        let fixture = try ProjectWindowSessionFixture()
+        defer { fixture.cleanup() }
+        let firstRegistry = fixture.makeRegistry()
+        _ = try #require(
+            firstRegistry.projectManager(for: fixture.firstProject)
+        )
+        let session = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+        await session.openProject(
+            fixture.secondProject,
+            registry: firstRegistry
+        )
+        #expect(
+            await session.closeProject(
+                fixture.firstProject,
+                registry: firstRegistry
+            )
+        )
+        session.windowDidClose(registry: firstRegistry)
+
+        let coldRegistry = fixture.makeRegistry()
+        let restored = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+
+        #expect(
+            await restored.restoreIfNeeded(registry: coldRegistry)
+                == .restored
+        )
+        #expect(
+            restored.activeProjectURL
+                == fixture.secondProject.standardizedFileURL
+        )
+        #expect(
+            coldRegistry.projectManagerIfAdmitted(
+                for: fixture.secondProject
+            ) != nil
+        )
+        #expect(
+            coldRegistry.projectManagerIfAdmitted(
+                for: fixture.firstProject
+            ) == nil
+        )
+    }
+
     @Test("switching keeps each project alive and restores the active project")
     func switchingAndRestoration() async throws {
         let fixture = try ProjectWindowSessionFixture()
@@ -66,7 +149,7 @@ struct ProjectWindowSessionTests {
             initialProjectURL: fixture.secondProject,
             defaults: fixture.defaults
         )
-        await restored.restoreIfNeeded(registry: registry)
+        _ = await restored.restoreIfNeeded(registry: registry)
 
         #expect(
             restored.sceneProjectURL
@@ -205,7 +288,7 @@ struct ProjectWindowSessionTests {
             initialProjectURL: fixture.firstProject,
             defaults: fixture.defaults
         )
-        await session.restoreIfNeeded(registry: registry)
+        _ = await session.restoreIfNeeded(registry: registry)
 
         #expect(session.managedWorktrees.count == 1)
         #expect(


### PR DESCRIPTION
## Summary
- mount a loading placeholder so cold-restored WindowGroup scenes can run their one-shot project admission
- restore fresh and persisted multi-project scenes, dismissing unavailable scenes back to Welcome
- route Open Recent through an existing owning scene anchor to avoid duplicate project windows

## Validation
- SwiftLint on all changed files: 0 violations
- restoration and native menu tests: 27 passed
- adjacent window lifecycle suites: 102 passed
- all eight suites that timed out under full parallel load: 153 passed when rerun serially
- full PineTests run reached 777 tests; 24 timing/resource issues appeared only under parallel load and all affected suites passed in the serial rerun
- xcodebuild build succeeded

## Compatibility
- macOS 27.0 (26A5416b)
- Xcode 27.0 beta (27A5237l)
- macOS SDK 27.0 (26A5406c)
- macOS 26 runtime was not available locally; deployment target remains 26.0 and CI covers the baseline