### PR TITLE
fix(tests): stop a failed count assertion from killing the test process

### DIFF
--- a/PineTests/CommandOverlayHostedAnnouncementTests.swift
+++ b/PineTests/CommandOverlayHostedAnnouncementTests.swift
@@ -9,13 +9,104 @@ import Testing
 
 @testable import Pine
 
-@Suite("Hosted command overlay announcements")
+/// Hosted end-to-end coverage for the VoiceOver selection announcements that
+/// `QuickOpenView` and `SymbolNavigatorView` publish (#1497).
+///
+/// Serialized deliberately, but the trait buys less than it looks like. It
+/// serializes only *this* suite's own tests, and the one genuinely blocking
+/// call here is the 20 ms reentrant `RunLoop.main.run(until:)` drain in
+/// `host(_:size:)` — so what the trait actually guarantees is that two drains
+/// *of this suite* never nest inside one another. It says nothing about the
+/// other hosted suites that drain the same main runloop without being
+/// serialized against this one (`CommandPaletteHostedInteractionTests:303`,
+/// `CommandOverlayViewTests:221`, `QuickTerminalContentHostedTests:105`,
+/// `GlobalTabSwitcherOverlayHostedTests:400`). `settle` itself sleeps and
+/// leaves the main actor free, so the waiting is not what needs serializing.
+///
+/// Time-limited deliberately: the settle gate below is budgeted in polls, not
+/// in wall-clock time, so a genuinely broken view does not fail fast — it
+/// spends its whole budget waiting. Without a ceiling that reads as a hung run
+/// rather than a red test, which is exactly the unreadable failure mode #1506
+/// was filed about. The limit applies per test, not per suite, and it
+/// *tightens* the status quo: the bundle runs with `-test-timeouts-enabled
+/// YES` and no `-default-test-execution-time-allowance`, so today every test
+/// here inherits Xcode's 600-second default.
+///
+/// Three minutes, not one, and the headroom is sized from a measurement — but
+/// a *local* one, so read it as a floor on the required slack rather than as
+/// bundle behaviour. On CI (macos-26, `-parallel-testing-enabled NO`) the
+/// whole bundle is 6744 tests in 396.658 s with zero retries, and this suite
+/// is nowhere near any ceiling. Locally, on the toolchain recorded in
+/// `settlePollBudget` below, the same bundle periodically wedges the main
+/// thread hard enough that trivial tests doing no I/O at all record 59.7–61.8
+/// seconds of elapsed time. A one-minute ceiling therefore has ample headroom
+/// on CI and none at all on that local combination — it would stop being a
+/// ceiling and start being a second lottery, which is what this change exists
+/// to remove. Three minutes still turns a genuinely broken view red instead of
+/// leaving it to hang, and stays far below the job's `timeout-minutes: 60`
+/// (the current unit-test job finishes in 8 m 36 s). Precedent:
+/// `ConcurrencyStressTests.swift:116`.
+@Suite(
+    "Hosted command overlay announcements",
+    .serialized,
+    .timeLimit(.minutes(3))
+)
 @MainActor
 struct CommandOverlayHostedAnnouncementTests {
+    /// Settle budget expressed in polls, not wall-clock time.
+    ///
+    /// In a local Xcode run `PineTests` executes its suites in parallel inside
+    /// one process (parallelism is the default there), and unrelated suites
+    /// block the main thread for seconds at a stretch —
+    /// `GitStatusProviderTests` is `@MainActor` and runs `/bin/sh` through
+    /// `process.waitUntilExit()`; `AgentHistoryCheckedUndoEngineTests` is
+    /// `@MainActor` and blocks on `DispatchSemaphore.wait(timeout:)` for up to
+    /// two seconds. A wall-clock deadline therefore measures how busy the rest
+    /// of the bundle is, not whether this view settled: starvation burns the
+    /// entire budget without the view ever getting a chance to run.
+    ///
+    /// This does **not** describe CI. Both `xcodebuild test` invocations pass
+    /// `-parallel-testing-enabled NO` (`.github/workflows/ci.yml:324` and
+    /// `:396`, enforced by `scripts/tests/test-xcodebuild-cli-options.sh`),
+    /// so on CI the suites run one after another and the poll budget degrades
+    /// to an ordinary 3-second deadline here (200 × 5 ms = 1 second in the
+    /// unit suite). The budget is insurance for the local shape, not a
+    /// description of the CI shape.
+    ///
+    /// The starvation numbers quoted in this file were measured locally on:
+    /// macOS 27.0 (26A5416b), Xcode 27.0 (27A5237l), macosx SDK 27.0
+    /// (26A5406c). They are a property of that combination, not of the test
+    /// bundle: the same suites are quick and stable on the macos-26 runner.
+    ///
+    /// Budgeting in scheduling opportunities is strictly better, but it is
+    /// still a budget, not determinism: it buys roughly 300 chances to observe
+    /// the view instead of roughly 200, and a real product regression that
+    /// needs somewhere between those two numbers now passes here where it used
+    /// to fail. Deterministic settling would need a production seam —
+    /// `CommandOverlaySelectionAnnouncer.init(delay:)` already accepts an
+    /// injected delay, but no view forwards one and `QuickOpenView` hardcodes
+    /// a 150 ms `Task.sleep` — and adding that seam is deliberately out of
+    /// scope for a test-only change (#1506).
+    private static let settlePollBudget = 300
+
+    /// Wait between polls. Sleeping (rather than spinning on `Task.yield()`)
+    /// hands the main actor back so the view's debounced search and
+    /// announcement tasks can actually run.
+    private static let settlePollInterval = Duration.milliseconds(10)
+
     @Test("Quick Open arrow navigation reaches the announcement sink")
     func quickOpenArrowAnnouncement() async throws {
         let projectManager = ProjectManager()
-        let root = URL(fileURLWithPath: "/tmp/quick-open-announcement")
+        // Unique per run, never the shared `/tmp/quick-open-announcement`.
+        // That fixed path let machine state leak into the fixture two ways: a
+        // stray `First.swift` *directory* there makes `collectFiles` drop the
+        // entry, leaving one result and an unsatisfiable gate; and
+        // `QuickOpenProvider.loadRecentFiles` reads `UserDefaults.standard`
+        // under a key derived from the root path, so a previously recorded
+        // recent file would boost `Second.swift` and flip the sort order that
+        // `moveDown:` is asserted against (#1506).
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
         projectManager.workspace.rootURL = root
         projectManager.workspace.rootNodes = [
             FileNode(url: root.appendingPathComponent("First.swift")),
@@ -39,18 +130,37 @@ struct CommandOverlayHostedAnnouncementTests {
             name: NSControl.textDidChangeNotification,
             object: field
         ))
-        #expect(await waitUntil {
-            recorder.messages.contains { $0.hasPrefix("2 results.") }
-        })
-        recorder.messages.removeAll()
+        // Hard precondition, not a soft one: until the summary lands the view
+        // still holds zero results, `moveSelection` short-circuits, and every
+        // assertion below would be measuring the wrong thing.
+        try #require(
+            await settle {
+                recorder.messages.contains { $0.hasPrefix("2 results.") }
+            },
+            """
+            Hosted Quick Open never published its result summary; \
+            recorded \(recorder.messages).
+            """
+        )
 
