### PR TITLE
fix: persist dismissed stale agent tasks

### DIFF
--- a/Pine/Agent/AgentTaskMetadataStore.swift
+++ b/Pine/Agent/AgentTaskMetadataStore.swift
@@ -2088,7 +2088,11 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
                       task.route.availability == .missing else { return false }
             }
             if task.lifecycle == .dismissed {
-                guard last.liveness == .terminated,
+                // Dismissal is an Inbox/history decision, not evidence that
+                // an unreachable process exited. Preserve an honestly stale
+                // tail instead of manufacturing `terminated` solely to make
+                // the record durable.
+                guard last.liveness != .live,
                       task.route.availability == .missing else { return false }
             }
             let waitingIsAllowed = task.lifecycle == .active

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -823,6 +823,50 @@ struct AgentTaskRegistryTests {
         #expect(loaded.lifecycle == .paused)
     }
 
+    @Test("dismissing stale history remains durable across quit")
+    func staleDismissalRemainsDurable() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        let writer = AgentTaskRegistry(persistence: store)
+        writer.registerProject(identity)
+        #expect(await writer.flushPersistence() == .saved)
+
+        let session = makeSession(pid: 805, generation: 1)
+        writer.bridge(
+            session,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 74)
+        )
+        #expect(await writer.flushPersistence() == .saved)
+        let taskID = try #require(writer.task(forSessionID: session.id)?.id)
+
+        // Relaunch invalidates runtime-only process authority honestly: the
+        // run is stale and paused, not falsely reported as terminated.
+        let relaunched = AgentTaskRegistry(persistence: store)
+        relaunched.registerProject(identity)
+        #expect(await relaunched.flushPersistence() == .saved)
+        let stale = try #require(relaunched.task(for: taskID))
+        #expect(stale.lifecycle == .paused)
+        #expect(stale.route.availability == .missing)
+        #expect(stale.runs.last?.liveness == .stale)
+        #expect(stale.runs.last?.endedAt == nil)
+
+        #expect(relaunched.dismissTask(taskID))
+        #expect(await relaunched.flushPersistence() == .saved)
+
+        let persisted = try #require(
+            await store.load(project: identity).tasks.first(where: {
+                $0.id == taskID
+            })
+        )
+        #expect(persisted.lifecycle == .dismissed)
+        #expect(persisted.route.availability == .missing)
+        #expect(persisted.runs.last?.liveness == .stale)
+        #expect(persisted.runs.last?.endedAt == nil)
+    }
+
     @Test("route changes retain task identity")
     func canonicalRouteUpdate() throws {
         let registry = AgentTaskRegistry()


### PR DESCRIPTION
## Summary

- allow dismissed agent history with a non-live stale tail to pass metadata validation
- preserve the honest stale process state instead of manufacturing a terminated run
- add a regression test covering relaunch, dismissal, and the durable quit barrier

## Root cause

The registry allowed users to dismiss paused or stale agent history, but the metadata validator accepted dismissed tasks only when the last run was terminated. That mismatch made every persistence retry fail with invalidMetadata and caused the Sparkle termination handshake to show the generic safe-shutdown failure during an update.

## Testing

- AgentTaskRegistryTests: 88 passed
- WindowLifecycleTests: 58 passed
- SwiftLint: 0 violations
- git diff --check

Validated on macOS 27.0 build 26A5416b with Xcode 27.0 build 27A5237l and macOS SDK 27.0 build 26A5406c. A macOS 26 runtime was not available on this host.