### PR TITLE
feat(agent): route Dock task items to their exact live task

### DIFF
--- a/Pine/Agent/AgentDockMenuRouting.swift
+++ b/Pine/Agent/AgentDockMenuRouting.swift
@@ -1,0 +1,120 @@
+//
+//  AgentDockMenuRouting.swift
+//  Pine
+//
+//  Exact per-task routing for the Dock menu's live agent entries (#1492).
+//
+//  `AppDelegate.applicationDockMenu` builds one entry per live agent run
+//  (#1355). Before this file every entry carried only `AgentTask.id` and every
+//  click opened the general Agent Inbox, so a Dock full of distinct tasks
+//  performed one indistinguishable action.
+//
+//  The projection below captures the same notification-grade identity the
+//  user-notification path already routes with — task, run, and process
+//  generation — so a Dock entry can only ever focus the exact process it was
+//  rendered for. PID reuse, a replacement shell, or a newer run inside the same
+//  task all change the identity, and the stored one stops matching. Navigation
+//  itself is not reimplemented here: the identity is handed to the existing
+//  `AgentNotificationRouteIdentity` authority, which fails closed to durable
+//  Inbox history.
+//
+//  Privacy: an entry carries a title built from
+//  ``AgentPresenceController/dockMenuAgentTitle(for:)`` (agent name, objective,
+//  project display name) and three opaque Pine-owned identifiers. No prompt,
+//  terminal output, token, absolute path, or opaque vendor session identifier
+//  ever reaches the Dock.
+//
+
+import Foundation
+
+/// One Dock entry for a live agent task: what it reads and where it routes.
+nonisolated struct AgentDockMenuItem: Equatable, Sendable {
+    let title: String
+    let identity: AgentNotificationRouteIdentity
+}
+
+/// The action a Dock agent entry resolved to.
+nonisolated enum AgentDockMenuRoute: Equatable, Sendable {
+    /// Focus this exact task, run, and process generation.
+    case task(AgentNotificationRouteIdentity)
+    /// Fail closed: present the Agent Inbox and its truthful durable history.
+    case inbox
+}
+
+@MainActor
+enum AgentDockMenuRouting {
+    /// Matches the Dock projection cap in ``AgentPresenceController/liveTasks(for:limit:)``.
+    static let itemLimit = 10
+
+    /// Notification-grade identity for one live task, or `nil` when the task
+    /// has no live latest run.
+    ///
+    /// The identity is read from `runs.last` exactly as
+    /// ``AgentTaskRegistry/matchesNotificationRoute(_:)`` reads it, so a
+    /// captured entry validates against the same authority that admitted it.
+    /// A paused, completed, dismissed, ended, or evidence-stale task never
+    /// produces one: the Dock must not offer a route it cannot substantiate.
+    nonisolated static func routeIdentity(
+        for task: AgentTask
+    ) -> AgentNotificationRouteIdentity? {
+        guard task.lifecycle == .active,
+              let run = task.runs.last,
+              run.liveness == .live,
+              run.endedAt == nil else {
+            return nil
+        }
+        return AgentNotificationRouteIdentity(
+            taskID: task.id,
+            runID: run.id,
+            processGeneration: run.process.processGeneration
+        )
+    }
+
+    /// Dock entries for the live tasks, newest-first, capped so an extreme
+    /// fleet cannot overflow the Dock menu. Order and cap match the Inbox
+    /// `working` section via ``AgentPresenceController/liveTasks(for:limit:)``.
+    static func items(
+        for tasks: [AgentTask],
+        limit: Int = itemLimit
+    ) -> [AgentDockMenuItem] {
+        AgentPresenceController.liveTasks(for: tasks, limit: limit)
+            .compactMap { task in
+                guard let identity = routeIdentity(for: task) else { return nil }
+                return AgentDockMenuItem(
+                    title: AgentPresenceController.dockMenuAgentTitle(for: task),
+                    identity: identity
+                )
+            }
+    }
+
+    /// Whether a captured entry still describes the task's current live run.
+    ///
+    /// This is deliberately "re-render the entry and compare", not a second
+    /// hand-written predicate: the Dock may navigate only when the row it
+    /// would build right now is byte-for-byte the row the user selected. It is
+    /// strictly stronger than
+    /// ``AgentTaskRegistry/matchesNotificationRoute(_:)`` — which compares the
+    /// latest run and generation but not lifecycle, liveness, or end time —
+    /// and matches the preconditions
+    /// `ProjectRegistry.navigateToAgentTaskFromInbox` enforces after every
+    /// suspension, so it can only reject routes that would have failed later.
+    nonisolated static func matchesCurrentRoute(
+        _ identity: AgentNotificationRouteIdentity,
+        task: AgentTask?
+    ) -> Bool {
+        guard let task, task.id == identity.taskID else { return false }
+        return routeIdentity(for: task) == identity
+    }
+
+    /// Fail-closed decode of an `NSMenuItem.representedObject`.
+    ///
+    /// Only a full route identity is accepted. A bare task UUID — the value
+    /// Dock entries carried before #1492 — a path, a string, or any other
+    /// payload returns `nil` so the action degrades to the Inbox instead of
+    /// guessing which session the user meant.
+    nonisolated static func routeIdentity(
+        fromRepresentedObject object: Any?
+    ) -> AgentNotificationRouteIdentity? {
+        object as? AgentNotificationRouteIdentity
+    }
+}

--- a/Pine/Agent/AgentPresenceController.swift
+++ b/Pine/Agent/AgentPresenceController.swift
@@ -14,8 +14,10 @@
 //    1. `NSApp.dockTile.badgeLabel` — the live agent-run count.
 //    2. The sudden-termination guard — balanced across run start/stop cycles.
 //