+        // Keep the recorder's history intact instead of clearing it: the
+        // announcer's duplicate-suppression boundary is private to the view,
+        // so a cleared recorder and a live `lastDeliveredMessage` would
+        // disagree about what has already been spoken.
+        let baseline = recorder.messages.count
+        // Note: this only proves the selector was consumed — the coordinator
+        // returns `true` for `moveDown:` whether or not anything was announced.
         #expect(coordinator.control(
             field,
             textView: NSTextView(),
             doCommandBy: #selector(NSResponder.moveDown(_:))
         ))
-        #expect(recorder.messages.count == 1)
-        #expect(recorder.messages[0].contains("Second.swift"))
+        // Soft count first: `announcement(in:after:)` throws, so anything
+        // ordered after it is missing from the failure report exactly when
+        // the report matters most.
+        #expect(recorder.messages.count == baseline + 1)
+        let announced = try announcement(in: recorder, after: baseline)
+        #expect(announced.contains("Second.swift"))
         withExtendedLifetime(hosted) {}
     }
 
@@ -77,19 +187,230 @@ struct CommandOverlayHostedAnnouncementTests {
             field.delegate as? QuickOpenSearchField.Coordinator
         )
 
-        #expect(await waitUntil {
-            recorder.messages.contains { $0.hasPrefix("2 results.") }
-        })
-        recorder.messages.removeAll()
+        try #require(
+            await settle {
+                recorder.messages.contains { $0.hasPrefix("2 results.") }
+            },
+            """
+            Hosted Symbol Navigator never published its result summary; \
+            recorded \(recorder.messages).
+            """
+        )
 
+        let baseline = recorder.messages.count
         #expect(coordinator.control(
             field,
             textView: NSTextView(),
             doCommandBy: #selector(NSResponder.moveDown(_:))
         ))
-        #expect(recorder.messages.count == 1)
-        #expect(recorder.messages[0].contains("beta"))
+        #expect(recorder.messages.count == baseline + 1)
+        let announced = try announcement(in: recorder, after: baseline)
+        #expect(announced.contains("beta"))
         withExtendedLifetime(hosted) {}