-//  The Dock menu entries are built by `AppDelegate.applicationDockMenu`,
-//  which reads the same registry through ``liveTasks(for:)`` below.
+//  The Dock menu entries are built by `AppDelegate.applicationDockMenu`
+//  through ``AgentDockMenuRouting``, which projects this same registry with
+//  ``liveTasks(for:limit:)`` below and pairs each row with the exact route
+//  identity it may focus (#1492).
 //
 
 import AppKit

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -947,7 +947,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             self?.registry.isAgentTaskPresented(taskID) ?? false
         },
         openTask: { [weak self] identity in
-            self?.openAgentTaskFromNotification(identity)
+            self?.openAgentTaskRoute(identity)
         }
     )
 
@@ -1081,7 +1081,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         NSApp.activate()
     }
 
-    private func openAgentTaskFromNotification(
+    /// Focuses one exact agent route on behalf of an explicit user action —
+    /// a notification response, or a Dock live-task entry (#1492). This is the
+    /// single navigation authority for both: every failure mode degrades to
+    /// the Agent Inbox rather than to a different session.
+    private func openAgentTaskRoute(
         _ identity: AgentNotificationRouteIdentity
     ) {
         guard registry.agentTasks.matchesNotificationRoute(identity) else {
@@ -2009,21 +2013,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         let menu = NSMenu()
 
         // Live agent runs are reachable with no window open (#1355). Each
-        // entry opens the Agent Inbox, the single surface that resumes,
-        // navigates, and dismisses a backgrounded task. Per-task terminal
-        // focus from the Dock is a follow-up.
-        let liveTasks = AgentPresenceController.liveTasks(for: registry.agentTasks.tasks)
-        for task in liveTasks {
+        // entry carries the exact task, run, and process generation it was
+        // rendered for (#1492), so selecting one focuses that session's own
+        // terminal instead of the general Inbox.
+        let agentItems = AgentDockMenuRouting.items(
+            for: registry.agentTasks.tasks
+        )
+        for entry in agentItems {
             let item = NSMenuItem(
-                title: AgentPresenceController.dockMenuAgentTitle(for: task),
+                title: entry.title,
                 action: #selector(dockMenuOpenAgentTask(_:)),
                 keyEquivalent: ""
             )
             item.target = self
-            item.representedObject = task.id
+            item.representedObject = entry.identity
             menu.addItem(item)
         }
-        if !liveTasks.isEmpty {
+        if !agentItems.isEmpty {
             menu.addItem(.separator())
         }
 
@@ -2044,10 +2050,43 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
     }
 
     @objc func dockMenuOpenAgentTask(_ sender: NSMenuItem) {
-        // The represented taskID is captured for a future per-task focus
-        // path; today every entry routes to the Inbox so a background agent
-        // is reachable the instant Pine has no open window.
-        showAgentInbox()
+        routeDockMenuAgentTask(
+            representedObject: sender.representedObject,
+            presentInbox: { self.showAgentInbox() },
+            routeExactTask: { self.openAgentTaskRoute($0) }
+        )
+    }
+
+    /// Shared body of the Dock agent action (#1492).
+    ///
+    /// AppKit rebuilds the Dock menu on every open, but a run can still end
+    /// between rendering an entry and selecting it. The captured identity is
+    /// therefore rebuilt from the current registry snapshot and compared
+    /// before anything is activated; ``openAgentTaskRoute(_:)`` then applies
+    /// the shared notification-route authority again after every suspension.
+    /// A stale, replaced, or unreadable entry never focuses a different
+    /// session — it lands on the Inbox's truthful durable history.
+    ///
+    /// The two effects are parameters rather than direct calls so the
+    /// fail-closed decision stays deterministic in tests without presenting
+    /// AppKit windows.
+    @discardableResult
+    func routeDockMenuAgentTask(
+        representedObject: Any?,
+        presentInbox: @MainActor () -> Void,
+        routeExactTask: @MainActor (AgentNotificationRouteIdentity) -> Void
+    ) -> AgentDockMenuRoute {
+        guard let identity = AgentDockMenuRouting.routeIdentity(
+            fromRepresentedObject: representedObject
+        ), AgentDockMenuRouting.matchesCurrentRoute(
+            identity,
+            task: registry.agentTasks.task(for: identity.taskID)
+        ) else {
+            presentInbox()
+            return .inbox
+        }
+        routeExactTask(identity)
+        return .task(identity)
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/PineTests/AgentDockMenuRoutingTests.swift
+++ b/PineTests/AgentDockMenuRoutingTests.swift
@@ -1,0 +1,758 @@
+//
+//  AgentDockMenuRoutingTests.swift
+//  PineTests
+//
+//  Exact per-task Dock routing for live agent runs (#1492).
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import Pine
+
+@Suite("Agent Dock Menu Routing Tests")
+@MainActor
+struct AgentDockMenuRoutingTests {
+    // MARK: - Identity capture
+
+    @Test("every live Dock entry captures its own task, run, and generation")
+    func itemsCaptureExactIdentityPerLiveTask() throws {
+        let older = makeTask(seed: 1, title: "Older")
+        let newer = makeTask(seed: 2, title: "Newer")
+        let terminated = makeTask(
+            seed: 3,
+            liveness: .terminated,
+            lifecycle: .paused,
+            title: "Ended"
+        )
+        let items = AgentDockMenuRouting.items(
+            for: [older, newer, terminated]
+        )
+
+        // Newest-first, one entry per live task, and no entry for history.
+        #expect(items.count == 2)
+        #expect(items.map(\.identity.taskID) == [newer.id, older.id])
+        #expect(!items.contains { $0.identity.taskID == terminated.id })
+
+        // Distinct tasks never share a route identity — the whole point of
+        // #1492 is that two Dock rows stop performing the same action.
+        #expect(Set(items.map(\.identity.runID)).count == 2)
+        #expect(items[0].identity.runID == newer.runs[0].id)
+        #expect(items[0].identity.processGeneration == 2)
+        #expect(items[1].identity.runID == older.runs[0].id)
+        #expect(items[1].identity.processGeneration == 1)
+        #expect(items[0].title.contains("Newer"))
+        #expect(items[1].title.contains("Older"))
+    }
+
+    @Test("route identity fails closed for anything that is not a live run")
+    func routeIdentityRejectsEverythingButALiveRun() {
+        var noRuns = makeTask(seed: 10)
+        noRuns.runs = []
+        #expect(AgentDockMenuRouting.routeIdentity(for: noRuns) == nil)
+
+        for liveness in [AgentRunLiveness.stale, .terminated] {
+            let task = makeTask(seed: 11, liveness: liveness)
+            #expect(AgentDockMenuRouting.routeIdentity(for: task) == nil)
+        }
+
+        for lifecycle in [
+            AgentTaskLifecycle.paused, .completed, .dismissed,
+        ] {
+            let task = makeTask(seed: 12, lifecycle: lifecycle)
+            #expect(AgentDockMenuRouting.routeIdentity(for: task) == nil)
+        }
+
+        // A run that already recorded an end time is not routable even if its
+        // liveness field still says `.live`. `liveTasks` admits it; the Dock
+        // must not, so the extra fence is asserted through `items` too.
+        var endedButLive = makeTask(seed: 13)
+        endedButLive.runs[0].endedAt = Date(timeIntervalSince1970: 5_000)
+        #expect(AgentDockMenuRouting.routeIdentity(for: endedButLive) == nil)
+        #expect(AgentPresenceController.liveTasks(for: [endedButLive]).count == 1)
+        #expect(AgentDockMenuRouting.items(for: [endedButLive]).isEmpty)
+
+        // The last run is authority: an old live run behind a terminated one
+        // must not resurrect a route.
+        var replaced = makeTask(seed: 14)
+        let staleRun = replaced.runs[0]
+        var successor = makeTask(seed: 15, liveness: .terminated).runs[0]
+        successor.endedAt = Date(timeIntervalSince1970: 6_000)
+        replaced.runs = [staleRun, successor]
+        #expect(AgentDockMenuRouting.routeIdentity(for: replaced) == nil)
+    }
+
+    @Test("Dock entries stay capped and ordered like the Inbox working list")
+    func itemsAreCappedAndOrderedLikeTheInbox() {
+        let fleet = (1...25).map { makeTask(seed: $0) }
+        let items = AgentDockMenuRouting.items(for: fleet)
+
+        #expect(items.count == AgentDockMenuRouting.itemLimit)
+        #expect(
+            items.map(\.identity.taskID)
+                == AgentPresenceController.liveTasks(for: fleet).map(\.id)
+        )
+        // Every capped entry is still individually addressable.
+        #expect(Set(items.map(\.identity.runID)).count == items.count)
+    }
+
+    // MARK: - Represented value decoding
+
+    @Test("only a full route identity is accepted as a represented value")
+    func representedValueDecodingFailsClosed() {
+        let task = makeTask(seed: 20)
+        let identity = AgentDockMenuRouting.routeIdentity(for: task)
+
+        let rejected: [Any?] = [
+            nil,
+            // The pre-#1492 represented value: a bare task UUID cannot reject
+            // PID or process-generation reuse, so it must not route.
+            task.id,
+            task.id.uuidString,
+            "/tmp/dock-demo",
+            URL(fileURLWithPath: "/tmp/dock-demo"),
+            NSNull(),
+            NSNumber(value: 7),
+            task,
+        ]
+        for value in rejected {
+            #expect(
+                AgentDockMenuRouting.routeIdentity(
+                    fromRepresentedObject: value
+                ) == nil
+            )
+        }
+
+        // A real identity survives AppKit's `Any?` box round trip.
+        let item = NSMenuItem()
+        item.representedObject = identity
+        #expect(
+            AgentDockMenuRouting.routeIdentity(
+                fromRepresentedObject: item.representedObject
+            ) == identity
+        )
+    }
+
+    // MARK: - Privacy
+
+    @Test("Dock titles and represented values expose no private detail")
+    func dockEntriesExposeNoPrivateDetail() throws {
+        let secretRoot = "/Users/tester/Private Work"
+        var task = makeTask(
+            seed: 21,
+            title: "Ship the release",
+            project: "\(secretRoot)/dock-demo"
+        )
+        task.runs[0].vendorIdentity = AgentVendorSessionIdentity(
+            provider: "acme",
+            opaqueIdentifier: "vendor-opaque-secret",
+            executableVersion: "9.9.9"
+        )
+        let item = try #require(AgentDockMenuRouting.items(for: [task]).first)
+
+        // The project is identified by display name only.
+        #expect(item.title.contains("dock-demo"))
+        #expect(!item.title.contains(secretRoot))
+        #expect(!item.title.contains("/"))
+        #expect(!item.title.contains("vendor-opaque-secret"))
+        #expect(!item.title.contains("acme"))
+
+        // The represented value carries three Pine-owned identifiers and
+        // nothing else — no path, no vendor identity, no PID.
+        let described = String(describing: item.identity)
+        #expect(described.contains(task.id.uuidString))
+        #expect(!described.contains(secretRoot))
+        #expect(!described.contains("vendor-opaque-secret"))
+        #expect(!described.contains("acme"))
+        #expect(item.identity.processGeneration == 21)
+        #expect(!described.contains("processIdentifier"))
+    }
+
+    // MARK: - Revalidation against the live registry
+
+    @Test("a captured identity rejects PID and process-generation reuse")
+    func capturedIdentityRejectsProcessReuse() throws {
+        let registry = AgentTaskRegistry()
+        let task = makeTask(seed: 30)
+        registry.setTasksForTesting([task])
+        let identity = try #require(AgentDockMenuRouting.routeIdentity(for: task))
+        #expect(registry.matchesNotificationRoute(identity))
+
+        // Same task, same PID, new process generation: the shell was replaced.
+        var reused = task
+        reused.runs = [makeRun(
+            seed: 30,
+            processIdentifier: 30,
+            processGeneration: 31,
+            runIDSeed: 131
+        )]
+        registry.setTasksForTesting([reused])
+        #expect(!registry.matchesNotificationRoute(identity))
+
+        let refreshed = try #require(
+            AgentDockMenuRouting.routeIdentity(for: reused)
+        )
+        #expect(refreshed.taskID == identity.taskID)
+        #expect(refreshed.runID != identity.runID)
+        #expect(registry.matchesNotificationRoute(refreshed))
+
+        // Same run identifier, different generation — PID reuse inside one
+        // run must not extend the old route either.
+        var sameRunNewGeneration = task
+        sameRunNewGeneration.runs = [makeRun(
+            seed: 30,
+            processIdentifier: 30,
+            processGeneration: 99,
+            runIDSeed: 130
+        )]
+        registry.setTasksForTesting([sameRunNewGeneration])
+        #expect(sameRunNewGeneration.runs[0].id == task.runs[0].id)
+        #expect(!registry.matchesNotificationRoute(identity))
+
+        // The task disappearing entirely is also a rejection, not a crash.
+        registry.setTasksForTesting([])
+        #expect(!registry.matchesNotificationRoute(identity))
+        #expect(!registry.matchesNotificationRoute(refreshed))
+        #expect(!AgentDockMenuRouting.matchesCurrentRoute(identity, task: nil))
+    }
+
+    @Test("the current-route fence rejects what the run/generation check admits")
+    func currentRouteFenceIsStricterThanTheRunComparison() throws {
+        let registry = AgentTaskRegistry()
+        let task = makeTask(seed: 35)
+        registry.setTasksForTesting([task])
+        let identity = try #require(AgentDockMenuRouting.routeIdentity(for: task))
+        #expect(AgentDockMenuRouting.matchesCurrentRoute(identity, task: task))
+
+        // Same run, same generation — `matchesNotificationRoute` still says
+        // yes for each of these, but none of them may focus a terminal.
+        var ended = task
+        ended.runs[0].liveness = .terminated
+        ended.runs[0].endedAt = Date(timeIntervalSince1970: 9_000)
+        ended.lifecycle = .paused
+
+        var stale = task
+        stale.runs[0].liveness = .stale
+
+        var dismissed = task
+        dismissed.lifecycle = .dismissed
+
+        for variant in [ended, stale, dismissed] {
+            registry.setTasksForTesting([variant])
+            #expect(registry.matchesNotificationRoute(identity))
+            #expect(!AgentDockMenuRouting.matchesCurrentRoute(
+                identity,
+                task: variant
+            ))
+        }
+
+        // An identity whose taskID does not belong to the inspected task is
+        // never accepted, even when run and generation coincide.
+        let sibling = makeTask(seed: 35)
+        #expect(sibling.id != task.id)
+        #expect(sibling.runs[0].id == task.runs[0].id)
+        #expect(!AgentDockMenuRouting.matchesCurrentRoute(
+            identity,
+            task: sibling
+        ))
+    }
+
+    // MARK: - Dock action
+
+    @Test("each Dock entry routes to its own exact identity")
+    func dockActionRoutesEachEntryExactly() throws {
+        let delegate = makeDelegate()
+        let first = makeTask(seed: 40, title: "First")
+        let second = makeTask(seed: 41, title: "Second")
+        delegate.registry.agentTasks.setTasksForTesting([first, second])
+        let items = AgentDockMenuRouting.items(
+            for: delegate.registry.agentTasks.tasks
+        )
+        #expect(items.count == 2)
+
+        var inboxCount = 0
+        var routed: [AgentNotificationRouteIdentity] = []
+        for item in items {
+            let route = delegate.routeDockMenuAgentTask(
+                representedObject: item.identity,
+                presentInbox: { inboxCount += 1 },
+                routeExactTask: { routed.append($0) }
+            )
+            #expect(route == .task(item.identity))
+        }
+
+        #expect(inboxCount == 0)
+        #expect(routed == items.map(\.identity))
+        #expect(Set(routed.map(\.taskID)) == Set([first.id, second.id]))
+    }
+
+    @Test("stale, replaced, and unreadable Dock entries fall back to the Inbox")
+    func dockActionFailsClosed() throws {
+        let delegate = makeDelegate()
+        let task = makeTask(seed: 50)
+        delegate.registry.agentTasks.setTasksForTesting([task])
+        let identity = try #require(AgentDockMenuRouting.routeIdentity(for: task))
+
+        var inboxCount = 0
+        var routed: [AgentNotificationRouteIdentity] = []
+        func route(_ value: Any?) -> AgentDockMenuRoute {
+            delegate.routeDockMenuAgentTask(
+                representedObject: value,
+                presentInbox: { inboxCount += 1 },
+                routeExactTask: { routed.append($0) }
+            )
+        }
+
+        // Unreadable payloads never reach navigation.
+        #expect(route(nil) == .inbox)
+        #expect(route(task.id) == .inbox)
+        #expect(route("agent") == .inbox)
+        #expect(inboxCount == 3)
+        #expect(routed.isEmpty)
+
+        // The entry is valid while the run is the current one.
+        #expect(route(identity) == .task(identity))
+        #expect(routed == [identity])
+
+        // The run ends between rendering the menu and the click.
+        var ended = task
+        ended.runs[0].liveness = .terminated
+        ended.runs[0].endedAt = Date(timeIntervalSince1970: 5_000)
+        ended.lifecycle = .paused
+        delegate.registry.agentTasks.setTasksForTesting([ended])
+        #expect(route(identity) == .inbox)
+
+        // A replacement run in the same task is a different session.
+        var replaced = task
+        replaced.runs = [makeRun(
+            seed: 51,
+            processIdentifier: 50,
+            processGeneration: 51,
+            runIDSeed: 151
+        )]
+        delegate.registry.agentTasks.setTasksForTesting([replaced])
+        #expect(route(identity) == .inbox)
+
+        // And the task disappearing from the registry.
+        delegate.registry.agentTasks.setTasksForTesting([])
+        #expect(route(identity) == .inbox)
+        #expect(routed == [identity])
+        #expect(inboxCount == 6)
+    }
+
+    @Test("the Dock menu binds one exact entry per live task")
+    func applicationDockMenuBindsExactEntries() throws {
+        let directory = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let delegate = makeDelegate()
+        let first = makeTask(seed: 60, title: "First")
+        let second = makeTask(seed: 61, title: "Second")
+        let history = makeTask(seed: 62, liveness: .terminated, lifecycle: .paused)
+        delegate.registry.agentTasks.setTasksForTesting([first, second, history])
+        _ = delegate.registry.projectManager(for: directory)
+
+        let menu = try #require(delegate.applicationDockMenu(NSApplication.shared))
+        #expect(menu.items.count == 4)
+        #expect(menu.items[2].isSeparatorItem)
+
+        let identities = try (0..<2).map { index -> AgentNotificationRouteIdentity in
+            let item = menu.items[index]
+            #expect(item.target === delegate)
+            #expect(item.action == #selector(AppDelegate.dockMenuOpenAgentTask(_:)))
+            return try #require(
+                AgentDockMenuRouting.routeIdentity(
+                    fromRepresentedObject: item.representedObject
+                )
+            )
+        }
+        #expect(identities.map(\.taskID) == [second.id, first.id])
+        #expect(Set(identities.map(\.runID)).count == 2)
+        #expect(!identities.contains { $0.taskID == history.id })
+
+        // The recent-project entry keeps its own URL contract.
+        #expect(
+            menu.items[3].representedObject as? URL
+                == directory.resolvingSymlinksInPath()
+        )
+    }
+
+    @Test("an empty live fleet leaves the Dock menu without a stray separator")
+    func dockMenuOmitsSeparatorWithoutLiveTasks() throws {
+        let directory = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let delegate = makeDelegate()
+        delegate.registry.agentTasks.setTasksForTesting([
+            makeTask(seed: 63, liveness: .terminated, lifecycle: .paused),
+        ])
+        _ = delegate.registry.projectManager(for: directory)
+
+        let menu = try #require(delegate.applicationDockMenu(NSApplication.shared))
+        #expect(menu.items.count == 1)
+        #expect(!menu.items.contains { $0.isSeparatorItem })
+    }
+
+    // MARK: - Exact navigation through the shared authority
+
+    @Test("each Dock identity focuses only its own pane and terminal tab")
+    func dockIdentityFocusesItsOwnTerminal() async throws {
+        let fixture = try DockProjectFixture()
+        defer { fixture.cleanup() }
+        let taskRegistry = AgentTaskRegistry()
+        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        let firstPane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let secondPane = try #require(manager.paneManager.createTerminalPane(
+            relativeTo: firstPane,
+            axis: .horizontal,
+            workingDirectory: fixture.project
+        ))
+        let firstState = try #require(
+            manager.paneManager.terminalState(for: firstPane)
+        )
+        let secondState = try #require(
+            manager.paneManager.terminalState(for: secondPane)
+        )
+        let firstTab = try #require(firstState.terminalTabs.first)
+        let secondTab = try #require(secondState.terminalTabs.first)
+
+        let firstSession = makeSession(seed: 70)
+        manager.terminal.bridgeAgentSession(firstSession, replacing: nil, in: firstTab)
+        firstTab.agentSession = firstSession
+        let secondSession = makeSession(seed: 71)
+        manager.terminal.bridgeAgentSession(secondSession, replacing: nil, in: secondTab)
+        secondTab.agentSession = secondSession
+
+        let identities = AgentDockMenuRouting.items(for: taskRegistry.tasks)
+            .map(\.identity)
+        #expect(identities.count == 2)
+        let firstIdentity = try #require(
+            identities.first { $0.runID == firstSession.id }
+        )
+        let secondIdentity = try #require(
+            identities.first { $0.runID == secondSession.id }
+        )
+        #expect(firstIdentity.processGeneration == 70)
+        #expect(secondIdentity.processGeneration == 71)
+        #expect(firstIdentity.taskID != secondIdentity.taskID)
+
+        let window = makeEligibleProjectWindow()
+        manager.bindDialogOwnerWindow(window)
+        defer {
+            manager.unbindDialogOwnerWindow(window)
+            window.orderOut(nil)
+        }
+
+        manager.terminal.lastActiveTerminalPaneID = secondPane
+        #expect(taskRegistry.setReviewed(false, taskID: firstIdentity.taskID))
+        #expect(taskRegistry.setReviewed(false, taskID: secondIdentity.taskID))
+        #expect(await navigate(projectRegistry, firstIdentity) == .focused(
+            AgentTaskRoute(
+                paneID: firstPane.id,
+                tabID: firstTab.id,
+                terminalID: firstTab.id
+            )
+        ))
+        #expect(firstState.activeTerminalID == firstTab.id)
+        #expect(manager.terminal.lastActiveTerminalPaneID == firstPane)
+        #expect(taskRegistry.task(for: firstIdentity.taskID)?.isUnread == false)
+        // The sibling task is untouched — the two Dock rows are not the same
+        // action any more.
+        #expect(taskRegistry.task(for: secondIdentity.taskID)?.isUnread == true)
+
+        #expect(await navigate(projectRegistry, secondIdentity) == .focused(
+            AgentTaskRoute(
+                paneID: secondPane.id,
+                tabID: secondTab.id,
+                terminalID: secondTab.id
+            )
+        ))
+        #expect(secondState.activeTerminalID == secondTab.id)
+        #expect(manager.terminal.lastActiveTerminalPaneID == secondPane)
+
+        // Crossing the identities — one task's id with the other's run — is
+        // rejected before any window is touched.
+        let crossed = AgentNotificationRouteIdentity(
+            taskID: firstIdentity.taskID,
+            runID: secondIdentity.runID,
+            processGeneration: secondIdentity.processGeneration
+        )
+        #expect(!taskRegistry.matchesNotificationRoute(crossed))
+        #expect(await navigate(projectRegistry, crossed) == .routeStale)
+    }
+
+    @Test("a replaced process makes the captured Dock identity stale")
+    func dockIdentityRejectsProcessReplacement() async throws {
+        let fixture = try DockProjectFixture()
+        defer { fixture.cleanup() }
+        let taskRegistry = AgentTaskRegistry()
+        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let state = try #require(manager.paneManager.terminalState(for: pane))
+        let tab = try #require(state.terminalTabs.first)
+        let session = makeSession(seed: 80)
+        manager.terminal.bridgeAgentSession(session, replacing: nil, in: tab)
+        tab.agentSession = session
+
+        let identity = try #require(
+            AgentDockMenuRouting.items(for: taskRegistry.tasks).first?.identity
+        )
+        let window = makeEligibleProjectWindow()
+        manager.bindDialogOwnerWindow(window)
+        defer {
+            manager.unbindDialogOwnerWindow(window)
+            window.orderOut(nil)
+        }
+
+        // The Dock menu was rendered, then the shell was replaced.
+        session.applyLiveness(.terminated)
+        let replacement = makeSession(seed: 81)
+        manager.terminal.bridgeAgentSession(
+            replacement,
+            replacing: session,
+            in: tab
+        )
+        tab.agentSession = replacement
+
+        // The run identifier and generation alone still compare equal, so the
+        // Dock's own current-route fence is what rejects the stale entry.
+        #expect(!AgentDockMenuRouting.matchesCurrentRoute(
+            identity,
+            task: taskRegistry.task(for: identity.taskID)
+        ))
+        let unreadBefore = taskRegistry.task(for: identity.taskID)?.isUnread
+        #expect(await navigate(projectRegistry, identity) == .routeStale)
+        // A rejected route never silently marks the task reviewed.
+        #expect(taskRegistry.task(for: identity.taskID)?.isUnread == unreadBefore)
+
+        // A freshly rendered Dock menu routes the replacement exactly.
+        let refreshed = try #require(
+            AgentDockMenuRouting.items(for: taskRegistry.tasks).first?.identity
+        )
+        #expect(refreshed.runID == replacement.id)
+        #expect(await navigate(projectRegistry, refreshed) == .focused(
+            AgentTaskRoute(paneID: pane.id, tabID: tab.id, terminalID: tab.id)
+        ))
+    }
+
+    @Test("a Dock identity reopens only its own backgrounded project window")
+    func dockIdentityReopensOwningProject() async throws {
+        let fixture = try DockProjectFixture()
+        let other = try DockProjectFixture()
+        defer {
+            fixture.cleanup()
+            other.cleanup()
+        }
+        let taskRegistry = AgentTaskRegistry()
+        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        _ = try #require(projectRegistry.projectManager(for: other.project))
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let state = try #require(manager.paneManager.terminalState(for: pane))
+        let tab = try #require(state.terminalTabs.first)
+        let session = makeSession(seed: 90)
+        manager.terminal.bridgeAgentSession(session, replacing: nil, in: tab)
+        tab.agentSession = session
+        let identity = try #require(
+            AgentDockMenuRouting.items(for: taskRegistry.tasks).first?.identity
+        )
+
+        let canonical = projectRegistry.canonicalProjectURL(fixture.project)
+        projectRegistry.closeProjectWindow(fixture.project)
+        #expect(projectRegistry.backgroundProjects.contains(canonical))
+
+        var openedURLs: [URL] = []
+        var activated: [ObjectIdentifier] = []
+        var presentationWindow: NSWindow?
+        defer {
+            if let presentationWindow {
+                manager.unbindDialogOwnerWindow(presentationWindow)
+                presentationWindow.orderOut(nil)
+            }
+        }
+
+        let result = await projectRegistry.navigateToAgentTaskFromInbox(
+            identity.taskID,
+            openProjectWindow: { openedURLs.append($0) },
+            waitUntilPresented: { reopened in
+                #expect(reopened === manager)
+                let window = self.makeEligibleProjectWindow()
+                presentationWindow = window
+                reopened.bindDialogOwnerWindow(window)
+                return true
+            },
+            activateApplication: { activated.append(ObjectIdentifier($0)) },
+            expectedNotificationRoute: identity
+        )
+
+        #expect(result == .focused(
+            AgentTaskRoute(paneID: pane.id, tabID: tab.id, terminalID: tab.id)
+        ))
+        // Only the owning project was asked to reopen.
+        #expect(openedURLs == [canonical])
+        #expect(activated == [ObjectIdentifier(manager)])
+        #expect(state.activeTerminalID == tab.id)
+    }
+
+    // MARK: - Helpers
+
+    private func navigate(
+        _ projectRegistry: ProjectRegistry,
+        _ identity: AgentNotificationRouteIdentity
+    ) async -> AgentInboxNavigationResult {
+        await projectRegistry.navigateToAgentTaskFromInbox(
+            identity.taskID,
+            openProjectWindow: { _ in },
+            waitUntilPresented: { _ in true },
+            activateApplication: { _ in },
+            expectedNotificationRoute: identity
+        )
+    }
+
+    private func makeDelegate() -> AppDelegate {
+        let delegate = AppDelegate()
+        let registry = ProjectRegistry(agentTasks: AgentTaskRegistry())
+        registry.recentProjects = []
+        delegate.registry = registry
+        return delegate
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineDockRouting-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        return directory
+    }
+
+    private func makeEligibleProjectWindow() -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.orderFront(nil)
+        return window
+    }
+
+    private func makeSession(seed: Int) -> AgentSession {
+        let session = AgentSession(
+            agentType: .codex,
+            state: .executing,
+            startedAt: Date(timeIntervalSince1970: TimeInterval(seed))
+        )
+        _ = session.bindProcessEvidence(AgentProcessEvidence(
+            processIdentifier: Int32(1_000 + seed),
+            processGeneration: UInt64(seed),
+            startIdentifier: "dock-session-\(seed)",
+            observedStartedAt: Date(timeIntervalSince1970: TimeInterval(seed)),
+            startIsAuthoritative: true
+        ))
+        return session
+    }
+
+    private func makeRun(
+        seed: Int,
+        processIdentifier: Int32,
+        processGeneration: UInt64,
+        runIDSeed: Int,
+        liveness: AgentRunLiveness = .live
+    ) -> AgentTaskRun {
+        let started = Date(timeIntervalSince1970: TimeInterval(1_000 + seed))
+        return AgentTaskRun(AgentTaskRunInput(
+            id: uuid(runIDSeed),
+            terminalID: uuid(seed + 1),
+            process: AgentProcessEvidence(
+                processIdentifier: processIdentifier,
+                processGeneration: processGeneration,
+                startIdentifier: "dock-\(seed)-\(processGeneration)",
+                observedStartedAt: started,
+                startIsAuthoritative: true
+            ),
+            status: AgentTaskRunStatus(
+                state: .executing,
+                liveness: liveness,
+                observedAt: started
+            )
+        ))
+    }
+
+    private func makeTask(
+        seed: Int,
+        liveness: AgentRunLiveness = .live,
+        lifecycle: AgentTaskLifecycle = .active,
+        title: String? = "Review tests",
+        project: String = "/tmp/dock-demo"
+    ) -> AgentTask {
+        let route = AgentTaskRoute(
+            paneID: uuid(seed),
+            tabID: uuid(seed + 1),
+            terminalID: uuid(seed + 1)
+        )
+        let started = Date(timeIntervalSince1970: TimeInterval(1_000 + seed))
+        var task = AgentTask(
+            descriptor: AgentDescriptor(agentType: .codex),
+            context: AgentTaskBridgeContext(
+                project: AgentTaskProjectIdentity(
+                    canonicalProjectPath: project,
+                    canonicalWorktreePath: project
+                ),
+                route: route,
+                origin: .discoveredInTerminal,
+                observedAt: started
+            ),
+            title: title
+        )
+        task.lifecycle = lifecycle
+        task.runs = [makeRun(
+            seed: seed,
+            processIdentifier: Int32(seed),
+            processGeneration: UInt64(seed),
+            runIDSeed: seed + 100,
+            liveness: liveness
+        )]
+        return task
+    }
+
+    private func uuid(_ seed: Int) -> UUID {
+        let suffix = String(format: "%012llX", UInt64(seed))
+        return UUID(uuidString: "00000000-0000-0000-0000-\(suffix)") ?? UUID()
+    }
+}
+
+private final class DockProjectFixture {
+    let root: URL
+    let project: URL
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory
+            .resolvingSymlinksInPath()
+            .appendingPathComponent("PineDock-\(UUID().uuidString)")
+        project = root.appendingPathComponent("project", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: project,
+            withIntermediateDirectories: true
+        )
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: root)
+    }
+}