+    }
+
+    // MARK: - Failure-path regressions (#1506)
+
+    @Test("An empty recorder fails the announcement read instead of trapping")
+    func emptyRecorderFailsWithoutTrapping() throws {
+        let recorder = HostedOverlayAnnouncementRecorder()
+        var continuedPastRead = false
+
+        // `try` only because the `matching:` overload is `rethrows` for the
+        // `when:` short-circuit; with the default precondition the body's
+        // error is always absorbed here.
+        try withKnownIssue(
+            "Deliberate empty-recorder read: it must fail, never trap."
+        ) {
+            _ = try announcement(in: recorder, after: 0)
+            continuedPastRead = true
+        } matching: { Self.isExpectationFailure($0) }
+
+        #expect(continuedPastRead == false)
+        // Reaching this line at all is the regression: a bare `messages[0]`
+        // raises `EXC_BREAKPOINT`, which Swift Testing cannot contain, and the
+        // whole `PineTests` process dies with every unrelated test in it.
+        #expect(recorder.record("process survived the failed read"))
+        #expect(recorder.messages.count == 1)
+    }
+
+    @Test("A stale baseline fails the announcement read instead of trapping")
+    func staleBaselineFailsWithoutTrapping() throws {
+        let recorder = HostedOverlayAnnouncementRecorder()
+        #expect(recorder.record("2 results. Selected: First.swift"))
+        var continuedPastRead = false
+
+        // Nothing was announced after the summary, so the read must fail even
+        // though the recorder itself is non-empty.
+        try withKnownIssue("Deliberate short-recorder read: it must fail.") {
+            _ = try announcement(in: recorder, after: 1)
+            continuedPastRead = true
+        } matching: { Self.isExpectationFailure($0) }
+
+        #expect(continuedPastRead == false)
+        #expect(recorder.messages.count == 1)
+    }
+
+    @Test("The settle gate resolves on the first poll when already satisfied")
+    func settleResolvesWithoutYielding() async {
+        var polls = 0
+        var sleeps = 0
+        let settled = await settle(
+            sleeper: { _ in sleeps += 1 },
+            condition: {
+                polls += 1
+                return true
+            }
+        )
+
+        #expect(settled)
+        #expect(polls == 1)
+        // `polls == 1` alone would also hold for a "sleep first, then check"
+        // gate, which is the shape this test exists to rule out: it would add
+        // a poll interval of latency to every already-satisfied wait. The
+        // sleep spy is what rules it out, and it does so structurally — an
+        // elapsed-time bound here would be the one assertion in this file
+        // whose outcome depends on the host scheduler rather than on observed
+        // state, in a suite whose entire premise is that wall-clock readings
+        // in this process measure someone else's load.
+        #expect(
+            sleeps == 0,
+            "Settle gate slept \(sleeps) time(s) before its first check."
+        )
+    }
+
+    @Test("A never-satisfied settle gate terminates and fails softly")
+    func unsettledGateFailsWithoutTrapping() async {
+        var polls = 0
+        var sleeps = 0
+        let settled = await settle(
+            pollBudget: 3,
+            sleeper: { _ in sleeps += 1 },
+            condition: {
+                polls += 1
+                return false
+            }
+        )
+
+        #expect(settled == false)
+        // Three budgeted polls plus one final re-check after the last sleep.
+        #expect(polls == 4)
+        #expect(sleeps == 3)
+    }
+
+    @Test("The settle gate accepts a condition that only becomes true later")
+    func settleObservesLateCondition() async {
+        var polls = 0
+        var sleeps = 0
+        let settled = await settle(
+            pollBudget: 10,
+            sleeper: { _ in sleeps += 1 },
+            condition: {
+                polls += 1
+                return polls >= 3
+            }
+        )
+        #expect(settled)
+        #expect(polls == 3)
+        // One sleep between each pair of polls, none after the last.
+        #expect(sleeps == 2)
+    }
+
+    @Test("The settle gate re-checks once and stops when the sleeper throws")
+    func settleStopsWhenSleepIsCancelled() async {
+        var polls = 0
+        // Stands in for `.timeLimit` cancelling `Task.sleep`: the gate must
+        // report on what it can observe *now* rather than burning the rest of
+        // its budget and adding a second issue on top of the time-limit one.
+        let settled = await settle(
+            pollBudget: 100,
+            sleeper: { _ in throw CancellationError() },
+            condition: {
+                polls += 1
+                return polls >= 3
+            }
+        )
+        #expect(settled == false)
+        // One budgeted poll, one throwing sleep, one final re-check.
+        #expect(polls == 2)
+    }
+
+    // MARK: - Helpers
+
+    /// Reads the announcement recorded after `baseline`.
+    ///
+    /// Every hosted assertion funnels through here on purpose. A direct
+    /// `recorder.messages[0]` after a *soft* count expectation turns one failed
+    /// expectation into an `EXC_BREAKPOINT` that takes the entire `PineTests`
+    /// process down (#1506); `#require` throws instead, so the test fails and
+    /// the process keeps running.
+    private func announcement(
+        in recorder: HostedOverlayAnnouncementRecorder,
+        after baseline: Int,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) throws -> String {
+        try #require(
+            recorder.messages.dropFirst(baseline).first,
+            """
+            Expected an announcement after index \(baseline); \
+            recorded \(recorder.messages).
+            """,
+            sourceLocation: sourceLocation
+        )
+    }
+
+    /// Whether `issue` is an expectation failure rather than some other kind
+    /// of recorded issue.
+    ///
+    /// Used to narrow `withKnownIssue` so it swallows only the failure the
+    /// test deliberately provokes. Both branches are load-bearing across
+    /// swift-testing versions: a failed `#require` records
+    /// `.expectationFailed` and throws `ExpectationFailedError`, and which of
+    /// the two the recorded issue carries is an implementation detail of the
+    /// framework, not something this test should depend on.
+    nonisolated private static func isExpectationFailure(
+        _ issue: Issue
+    ) -> Bool {
+        if case .expectationFailed = issue.kind { return true }
+        return issue.error is ExpectationFailedError
+    }
+
+    /// Polls `condition` on the main actor, sleeping between attempts.
+    ///
+    /// Budgeted in polls rather than elapsed time — see `settlePollBudget`
+    /// for what that trades away. The suite-level `.timeLimit` is the ceiling
+    /// that keeps an unsatisfiable budget from reading as a hung run.
+    ///
+    /// `sleeper` is injectable so the gate's own behaviour can be asserted
+    /// structurally — "did it sleep before the first check" is a question
+    /// about the loop, and answering it by reading a clock inside this
+    /// process would reintroduce exactly the wall-clock dependency #1506 is
+    /// about. Production call sites take the default.
+    ///
+    /// A throwing sleeper ends the wait after one more check rather than
+    /// being swallowed. That matters when the suite `.timeLimit` fires:
+    /// `Task.sleep` throws `CancellationError`, and a `try?` here would let
+    /// the loop grind through its remaining budget and then return `false`,
+    /// so the caller's `#require` would stack a second issue on top of
+    /// `timeLimitExceeded` — two failures for one cause, in a report whose
+    /// readability is the whole point of #1506.
+    private func settle(
+        pollBudget: Int = CommandOverlayHostedAnnouncementTests
+            .settlePollBudget,
+        sleeper: @MainActor (Duration) async throws -> Void = {
+            try await Task.sleep(for: $0)
+        },
+        condition: @MainActor () -> Bool
+    ) async -> Bool {
+        for _ in 0..<pollBudget {
+            if condition() { return true }
+            do {
+                try await sleeper(Self.settlePollInterval)
+            } catch {
+                return condition()
+            }
+        }
+        return condition()
     }
 
     private func host<Content: View>(
@@ -114,19 +435,6 @@ struct CommandOverlayHostedAnnouncementTests {
             }
         }
         return nil
-    }
-
-    private func waitUntil(
-        timeout: Duration = .seconds(2),
-        condition: @MainActor () -> Bool
-    ) async -> Bool {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: timeout)
-        while !condition() {
-            guard clock.now < deadline else { return false }
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-        return true
     }
 }
 

--- a/PineTests/CommandOverlaySelectionAnnouncementTests.swift
+++ b/PineTests/CommandOverlaySelectionAnnouncementTests.swift
@@ -9,12 +9,39 @@ import Testing
 
 @testable import Pine
 
-@Suite("Command overlay selection announcements")
+/// Unit coverage for `CommandOverlaySelectionAnnouncer` and the localization
+/// catalog behind the overlay announcements (#1497).
+///
+/// Time-limited deliberately: `settle` is budgeted in polls, not wall-clock
+/// time, so a broken announcer does not fail fast — it spends its whole budget
+/// waiting. Without a ceiling that reads as a hung run rather than a red test,
+/// which is exactly the unreadable failure mode #1506 was filed about. The
+/// limit is per test, not per suite, and it tightens rather than loosens the
+/// status quo — the bundle runs with `-test-timeouts-enabled YES` and no
+/// `-default-test-execution-time-allowance`, so the alternative is Xcode's
+/// 600-second default.
+///
+/// Three minutes, not one — see the same note on
+/// `CommandOverlayHostedAnnouncementTests`. The headroom is sized from a
+/// *local* measurement: on macOS 27.0 (26A5416b) / Xcode 27.0 (27A5237l) /
+/// macosx SDK 27.0 (26A5406c), a full parallel `PineTests` run records
+/// 59.7–61.8 seconds of elapsed time for tests that do no I/O whatsoever, so
+/// a one-minute ceiling fires there on runs that are otherwise healthy. CI
+/// does not show this: the macos-26 runner completes 6744 tests in 396.658 s
+/// with zero retries.
+@Suite("Command overlay selection announcements", .timeLimit(.minutes(3)))
 @MainActor
 struct CommandOverlaySelectionAnnouncementTests {
     private static let languages = [
         "de", "en", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-Hans",
     ]
+
+    /// Settle budget in polls — see `settle(pollBudget:condition:)`.
+    private static let settlePollBudget = 200
+
+    /// Wait between polls so the announcer's debounced task can run. Sleeping
+    /// leaves the main actor free; spinning on `Task.yield()` did not.
+    private static let settlePollInterval = Duration.milliseconds(5)
 
     private static let localizationKeys = [
         "commandOverlay.announcement.noResults",
@@ -34,11 +61,14 @@ struct CommandOverlaySelectionAnnouncementTests {
 
         announcer.schedule("Old results", using: recorder.record)
         announcer.schedule("Current results", using: recorder.record)
-        let delivered = await waitUntil {
+        let delivered = await settle {
             recorder.messages == ["Current results"]
         }
 
-        #expect(delivered)
+        #expect(
+            delivered,
+            "Announcer never delivered; recorded \(recorder.messages)."
+        )
         #expect(recorder.messages == ["Current results"])
     }
 
@@ -67,6 +97,14 @@ struct CommandOverlaySelectionAnnouncementTests {
         announcer.announceImmediately("Stale row") { _ in false }
 
         #expect(recorder.messages == ["Same row"])
+
+        // The rejected delivery must not have moved the duplicate-suppression
+        // boundary. `deliverIfNeeded` only advances `lastDeliveredMessage`
+        // once the sink accepts; drop that guard (`_ = sink(message)`) and
+        // every assertion above still passes, while "Stale row" is recorded
+        // as spoken and this line goes permanently silent for VoiceOver.
+        announcer.announceImmediately("Stale row", using: recorder.record)
+        #expect(recorder.messages == ["Same row", "Stale row"])
     }
 
     @Test("Quick Open includes useful path context without duplication")
@@ -197,17 +235,50 @@ struct CommandOverlaySelectionAnnouncementTests {
         return try #require(root["strings"] as? [String: Any])
     }
 
-    private func waitUntil(
-        timeout: Duration = .seconds(1),
+    /// Polls `condition`, budgeted in scheduling opportunities rather than
+    /// wall-clock time.
+    ///
+    /// The previous shape — a one-second deadline spun with `Task.yield()` —
+    /// failed for reasons that had nothing to do with the announcer. In a
+    /// local Xcode run `PineTests` executes its suites in parallel inside one
+    /// process (the default there; CI passes `-parallel-testing-enabled NO`
+    /// at `.github/workflows/ci.yml:324` and `:396`, so on CI the suites are
+    /// sequential and this budget degrades to an ordinary 1-second deadline),
+    /// and unrelated `@MainActor` suites block the main thread for seconds at
+    /// a time: `GitStatusProviderTests` runs `/bin/sh` through
+    /// `process.waitUntilExit()`, and `AgentHistoryCheckedUndoEngineTests`
+    /// blocks on `DispatchSemaphore.wait(timeout:)` for up to two seconds. The
+    /// deadline expired while the announcer's debounced delivery never got a
+    /// turn, and the busy `Task.yield()` loop burned the main actor it was
+    /// waiting on.
+    ///
+    /// Counting polls instead makes starvation delay the gate rather than fail
+    /// it, and sleeping between polls leaves the main actor free. It is not
+    /// determinism, though: it is still a budget, just one denominated in
+    /// something the test controls. A real announcer regression that needs
+    /// between roughly 30 and roughly 200 scheduling opportunities now passes
+    /// here where it used to fail; the suite-level `.timeLimit` is what keeps
+    /// an unsatisfiable budget from reading as a hung run (#1506).
+    ///
+    /// A cancelled sleep ends the wait after one more check rather than being
+    /// swallowed. When the suite `.timeLimit` fires, `Task.sleep` throws; a
+    /// `try?` here would let the loop grind through its remaining budget and
+    /// return `false`, stacking a second issue on top of `timeLimitExceeded`
+    /// — two failures for one cause.
+    private func settle(
+        pollBudget: Int = CommandOverlaySelectionAnnouncementTests
+            .settlePollBudget,
         condition: @MainActor () -> Bool
     ) async -> Bool {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: timeout)
-        while !condition() {
-            guard clock.now < deadline else { return false }
-            await Task.yield()
+        for _ in 0..<pollBudget {
+            if condition() { return true }
+            do {
+                try await Task.sleep(for: Self.settlePollInterval)
+            } catch {
+                return condition()
+            }
         }
-        return true
+        return condition()
     }
 }
 

--- a/PineTests/CommandPaletteHostedInteractionTests.swift
+++ b/PineTests/CommandPaletteHostedInteractionTests.swift
@@ -78,9 +78,16 @@ struct CommandPaletteHostedInteractionTests {
             doCommandBy: #selector(NSResponder.moveDown(_:))
         ))
 
+        // Soft expectations first: a `#require` throws out of the test, so
+        // anything ordered after it is missing from the failure report exactly
+        // when the report matters most.
         #expect(state.announcements.count == 1)
-        #expect(state.announcements[0].contains("Second Task"))
         #expect(state.isPresented)
+        // `#require`, never a bare subscript: a hosted view that has not
+        // settled announces nothing, and a subscript on the empty result traps
+        // the whole `PineTests` process instead of failing this test (#1506).
+        let announced = try #require(state.announcements.first)
+        #expect(announced.contains("Second Task"))
         _ = hosted
     }
 