### PR DESCRIPTION
Closes #1492.

## Problem

`applicationDockMenu` builds one entry per live agent run (#1355) and stores
`task.id` in `representedObject`, but `dockMenuOpenAgentTask` ignored it and
always opened the general Agent Inbox. Every task-specific Dock entry performed
the same indistinguishable action, and a bare task UUID cannot reject PID or
process-generation reuse anyway.

## What changed

**New `Pine/Agent/AgentDockMenuRouting.swift`** — a pure, UI-free projection:

- `routeIdentity(for:)` captures the full notification-grade
  `AgentNotificationRouteIdentity` (task + run + process generation) for a live
  task, read from `runs.last` exactly as
  `AgentTaskRegistry.matchesNotificationRoute` reads it. A non-active lifecycle,
  a stale/terminated run, or a run that already recorded `endedAt` produces
  nothing — the Dock never offers a route it cannot substantiate.
- `items(for:limit:)` pairs each row's title with its identity, keeping the
  newest-first order and 10-row cap of `AgentPresenceController.liveTasks`.
- `matchesCurrentRoute(_:task:)` re-renders the entry from the current registry
  snapshot and compares — "the row I would build right now is the row you
  selected". This is deliberately not a second hand-written predicate; it is
  strictly stronger than `matchesNotificationRoute` (which compares run and
  generation but not lifecycle, liveness, or end time) and matches the
  preconditions `navigateToAgentTaskFromInbox` enforces after every suspension,
  so it can only reject routes that would have failed later.
- `routeIdentity(fromRepresentedObject:)` is the fail-closed decode: a bare
  task UUID (the pre-#1492 value), a path, a string, or anything else returns
  `nil`.

**`PineApp.swift`**

- Dock entries now carry the identity rather than the task UUID.
- `dockMenuOpenAgentTask` delegates to `routeDockMenuAgentTask`, which
  revalidates and then hands the identity to the **existing** navigation
  authority — the private notification handler, renamed
  `openAgentTaskFromNotification` → `openAgentTaskRoute` because it now serves
  both explicit user actions. No parallel navigation path was added: window
  reopen, terminal activation, and every post-suspension recheck stay in
  `ProjectRegistry.navigateToAgentTaskFromInbox(_:expectedNotificationRoute:)`.
- The two effects (`presentInbox`, `routeExactTask`) are parameters so the
  fail-closed decision is deterministic in tests without presenting AppKit
  windows.

## Acceptance criteria

- [x] Full notification-grade identity stored, rejecting PID and
      process-generation reuse
- [x] Identity revalidated when the Dock action is invoked (synchronously
      before activation, and again inside the shared authority)
- [x] Reuses the existing exact routing authority
- [x] Activates or reopens only the owning project window and terminal tab
- [x] Falls back to the Agent Inbox popover for stale, replaced, unavailable,
      or failed routes
- [x] Privacy: titles carry agent name / objective / project display name only;
      represented values carry three opaque Pine-owned identifiers — no
      prompts, output, tokens, absolute paths, or vendor identifiers
- [x] Deterministic tests for exact routing, multiple live tasks, process
      replacement, project reopen, and fallback

## Tests

New `PineTests/AgentDockMenuRoutingTests.swift` — 14 tests, all passing
locally:

- identity capture per live task; distinct identities per row
- fail-closed for empty runs, stale/terminated liveness,
  paused/completed/dismissed lifecycle, `endedAt` set while `liveness == .live`,
  and an old live run hidden behind a terminated successor
- cap + ordering parity with the Inbox working list
- represented-value decoding rejects `nil`, a bare task UUID, a UUID string, a
  path string, a `URL`, `NSNull`, `NSNumber`, and an `AgentTask`; a real
  identity round-trips through `NSMenuItem.representedObject`
- privacy: no absolute path, no vendor opaque identifier, no PID in either the
  title or the represented value
- PID/generation reuse: same PID + new generation, same run id + new
  generation, and a vanished task all stop matching
- the current-route fence rejects three cases `matchesNotificationRoute`
  admits (ended, stale, dismissed) and rejects a sibling task with a colliding
  run id
- Dock action: each entry routes its own identity; `nil`/legacy-UUID/string
  payloads, an ended run, a replacement run, and a removed task all return
  `.inbox`
- `applicationDockMenu` binds exactly one entry per live task with correct
  target/action, keeps the separator only when live tasks exist, and leaves the
  recent-project URL contract untouched
- end-to-end through `navigateToAgentTaskFromInbox`: two live tasks in two
  panes each focus their own pane/tab and mark only their own task reviewed;
  crossing two identities is rejected; a replaced process makes the captured
  identity stale without marking it reviewed, while a freshly rendered entry
  focuses the replacement; a backgrounded project is reopened — and only the
  owning project is asked to reopen

## Verification

- macOS 27.0 (26A5416b), Xcode 27.0 beta (27A5237l), macOS SDK 27.0 (26A5406c)
- `xcodebuild build` — **BUILD SUCCEEDED**
- `xcodebuild test -only-testing:PineTests/AgentDockMenuRoutingTests` — 14/14 pass
- `xcodebuild test -only-testing:PineTests/DockMenuTests
  -only-testing:PineTests/AgentPresenceTests -only-testing:PineTests/AgentInboxTests
  -only-testing:PineTests/AgentNotificationTests` — pass
- `swiftlint --strict` — 0 violations in 781 files
- `git diff --check` — clean
- Full `PineTests` was run on this branch **and** on the base commit
  (6acaa6a9): the base produces a strict superset of the same
  environment-dependent failures (snapshot baselines on macOS 27 — CI-only per
  AGENTS.md — plus PTY/LSP/window-lifecycle timing suites). No failure is
  attributable to this diff.
- No UI test: the Dock menu is system UI and is not reachable from XCUITest, so
  no UI-shard rebalancing is needed.

Ready to merge once CI is green.