--- a/PineTests/LSPSettingsTests.swift
+++ b/PineTests/LSPSettingsTests.swift
@@ -530,12 +530,26 @@ struct LSPSettingsLifecycleTests {
 
         manager.didOpen(url: swiftURL, text: "let value = 1")
         manager.didOpen(url: pythonURL, text: "value = 1")
-        await waitUntil {
-            manager.servers.count == 2
-                && manager.servers.values.allSatisfy {
-                    $0.state == .initialized
-                }
-        }
+        // `#expect`, not `#require`: collect the whole picture instead of
+        // stopping at the first symptom. Nothing between here and the reads
+        // below can trap on an unsatisfied wait — every read is a `#require`
+        // or an `Optional` chain — so continuing costs nothing and a failure
+        // here reports the startup timeout *and* whatever the restart
+        // actually produced. (Note this is not a double-report question:
+        // `waitUntil` records its own issue and returns `false`, so a timeout
+        // is reported twice either way.)
+        #expect(
+            await waitUntil {
+                manager.servers.count == 2
+                    && manager.servers.values.allSatisfy {
+                        $0.state == .initialized
+                    }
+            },
+            """
+            Both language servers must be initialized before the restart; \
+            everything below measures the restart, not the startup.
+            """
+        )
 
         try settings.setServerOverride(
             language: "swift",
@@ -549,15 +563,41 @@ struct LSPSettingsLifecycleTests {
         let swiftClients = try #require(clientsByLanguage["swift"])
         let pythonClients = try #require(clientsByLanguage["python"])
         #expect(swiftClients.count == 2)
-        #expect(swiftClients[0].gracefulShutdownCount == 1)
-        #expect(
-            swiftClients[1].starts.first?.arguments
-                == ["$(literal)", "--stdio"]
-        )
-        #expect(swiftClients[1].opens.count == 1)
-        #expect(swiftClients[1].opens.first?.text == "let value = 2")
         #expect(pythonClients.count == 1)
+        // `[0]` is safe by construction — the only writer is
+        // `clientsByLanguage[language, default: []].append(client)`, so a key
+        // exists only once it holds at least one element.
+        #expect(swiftClients[0].gracefulShutdownCount == 1)
         #expect(pythonClients[0].gracefulShutdownCount == 0)
+
+        // `[1]` is not. The replacement client exists only if
+        // `applySettingsChange(.language("swift"))` carries the restart all
+        // the way through, and there are six ways for it not to. Two are
+        // `guard`s in `replayDocuments` (`LSPManager.swift:977-986`):
+        // disabled / epoch-superseded / no registry entry, and no open
+        // documents. The other four are the early exits in `ensureServer`
+        // (`:822-857`), which `replayDocuments` delegates its third `guard`
+        // to and which all return before `clientFactory` runs: the
+        // lifecycle/cancellation gate, an in-flight restart for the language,
+        // an entry already present for the language, and an unresolved launch
+        // configuration. (A seventh path — `replayDocuments`' final
+        // `canContinue(epoch:)` at `:988` — does create the client but skips
+        // the replay, so it fails the `opens` assertions instead of the
+        // count.) Any of the six leaves the count at 1, and a bare
+        // `swiftClients[1]` after a *soft* `#expect(count == 2)` raises
+        // `EXC_BREAKPOINT` — killing the whole `PineTests` process along with
+        // every unrelated suite sharing it (#1506). `#require` throws
+        // instead.
+        let restarted = try #require(
+            swiftClients.dropFirst().first,
+            """
+            The swift language server never came back after \
+            `applySettingsChange(.language("swift"))`.
+            """
+        )
+        #expect(restarted.starts.first?.arguments == ["$(literal)", "--stdio"])
+        #expect(restarted.opens.count == 1)
+        #expect(restarted.opens.first?.text == "let value = 2")
     }
 
     @Test("Disable stops clients, blocks lazy launch, and enable restores them")
@@ -1384,13 +1424,22 @@ struct LSPSettingsLifecycleTests {
         #expect(client.documentSymbolRequests.count == 2)
     }
 
+    /// Polls `condition`, returning whether it ever became true.
+    ///
+    /// The result is `@discardableResult` because most call sites here only
+    /// need the recorded issue. Any call site that goes on to index into
+    /// something the wait was supposed to populate must *not* discard it — a
+    /// soft timeout followed by a hard subscript is how a single flaky wait
+    /// takes down the whole `PineTests` process (#1506).
+    @discardableResult
     private func waitUntil(
         _ condition: @escaping @MainActor () -> Bool
-    ) async {
+    ) async -> Bool {
         for _ in 0..<100 {
-            if condition() { return }
+            if condition() { return true }
             await Task.yield()
         }
         Issue.record("Timed out waiting for LSP test state")
+        return false
     }
 }

--- a/PineTests/TerminalManagerTests.swift
+++ b/PineTests/TerminalManagerTests.swift
@@ -202,7 +202,7 @@ struct TerminalManagerTests {
 
     @Test("search finds matches in terminal buffer")
     @MainActor
-    func searchFindsMatches() async {
+    func searchFindsMatches() async throws {
         let tab = TerminalTab(name: "Test")
         let terminal = tab.terminalView.getTerminal()
         terminal.feed(text: "hello world\r\nhello pine\r\ngoodbye\r\n")
@@ -211,10 +211,12 @@ struct TerminalManagerTests {
 
         #expect(tab.searchMatches.count == 2)
         #expect(tab.currentMatchIndex == 0)
-        #expect(tab.searchMatches[0].row == 0)
-        #expect(tab.searchMatches[0].col == 0)
-        #expect(tab.searchMatches[0].length == 5)
-        #expect(tab.searchMatches[1].row == 1)
+        let first = try #require(tab.searchMatches.first)
+        let second = try #require(tab.searchMatches.dropFirst().first)
+        #expect(first.row == 0)
+        #expect(first.col == 0)
+        #expect(first.length == 5)
+        #expect(second.row == 1)
     }
 
     @Test("search finds multiple matches on same line")
@@ -227,9 +229,7 @@ struct TerminalManagerTests {
         await tab.search(for: "abc")
 
         #expect(tab.searchMatches.count == 3)
-        #expect(tab.searchMatches[0].col == 0)
-        #expect(tab.searchMatches[1].col == 4)
-        #expect(tab.searchMatches[2].col == 8)
+        #expect(tab.searchMatches.map(\.col) == [0, 4, 8])
     }
 
     @Test("search is case-insensitive by default")
@@ -246,7 +246,7 @@ struct TerminalManagerTests {
 
     @Test("search respects case sensitivity flag")
     @MainActor
-    func searchCaseSensitive() async {
+    func searchCaseSensitive() async throws {
         let tab = TerminalTab(name: "Test")
         let terminal = tab.terminalView.getTerminal()
         terminal.feed(text: "Hello HELLO hello\r\n")
@@ -254,7 +254,8 @@ struct TerminalManagerTests {
         await tab.search(for: "hello", caseSensitive: true)
 
         #expect(tab.searchMatches.count == 1)
-        #expect(tab.searchMatches[0].col == 12)
+        let match = try #require(tab.searchMatches.first)
+        #expect(match.col == 12)
     }
 
     @Test("nextMatch wraps around to first match")
@@ -307,7 +308,7 @@ struct TerminalManagerTests {
 
     @Test("new search replaces previous results")
     @MainActor
-    func newSearchReplacesOld() async {
+    func newSearchReplacesOld() async throws {
         let tab = TerminalTab(name: "Test")
         let terminal = tab.terminalView.getTerminal()
         terminal.feed(text: "foo bar baz\r\n")
@@ -317,7 +318,8 @@ struct TerminalManagerTests {
 
         await tab.search(for: "bar")
         #expect(tab.searchMatches.count == 1)
-        #expect(tab.searchMatches[0].col == 4)
+        let match = try #require(tab.searchMatches.first)
+        #expect(match.col == 4)
     }
 
     @Test("search for nonexistent text returns empty")
@@ -345,7 +347,7 @@ struct TerminalManagerTests {
 
     @Test("single character search")
     @MainActor
-    func singleCharSearch() async {
+    func singleCharSearch() async throws {
         let tab = TerminalTab(name: "Test")
         let terminal = tab.terminalView.getTerminal()
         terminal.feed(text: "abcabc\r\n")
@@ -353,9 +355,11 @@ struct TerminalManagerTests {
         await tab.search(for: "a")
 
         #expect(tab.searchMatches.count == 2)
-        #expect(tab.searchMatches[0].col == 0)
-        #expect(tab.searchMatches[0].length == 1)
-        #expect(tab.searchMatches[1].col == 3)
+        let first = try #require(tab.searchMatches.first)
+        #expect(first.col == 0)
+        #expect(first.length == 1)
+        let second = try #require(tab.searchMatches.dropFirst().first)
+        #expect(second.col == 3)
     }
 
     @Test("navigation with single match stays at index 0")
@@ -384,8 +388,7 @@ struct TerminalManagerTests {
         await tab.search(for: "aa")
 
         #expect(tab.searchMatches.count == 2)
-        #expect(tab.searchMatches[0].col == 0)
-        #expect(tab.searchMatches[1].col == 2)
+        #expect(tab.searchMatches.map(\.col) == [0, 2])
     }
 
     @Test("search with unicode characters")
@@ -414,7 +417,7 @@ struct TerminalManagerTests {
 
     @Test("search across empty lines in buffer")
     @MainActor
-    func searchWithEmptyLines() async {
+    func searchWithEmptyLines() async throws {
         let tab = TerminalTab(name: "Test")
         let terminal = tab.terminalView.getTerminal()
         terminal.feed(text: "match\r\n\r\n\r\nmatch\r\n")
@@ -423,12 +426,14 @@ struct TerminalManagerTests {
 
         #expect(tab.searchMatches.count == 2)
         // Rows should not be adjacent due to empty lines
-        #expect(tab.searchMatches[0].row != tab.searchMatches[1].row)
+        let first = try #require(tab.searchMatches.first)
+        let second = try #require(tab.searchMatches.dropFirst().first)
+        #expect(first.row != second.row)
     }
 
     @Test("search after clearSearch then new search works")
     @MainActor
-    func searchAfterClear() async {
+    func searchAfterClear() async throws {
         let tab = TerminalTab(name: "Test")
         let terminal = tab.terminalView.getTerminal()
         terminal.feed(text: "foo bar\r\n")
@@ -441,12 +446,13 @@ struct TerminalManagerTests {
 
         await tab.search(for: "bar")
         #expect(tab.searchMatches.count == 1)
-        #expect(tab.searchMatches[0].col == 4)
+        let match = try #require(tab.searchMatches.first)
+        #expect(match.col == 4)
     }
 
     @Test("case sensitive search finds exact match only")
     @MainActor
-    func caseSensitiveExact() async {
+    func caseSensitiveExact() async throws {
         let tab = TerminalTab(name: "Test")
         let terminal = tab.terminalView.getTerminal()
         terminal.feed(text: "Error error ERROR\r\n")
@@ -454,7 +460,8 @@ struct TerminalManagerTests {
         await tab.search(for: "Error", caseSensitive: true)
 
         #expect(tab.searchMatches.count == 1)
-        #expect(tab.searchMatches[0].col == 0)
+        let match = try #require(tab.searchMatches.first)
+        #expect(match.col == 0)
     }
 
     @Test("switching case sensitivity changes results")
@@ -568,7 +575,7 @@ struct TerminalManagerTests {
 
     @Test("rapid sequential searches replace previous results")
     @MainActor
-    func rapidSequentialSearches() async {
+    func rapidSequentialSearches() async throws {
         let tab = TerminalTab(name: "Test")
         let terminal = tab.terminalView.getTerminal()
         terminal.feed(text: "alpha beta gamma\r\n")
@@ -578,21 +585,34 @@ struct TerminalManagerTests {
 
         await tab.search(for: "beta")
         #expect(tab.searchMatches.count == 1)
-        #expect(tab.searchMatches[0].col == 6, "Should find 'beta' at col 6")
+        let betaMatch = try #require(tab.searchMatches.first)
+        #expect(betaMatch.col == 6, "Should find 'beta' at col 6")
 
         await tab.search(for: "gamma")
         #expect(tab.searchMatches.count == 1)
-        #expect(tab.searchMatches[0].col == 11)
+        let gammaMatch = try #require(tab.searchMatches.first)
+        #expect(gammaMatch.col == 11)
     }
 
     @Test("navigation through many matches visits all of them")
     @MainActor
-    func navigationThroughAllMatches() async {
+    func navigationThroughAllMatches() async throws {
         let tab = TerminalTab(name: "Test")
         let terminal = tab.terminalView.getTerminal()
         terminal.feed(text: "a a a a a\r\n")
 
         await tab.search(for: "a")
+        // Hard gate, not a soft `#expect`: `1..<count` traps with "Range
+        // requires lowerBound <= upperBound" on an empty result, and a trap
+        // takes the whole `PineTests` process down rather than this test
+        // (#1506). Same failure class as a bare subscript, different
+        // construct — found by mutating `TerminalTab.search` to yield no
+        // matches, which is reachable in production via the post-`await`
+        // `guard !Task.isCancelled` and a failed buffer decode.
+        try #require(
+            !tab.searchMatches.isEmpty,
+            "Search returned no matches, so there is nothing to navigate."
+        )
         let count = tab.searchMatches.count
         #expect(count == 5)
 
@@ -622,14 +642,15 @@ struct TerminalManagerTests {
 
     @Test("search match position is correct with leading spaces")
     @MainActor
-    func searchWithLeadingSpaces() async {
+    func searchWithLeadingSpaces() async throws {
         let tab = TerminalTab(name: "Test")
         let terminal = tab.terminalView.getTerminal()
         terminal.feed(text: "    indented\r\n")
 
         await tab.search(for: "indented")
         #expect(tab.searchMatches.count == 1)
-        #expect(tab.searchMatches[0].col == 4, "Match should account for leading spaces")
+        let match = try #require(tab.searchMatches.first)
+        #expect(match.col == 4, "Match should account for leading spaces")
     }
 
     // MARK: - Environment construction tests (#551)
@@ -680,7 +701,7 @@ struct TerminalManagerTests {
     }
 
     @Test("buildEnvironment produces valid KEY=VALUE strings")
-    func buildEnvironmentMapFormat() {
+    func buildEnvironmentMapFormat() throws {
         let tab = TerminalTab(name: "test")
         let env = tab.buildEnvironment()
         let envStrings = env.map { "\($0.key)=\($0.value)" }
@@ -688,7 +709,11 @@ struct TerminalManagerTests {
         for entry in envStrings {
             #expect(entry.contains("="), "Each env entry must contain '='")
             let parts = entry.split(separator: "=", maxSplits: 1)
-            #expect(!parts[0].isEmpty, "Key must not be empty in: \(entry)")
+            // `split` omits empty subsequences, so an entry of exactly "="
+            // yields an empty array and `parts[0]` would trap the whole
+            // process instead of failing this test (#1506).
+            let key = try #require(parts.first, "Empty env entry: \(entry)")
+            #expect(!key.isEmpty, "Key must not be empty in: \(entry)")
         }
 
         #expect(envStrings.contains("PINE_TERMINAL=1"))


### PR DESCRIPTION
Closes #1506.

## What this fixes

Four test files read a collection element with a bare subscript immediately after a **soft** `#expect` on its count. When the count assertion fails, the subscript traps. A Swift trap is not a test failure — `EXC_BREAKPOINT` cannot be contained by Swift Testing, so the entire `PineTests` process dies and takes every unrelated test in it along. This PR replaces those reads with `#require`, so the same condition produces one red test instead of a dead process.

## Why this matters on CI, independent of parallelism

`.github/workflows/ci.yml:395` passes `-retry-tests-on-failure` **without** `-test-repetition-relaunch-enabled`, so retries re-run **in the same process**. A trap kills that process; the retry cannot save it, and `validate_test_results.py` is fail-closed. The blast radius is therefore the **entire 6744-test run**, not one test. Converting the subscript to `#require` converts "lose the whole run" into "one red test". That is a CI-level improvement, not local convenience.

## The failure class is real, and demonstrated

`TerminalTab.search` can leave `searchMatches` empty by at least three routes: the post-`await` `guard !Task.isCancelled` at `Pine/TerminalSession.swift:2624` returns without assigning; `String(data:encoding:)` returning nil; `getBufferAsData()` on a windowless `TerminalView`. Injecting the second of these (`scan` yields nothing) and running `TerminalManagerTests`:

- **before this PR:** 48 × `Fatal error: Index out of range`, 2 × `Range requires lowerBound <= upperBound`, **25 process restarts**, no usable report. Crash dumps show `_swiftEmptyArrayStorage` in `x20`/`x22` — the array is empty, not merely short.
- **after this PR:** 82 tests, 48 recorded issues, **0 restarts**, every failure named and located.

These are **deliberate fault injections, not observed field crashes**. They establish the mechanism and the blast radius, not a frequency. Ten isolated iterations of the unmutated suite pass with zero restarts.

## Scope of the audit — deliberately partial

`TerminalManagerTests` is converted in full (20 subscript sites across 11 tests, plus the two constructs named above).

**The class is not eliminated.** A review scan found roughly 20 further files and ~34 tests. The worst instance is **not** in this PR: `PineTests/DialogPresentationCoordinatorTests.swift:64` calls `completions[0](.alertFirstButtonReturn)` with **no count assertion at all**, after a `settle()` (`:15-19`) that is eight bare `Task.yield()` calls. That is a stronger instance than three of the five files fixed here. Also outstanding: `FoldingCoordinatorTests`, `TabCloseHelperBulkTests`, `UserConfigurationAlertPresenterTests` (3 tests each), `AgentTaskRegistryTests`, `IntegrationSearchTests`, `ProjectSearchProviderTests`, `LSPTransportTests`, `AgentHistoryCheckedUndoEngineTests`, `UserConfigurationEditorTests` (2 each), and nine files with one each. A lint/grep gate to stop new instances is deferred to a follow-up — that gate, not this PR, is what would make the class non-recurring.

Note also that the issue's suggested starting point, `grep -nE '\.(first|last)!'`, is vacuous: zero hits across all 370 files in `PineTests/`, because `.swiftlint.yml:22` already opts into `force_unwrapping` and CI runs `swiftlint --strict`.

## Readiness gates

The wall-clock gates are replaced by poll budgets with an injectable sleeper. This is **not** deterministic settling — it is still a budget (~300 vs ~200 scheduling opportunities), and a regression needing between ~30 and ~300 would now pass where it used to fail. Real determinism needs a production seam: `CommandOverlaySelectionAnnouncer.init(delay:)` exists but no view forwards it, and `Pine/QuickOpenView.swift:176` hardcodes a 150 ms search debounce with no seam at all. That is out of scope for a test-only change.

## Traits

`.timeLimit(.minutes(3))` **tightens** current behaviour rather than relaxing it: the bundle runs `-test-timeouts-enabled YES` with no `-default-test-execution-time-allowance`, so these tests inherit Xcode's 600-second per-test default today. The limit is per test, not per suite, and is far below the job's `timeout-minutes: 60` (current unit job: 8 m 36 s).

`withKnownIssue` is the repository's first use. The `xcresulttool` schema was checked across four versions: `Expected Failure` is in the enum and `validate_test_results.py:78` counts it as passed. Narrowing it requires matching on `Issue.kind == .expectationFailed` — `issue.error is ExpectationFailedError` does **not** match a failed `#require`, verified by mutation in this branch.

## On the measurements in the doc comments

The 59.7–61.8 s starvation figures are **local**, on macOS 27.0 (26A5416b) / Xcode 27.0 (27A5237l) / macosx SDK 27.0 (26A5406c), where `PineTests` runs suites in parallel by default. They are a property of that combination, not of the bundle. CI is sequential (`-parallel-testing-enabled NO`, `ci.yml:324` and `:396`, enforced by `scripts/tests/test-xcodebuild-cli-options.sh`) and completes 6744 tests in 396.658 s with zero retries; `AgentAdapterRegistryTests` takes 0.246 s there. The poll budgets degrade to plain 3 s / 1 s deadlines on CI; they are insurance for the local shape.

## Review and verification

Two independent review rounds, three reviewers each (correctness/sufficiency, test quality/honesty, CI impact), plus a fix pass after each. Findings resolved include: the readiness gate having no wall-clock backstop; a new timing assertion that was itself scheduler-dependent (removed entirely — the sleeper is now injected and the test asserts `sleeps == 0`); mis-identified risky coordinates in `LSPSettingsTests` (the safe `[0]` sites were flagged and the genuinely trapping `[1]` sites were not); a discarded `waitUntil` result; a fixed `/tmp` fixture path that let `UserDefaults` recent-file scores reorder results; and an unlocked dedup boundary in the announcer (a rejected announcement could permanently mute one row for VoiceOver — now pinned by test, production unchanged).

Local: `git diff --check` clean, `swiftlint --strict` clean, `xcodebuild build` and `build-for-testing` succeeded, six affected suites × 10 iterations green with 0 restarts, `TerminalManagerTests` isolated × 10 green. Production code is untouched — `git diff --name-only` is entirely under `PineTests/`. UI tests were not run locally.

Ready to merge once CI is green.
