### PR TITLE
fix(agent): restore a minimized project window instead of creating a new Welcome window

### DIFF
--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -1038,7 +1038,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         // user is not typing in. The two agree in every single-window state,
         // so nothing on screen would look wrong.
         keyWindow: { NSApp.keyWindow },
-        welcomeWindow: { [weak self] in self?.visibleWelcomeWindow() }
+        // `onScreenOrDock`: the presentation workflow deminiaturizes its
+        // host before presenting, so a minimized Welcome window is reused
+        // rather than bypassed in favour of creating a second one (#1507).
+        welcomeWindow: { [weak self] in
+            self?.welcomeHostWindow(reach: .onScreenOrDock)
+        }
     )
 
     private var welcomeVisibilityGeneration = 0
@@ -1082,11 +1087,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
     /// all, the eligibility conjunction, and Welcome's fixed last position.
     /// The pure ordering rule cannot catch a mistake made here.
     ///
-    /// - Note: `window.isVisible` reads `false` for a miniaturized window, so
-    ///   a project window in the Dock never becomes an eligible candidate and
-    ///   the request falls through to Welcome. That is current behavior, not
-    ///   an oversight of this projection; changing it changes where ⇧⌘I lands
-    ///   and belongs in its own change (#1507).
+    /// - Note: a project window in the Dock **is** a candidate (#1507). The
+    ///   Inbox workflow restores and focuses its host before presenting, so
+    ///   ``WindowRoutingReach/onScreenOrDock`` is the honest reach for it —
+    ///   `window.isVisible` alone reads `false` for a miniaturized window and
+    ///   would send ⇧⌘I to a new Welcome window while the user's project
+    ///   stayed in the Dock. The in-place command paths keep the narrower
+    ///   reach; see ``isEligibleRoutingWindow(_:delegate:reach:)``.
     func agentInboxHostOptions(
         windows: [NSWindow],
         keyWindow: NSWindow?,
@@ -1104,7 +1111,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     isKeyWindow: window === keyWindow,
                     isEligibleWindow: isEligibleRoutingWindow(
                         window,
-                        delegate: delegate
+                        delegate: delegate,
+                        reach: .onScreenOrDock
                     ),
                     showsMostRecentlyActiveProject: mostRecentProject != nil
                         && project === mostRecentProject
@@ -1165,12 +1173,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
     /// `NSApp.windows`; keeping a single copy of the rule is what stops ⇧⌘I
     /// and a delivered notification from disagreeing about which windows are
     /// still alive.
+    /// - Parameter reach: whether a window sitting in the Dock counts as
+    ///   present. Only callers that restore and focus the host before acting
+    ///   pass ``WindowRoutingReach/onScreenOrDock`` (#1507); the in-place
+    ///   command paths keep the on-screen requirement so a menu command can
+    ///   never mutate a window the user cannot see.
     private func isEligibleRoutingWindow(
         _ window: NSWindow,
-        delegate: CloseDelegate
+        delegate: CloseDelegate,
+        reach: WindowRoutingReach = .onScreenOnly
     ) -> Bool {
         !delegate.didCompleteWindowLifecycle
-            && window.isVisible
+            && reach.admitsWindow(
+                isVisible: window.isVisible,
+                isMiniaturized: window.isMiniaturized
+            )
             && registry.isWindowOpen(delegate.projectURL)
             && isRegisteredProject(delegate.projectManager)
     }
@@ -1364,16 +1381,38 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
     }
 
     private func visibleWelcomeWindow() -> NSWindow? {
+        welcomeHostWindow(reach: .onScreenOnly)
+    }
+
+    /// The Welcome window a caller with this reach may route to, cached on
+    /// ``welcomeWindow`` when a live one is found by identifier.
+    ///
+    /// The Inbox passes ``WindowRoutingReach/onScreenOrDock`` so a Welcome
+    /// window the user minimized is restored and reused instead of a second
+    /// one being created behind it (#1507). Every other caller wants a window
+    /// that can show UI right now and keeps ``WindowRoutingReach/onScreenOnly``.
+    /// - Parameter windows: the window list to scan, defaulting to
+    ///   `NSApp.windows`. Injectable because the unit test host accumulates
+    ///   windows from every suite that ran before, so identity assertions
+    ///   against the live list would answer for someone else's window.
+    func welcomeHostWindow(
+        reach: WindowRoutingReach,
+        windows: [NSWindow]? = nil
+    ) -> NSWindow? {
         if let welcomeWindow,
-           welcomeWindow.isVisible,
-           !welcomeWindow.isMiniaturized {
+           reach.admitsWindow(
+               isVisible: welcomeWindow.isVisible,
+               isMiniaturized: welcomeWindow.isMiniaturized
+           ) {
             return welcomeWindow
         }
-        guard let liveWindow = NSApp.windows.first(where: {
+        guard let liveWindow = (windows ?? NSApp.windows).first(where: {
             $0.identifier?.rawValue == "welcome"
                 && $0.contentView != nil
-                && $0.isVisible
-                && !$0.isMiniaturized
+                && reach.admitsWindow(
+                    isVisible: $0.isVisible,
+                    isMiniaturized: $0.isMiniaturized
+                )
         }) else {
             return nil
         }

--- a/Pine/WindowRoutingReach.swift
+++ b/Pine/WindowRoutingReach.swift
@@ -1,0 +1,54 @@
+//
+//  WindowRoutingReach.swift
+//  Pine
+//
+//  How far a routing caller can reach for a window that is not on screen
+//  (#1507).
+//
+
+import Foundation
+
+/// Whether routed work may land in a window that is sitting in the Dock.
+///
+/// `NSWindow.isVisible` reads `false` while a window is miniaturized —
+/// miniaturizing removes the window from the screen list — so an eligibility
+/// check written as `isVisible` alone silently refuses every minimized
+/// window. Verified on macOS 27.0 (26A5416b): a miniaturized window reports
+/// `isVisible == false`, `isMiniaturized == true`, and stays in
+/// `NSApp.windows`; an ordered-out window reports `false` for both. The rule
+/// below therefore admits a Dock window through `isMiniaturized`, never by
+/// weakening the visibility test, so a closed or hidden window remains
+/// refused on either macOS version.
+///
+/// The distinction is not cosmetic: a caller that mutates a window in place
+/// — New File, Close Tab — would apply the command invisibly to a window in
+/// the Dock, while a caller that restores and focuses its host first shows
+/// the user exactly where the work landed. Each caller states which of the
+/// two it is.
+enum WindowRoutingReach {
+    /// The caller acts on the window as it is. A window in the Dock would
+    /// receive the command without ever coming back on screen, so it is
+    /// refused.
+    case onScreenOnly
+    /// The caller restores and focuses its host before presenting, so a
+    /// window in the Dock is a legitimate destination — it comes back first.
+    case onScreenOrDock
+
+    /// Whether a window with these AppKit facts may receive routed work.
+    ///
+    /// The two flags are read independently rather than assuming AppKit's
+    /// coupling holds: `.onScreenOnly` answers "is this window on screen",
+    /// so the contradictory pair — visible *and* miniaturized, which macOS 27
+    /// never reports — resolves to "in the Dock" and is refused, matching the
+    /// explicit `isVisible && !isMiniaturized` test the Welcome lookup used
+    /// before this rule existed. `.onScreenOrDock` accepts either flag, so it
+    /// admits a Dock window on any macOS that disagrees about `isVisible`.
+    func admitsWindow(isVisible: Bool, isMiniaturized: Bool) -> Bool {
+        switch self {
+        case .onScreenOnly:
+            return isVisible && !isMiniaturized
+        case .onScreenOrDock:
+            return isVisible || isMiniaturized
+        }
+    }
+}

--- a/PineTests/AgentInboxHostOptionsTests.swift
+++ b/PineTests/AgentInboxHostOptionsTests.swift
@@ -143,16 +143,13 @@ struct AgentInboxHostOptionsTests {
 
     // MARK: - Eligibility
 
-    /// Leaving the screen is what costs a window its eligibility, and the same
-    /// `isVisible` conjunct decides it. A window ordered out is the one form
-    /// of "not on screen" this suite can produce: the unit test host is a
-    /// background application, where `miniaturize(nil)` never reaches the
-    /// Dock, so *minimized* is asserted nowhere here.
+    /// Leaving the screen is what costs a window its eligibility. A window
+    /// ordered out is the one form of "not on screen" that survives the
+    /// widened reach of #1507: the Inbox now admits a window in the Dock,
+    /// because it restores that host before presenting, but a window that was
+    /// ordered out shows nothing and can host nothing.
     ///
-    /// On a real desktop AppKit reports `isVisible == false` for a window in
-    /// the Dock too, which is why a minimized project window silently loses
-    /// the Inbox to Welcome instead of being restored (#1507). That behavior
-    /// is documented in `agentInboxHostOptions`, not claimed as covered.
+    /// See `dockedProjectWindowIsACandidate` for the other side of that line.
     @Test("leaving the screen costs a window its eligibility")
     func orderedOutWindowLosesEligibility() throws {
         let fixture = try Fixture()
@@ -521,6 +518,259 @@ struct AgentInboxHostOptionsTests {
         #expect(!found.isMiniaturized)
     }
 
+    // MARK: - Windows in the Dock (#1507)
+
+    /// The regression: `NSWindow.isVisible` reads `false` for a window in the
+    /// Dock, so an eligibility test written as `isVisible` alone bypassed the
+    /// user's minimized project and opened the Inbox in a freshly created
+    /// Welcome window instead. The Inbox reach admits it; the presentation
+    /// workflow deminiaturizes it before presenting.
+    @Test("a project window in the Dock is still a candidate")
+    func dockedProjectWindowIsACandidate() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let window = try fixture.makeProjectWindow(named: "alpha", inDock: true)
+
+        // The precondition the fix rests on, asserted rather than assumed.
+        #expect(window.isMiniaturized)
+        #expect(!window.isVisible)
+
+        let options = fixture.appDelegate.agentInboxHostOptions(
+            windows: [window],
+            keyWindow: nil,
+            welcomeWindow: nil
+        )
+
+        #expect(options.count == 1)
+        #expect(options.first?.candidate.isEligibleWindow == true)
+        #expect(options.first?.host === window)
+    }
+
+    /// Widening the reach must not widen anything else. This window is in the
+    /// Dock *and* its project has been closed into the registry's background
+    /// set, so exactly one of the other conjuncts is false — and that alone
+    /// is enough to refuse it.
+    @Test("a Dock window whose project closed is still refused")
+    func dockedWindowStillObeysTheOtherConjuncts() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let url = try fixture.makeProjectDirectory(named: "alpha")
+        let manager = try #require(fixture.registry.projectManager(for: url))
+        let window = fixture.makeWindow(inDock: true)
+        fixture.attachCloseDelegate(
+            to: window,
+            projectURL: url,
+            projectManager: manager
+        )
+
+        fixture.registry.closeProjectWindow(
+            url,
+            expectedManager: manager,
+            expectedWindowGeneration: nil
+        )
+
+        let options = fixture.appDelegate.agentInboxHostOptions(
+            windows: [window],
+            keyWindow: nil,
+            welcomeWindow: nil
+        )
+
+        #expect(window.isMiniaturized)
+        #expect(options.first?.candidate.isEligibleWindow == false)
+    }
+
+    /// #1507's headline shape: one project, minimized, no Welcome window in
+    /// sight. Before the fix this produced `.createWelcomeHost` and left the
+    /// project sitting in the Dock.
+    @Test("a lone minimized project hosts the Inbox instead of a new Welcome")
+    func loneMinimizedProjectWinsOverCreatingWelcome() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let window = try fixture.makeProjectWindow(named: "alpha", inDock: true)
+        fixture.noteKeyWindowSession(showing: "alpha")
+
+        let options = fixture.appDelegate.agentInboxHostOptions(
+            windows: [window],
+            keyWindow: nil,
+            welcomeWindow: nil
+        )
+        let decision = AgentInboxHostRouting.decision(
+            among: options.map(\.candidate)
+        )
+
+        guard case .existingHost(let index) = decision else {
+            Issue.record("Expected the minimized project, got \(decision)")
+            return
+        }
+        #expect(options[index].host === window)
+    }
+
+    /// A minimized project the user was last working in outranks a Welcome
+    /// window that happens to be on screen: Welcome is the fallback for when
+    /// no project can host the Inbox, not a reason to abandon one.
+    @Test("a minimized most-recent project outranks a visible Welcome")
+    func minimizedMostRecentProjectOutranksVisibleWelcome() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let project = try fixture.makeProjectWindow(
+            named: "alpha",
+            inDock: true
+        )
+        let welcome = fixture.makeWelcomeWindow()
+        fixture.noteKeyWindowSession(showing: "alpha")
+
+        let options = fixture.appDelegate.agentInboxHostOptions(
+            windows: [project],
+            keyWindow: nil,
+            welcomeWindow: welcome
+        )
+        let decision = AgentInboxHostRouting.decision(
+            among: options.map(\.candidate)
+        )
+
+        guard case .existingHost(let index) = decision else {
+            Issue.record("Expected the minimized project, got \(decision)")
+            return
+        }
+        #expect(options[index].host === project)
+    }
+
+    /// Two projects, one in the Dock: the window the user can already see and
+    /// is typing in keeps the Inbox. Restoring a window from the Dock is only
+    /// right when there is nothing better on screen.
+    @Test("a key on-screen project still beats a minimized one")
+    func keyOnScreenProjectBeatsMinimizedProject() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let minimized = try fixture.makeProjectWindow(
+            named: "alpha",
+            inDock: true
+        )
+        let onScreen = try fixture.makeProjectWindow(named: "beta")
+        // The minimized one is also the most recently active project, so the
+        // key window has to win on its own merits.
+        fixture.noteKeyWindowSession(showing: "alpha")
+
+        let options = fixture.appDelegate.agentInboxHostOptions(
+            windows: [minimized, onScreen],
+            keyWindow: onScreen,
+            welcomeWindow: nil
+        )
+        let decision = AgentInboxHostRouting.decision(
+            among: options.map(\.candidate)
+        )
+
+        #expect(options.allSatisfy { $0.candidate.isEligibleWindow })
+        guard case .existingHost(let index) = decision else {
+            Issue.record("Expected the key window, got \(decision)")
+            return
+        }
+        #expect(options[index].host === onScreen)
+    }
+
+    /// The Welcome half of the same fix. The Inbox source accepts a Welcome
+    /// window in the Dock, so the workflow restores the one that exists
+    /// instead of reaching `.createWelcomeHost` for a window the user already
+    /// has.
+    @Test("the Inbox Welcome source finds a Welcome window in the Dock")
+    func inboxWelcomeSourceFindsDockedWelcome() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let welcome = fixture.makeWelcomeWindow(inDock: true)
+
+        let found = try #require(
+            fixture.withOnlyOwnWelcomeWindow(welcome) {
+                fixture.appDelegate.agentInboxWindowSources.welcomeWindow()
+            },
+            "a minimized Welcome window is a host the Inbox can restore"
+        )
+
+        #expect(found === welcome)
+        #expect(found.isMiniaturized)
+    }
+
+    /// Every other caller wants a window that can show UI right now, and a
+    /// window in the Dock cannot. The narrower lookup is what `showWelcome()`
+    /// and the application dialog owner still read.
+    @Test("the on-screen Welcome lookup refuses a Welcome window in the Dock")
+    func onScreenWelcomeLookupRefusesDockedWelcome() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let welcome = fixture.makeWelcomeWindow(inDock: true)
+
+        // Prime the `welcomeWindow` cache through the wider reach first: a
+        // cached window must be re-checked against the caller's reach, not
+        // handed back because it was once found.
+        #expect(
+            fixture.appDelegate.welcomeHostWindow(
+                reach: .onScreenOrDock,
+                windows: [welcome]
+            ) === welcome
+        )
+
+        #expect(
+            fixture.appDelegate.welcomeHostWindow(
+                reach: .onScreenOnly,
+                windows: [welcome]
+            ) == nil
+        )
+    }
+
+    /// Both windows in the Dock: the project the user was last in still wins,
+    /// and the Inbox restores it rather than a Welcome window they minimized
+    /// and stopped caring about.
+    @Test("a minimized project outranks a minimized Welcome")
+    func minimizedProjectOutranksMinimizedWelcome() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let project = try fixture.makeProjectWindow(
+            named: "alpha",
+            inDock: true
+        )
+        let welcome = fixture.makeWelcomeWindow(inDock: true)
+        fixture.noteKeyWindowSession(showing: "alpha")
+
+        let options = fixture.appDelegate.agentInboxHostOptions(
+            windows: [project],
+            keyWindow: nil,
+            welcomeWindow: welcome
+        )
+        let decision = AgentInboxHostRouting.decision(
+            among: options.map(\.candidate)
+        )
+
+        guard case .existingHost(let index) = decision else {
+            Issue.record("Expected the minimized project, got \(decision)")
+            return
+        }
+        #expect(options[index].host === project)
+    }
+
+    /// No project at all and the only Welcome window is in the Dock. The
+    /// decision must reuse it — creating a second Welcome window behind a
+    /// minimized one is the duplicate-window shape #1507 reported.
+    @Test("a minimized Welcome is reused instead of creating a second one")
+    func minimizedWelcomeIsReusedNotDuplicated() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let welcome = fixture.makeWelcomeWindow(inDock: true)
+
+        let options = fixture.appDelegate.agentInboxHostOptions(
+            windows: [],
+            keyWindow: nil,
+            welcomeWindow: welcome
+        )
+        let decision = AgentInboxHostRouting.decision(
+            among: options.map(\.candidate)
+        )
+
+        guard case .existingHost(let index) = decision else {
+            Issue.record("Expected the minimized Welcome, got \(decision)")
+            return
+        }
+        #expect(options[index].host === welcome)
+    }
+
     // MARK: - Fixture
 
     @MainActor
@@ -578,10 +828,13 @@ struct AgentInboxHostOptionsTests {
             return url
         }
 
-        func makeWindow(onScreen: Bool = true) -> NSWindow {
-            let window = NSWindow(
+        func makeWindow(
+            onScreen: Bool = true,
+            inDock: Bool = false
+        ) -> NSWindow {
+            let window = DockableWindow(
                 contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
-                styleMask: [.titled, .closable],
+                styleMask: [.titled, .closable, .miniaturizable],
                 backing: .buffered,
                 defer: false
             )
@@ -591,6 +844,7 @@ struct AgentInboxHostOptionsTests {
             if onScreen {
                 window.orderFront(nil)
             }
+            window.isInDock = inDock
             windows.append(window)
             return window
         }
@@ -599,11 +853,12 @@ struct AgentInboxHostOptionsTests {
         /// the only shape that satisfies every eligibility conjunct.
         func makeProjectWindow(
             named name: String,
-            onScreen: Bool = true
+            onScreen: Bool = true,
+            inDock: Bool = false
         ) throws -> NSWindow {
             let url = try makeProjectDirectory(named: name)
             let manager = try #require(registry.projectManager(for: url))
-            let window = makeWindow(onScreen: onScreen)
+            let window = makeWindow(onScreen: onScreen, inDock: inDock)
             attachCloseDelegate(
                 to: window,
                 projectURL: url,
@@ -632,10 +887,38 @@ struct AgentInboxHostOptionsTests {
         /// A window shaped like Welcome for `visibleWelcomeWindow()`: the
         /// identifier it scans for, a mounted content view, and on screen.
         @discardableResult
-        func makeWelcomeWindow() -> NSWindow {
-            let window = makeWindow()
+        func makeWelcomeWindow(inDock: Bool = false) -> NSWindow {
+            let window = makeWindow(inDock: inDock)
             window.identifier = NSUserInterfaceItemIdentifier("welcome")
             return window
+        }
+
+        /// Runs `body` with every *other* Welcome-identified window in
+        /// `NSApp.windows` temporarily anonymised, so a source that scans the
+        /// live list answers about this fixture's window.
+        ///
+        /// The unit test host is one long-lived application: windows other
+        /// suites ordered out still sit in `NSApp.windows` with their
+        /// identifiers attached, and `first(where:)` finds the oldest one.
+        /// The identifiers are restored before `body` returns, and the whole
+        /// helper is synchronous, so no other main-actor test can observe the
+        /// windows while they are anonymous.
+        func withOnlyOwnWelcomeWindow<T>(
+            _ window: NSWindow,
+            _ body: () -> T
+        ) -> T {
+            let foreign = NSApp.windows.filter {
+                $0 !== window && $0.identifier?.rawValue == "welcome"
+            }
+            for other in foreign {
+                other.identifier = nil
+            }
+            defer {
+                for other in foreign {
+                    other.identifier = NSUserInterfaceItemIdentifier("welcome")
+                }
+            }
+            return body()
         }
 
         func makeForeignDelegate() -> any NSWindowDelegate {
@@ -657,7 +940,9 @@ struct AgentInboxHostOptionsTests {
         func cleanup() {
             for window in windows {
                 window.delegate = nil
+                (window as? DockableWindow)?.isInDock = false
                 window.orderOut(nil)
+                window.identifier = nil
             }
             windows.removeAll()
             delegates.removeAll()
@@ -671,4 +956,21 @@ struct AgentInboxHostOptionsTests {
     }
 
     private final class ForeignWindowDelegate: NSObject, NSWindowDelegate {}
+
+    /// A window that can report the AppKit facts of a window sitting in the
+    /// Dock without a window server.
+    ///
+    /// The unit test host is a background application: `miniaturize(nil)`
+    /// never reaches the Dock there, and it is animated and asynchronous even
+    /// when it does, so a real minimize cannot be asserted deterministically.
+    /// The staged facts are the ones measured on macOS 27.0 (26A5416b) — a
+    /// miniaturized window reports `isMiniaturized == true` and `isVisible ==
+    /// false` while staying in `NSApp.windows`.
+    private final class DockableWindow: NSWindow {
+        var isInDock = false
+
+        override var isMiniaturized: Bool { isInDock }
+
+        override var isVisible: Bool { isInDock ? false : super.isVisible }
+    }
 }

--- a/PineTests/AgentInboxPresentationCoordinatorTests.swift
+++ b/PineTests/AgentInboxPresentationCoordinatorTests.swift
@@ -39,23 +39,17 @@ struct AgentInboxPresentationCoordinatorTests {
     }
 
     /// `AgentInboxHosting` promises restore-then-focus, and this pins that
-    /// ordering — but it is a **protocol contract test, not evidence of a
-    /// user-visible behavior**. `AppDelegate.agentInboxHostOptions` derives
-    /// eligibility from `NSWindow.isVisible`, which reads `false` while a
-    /// window is in the Dock, and `visibleWelcomeWindow()` rejects
-    /// miniaturized windows outright — so this workflow never selects a
-    /// miniaturized host and cannot reach `restoreHostFromMiniaturized()`.
+    /// ordering for a host the workflow can now really be handed: since #1507
+    /// `agentInboxHostOptions` admits a project window in the Dock through
+    /// ``WindowRoutingReach/onScreenOrDock``, and the Inbox Welcome lookup
+    /// admits a minimized Welcome window, so `restoreHostFromMiniaturized()`
+    /// is reachable from the shipped selection path rather than only from a
+    /// staged double.
     ///
-    /// The gap is narrower than "minimized hosts are not restored": a
-    /// minimized Welcome window *is* brought back, because selection skips it,
-    /// the decision falls through to `.createWelcomeHost`, and
-    /// `ensureWelcomeVisible()` deminiaturizes it. What no code does is return
-    /// the user to a minimized **project** window: that window is silently
-    /// bypassed in favour of Welcome. #1491's "minimized hosts are restored
-    /// before presentation" is therefore **not covered** for project windows;
-    /// widening eligibility changes where ⇧⌘I lands and belongs in its own
-    /// change (#1507). This test exists so that change inherits a specified
-    /// workflow rather than an unspecified one.
+    /// Which windows arrive here is asserted in `AgentInboxHostOptionsTests`
+    /// ("Windows in the Dock"); this test owns the other half — that whatever
+    /// arrives minimized is deminiaturized *before* it is focused, so the
+    /// popover never anchors to a window still on its way out of the Dock.
     @Test("the hosting contract restores a host before it focuses it")
     func hostingContractRestoresBeforeFocusing() {
         let fixture = Fixture()

--- a/PineTests/WindowRoutingReachTests.swift
+++ b/PineTests/WindowRoutingReachTests.swift
@@ -1,0 +1,100 @@
+//
+//  WindowRoutingReachTests.swift
+//  PineTests
+//
+//  The reach rule that decides whether a window in the Dock may receive
+//  routed work (#1507).
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Window routing reach")
+struct WindowRoutingReachTests {
+    /// Every combination of the two AppKit flags, for both reaches. The rule
+    /// is four lines long, so an exhaustive table is cheaper than choosing
+    /// which cases matter — and it is the table that documents the decision
+    /// #1507 had to make.
+    @Test(
+        "each pair of AppKit facts admits exactly the intended windows",
+        arguments: [
+            // On screen: every caller may route here.
+            (true, false, true, true),
+            // In the Dock: only a caller that restores its host first.
+            (false, true, false, true),
+            // Ordered out, closed, or never shown: nobody may route here.
+            (false, false, false, false),
+            // AppKit never reports this pair; both reaches read it as
+            // "not on screen" rather than trusting one flag over the other.
+            (true, true, false, true),
+        ]
+    )
+    func admissionTable(
+        isVisible: Bool,
+        isMiniaturized: Bool,
+        onScreenOnlyAdmits: Bool,
+        onScreenOrDockAdmits: Bool
+    ) {
+        #expect(
+            WindowRoutingReach.onScreenOnly.admitsWindow(
+                isVisible: isVisible,
+                isMiniaturized: isMiniaturized
+            ) == onScreenOnlyAdmits
+        )
+        #expect(
+            WindowRoutingReach.onScreenOrDock.admitsWindow(
+                isVisible: isVisible,
+                isMiniaturized: isMiniaturized
+            ) == onScreenOrDockAdmits
+        )
+    }
+
+    /// The regression #1507 is about: the Inbox reach must not depend on
+    /// `isVisible` being `true` for a window in the Dock, because measured on
+    /// macOS 27.0 (26A5416b) it is `false`.
+    @Test("a window in the Dock is reachable without being visible")
+    func dockWindowIsReachable() {
+        #expect(
+            WindowRoutingReach.onScreenOrDock.admitsWindow(
+                isVisible: false,
+                isMiniaturized: true
+            )
+        )
+    }
+
+    /// The other half of that fix: widening the reach must not turn a closed
+    /// or hidden window into a destination. Both flags are `false` for an
+    /// ordered-out window, which is exactly the shape a weakened check would
+    /// let through.
+    @Test("widening the reach never admits an ordered-out window")
+    func widerReachStillRefusesHiddenWindows() {
+        #expect(
+            !WindowRoutingReach.onScreenOrDock.admitsWindow(
+                isVisible: false,
+                isMiniaturized: false
+            )
+        )
+    }
+
+    /// In-place command paths — New File, Close Tab — keep the narrow reach,
+    /// so the deliberate divergence between them and the Inbox is asserted
+    /// rather than left to a comment.
+    @Test("the two reaches disagree only about a window in the Dock")
+    func reachesDivergeOnlyInTheDock() {
+        let facts = [(true, false), (false, true), (false, false), (true, true)]
+        let divergent = facts.filter { isVisible, isMiniaturized in
+            WindowRoutingReach.onScreenOnly.admitsWindow(
+                isVisible: isVisible,
+                isMiniaturized: isMiniaturized
+            ) != WindowRoutingReach.onScreenOrDock.admitsWindow(
+                isVisible: isVisible,
+                isMiniaturized: isMiniaturized
+            )
+        }
+
+        #expect(divergent.allSatisfy { $0.1 })
+        #expect(divergent.count == 2)
+    }
+}


### PR DESCRIPTION
Closes #1507. Unblocks the "minimized hosts are restored before presentation" criterion in #1491, and with it the 2.6.0 release gate.

## The bug

⇧⌘I with the only project window minimized left that window in the Dock and opened the Agent Inbox in a **new Welcome window**.

`NSWindow.isVisible` reads `false` for a miniaturized window, and both Inbox host resolvers required it:

- `isEligibleRoutingWindow` — so a project window in the Dock was never a candidate;
- `visibleWelcomeWindow()` — so a minimized Welcome window produced no candidate either, and it was the only resolver behind the `.welcome` candidate.

The restore step the presentation workflow already implements (`isHostMiniaturized` → `restoreHostFromMiniaturized()`) was therefore structurally unreachable: every host that arrived there was non-miniaturized by construction.

## The fix

`WindowRoutingReach` makes each caller state whether a window in the Dock is a legitimate destination:

| Caller | Reach | Why |
|---|---|---|
| Agent Inbox host selection | `.onScreenOrDock` | deminiaturizes and focuses the host before presenting — the user sees where the work landed |
| `nativeCommandDestination` (New File, Open File, Close Tab, Close Window) | `.onScreenOnly` | shows nothing; routing into a Dock window would mutate it invisibly |

**On the shared predicate.** #1507 asks for a deliberate decision about `nativeCommandDestination`, which shares `isEligibleRoutingWindow`. I kept it narrow. Widening it is not a free consistency win: those paths have no restore step, so `⌘N` or Close Tab would act on a window the user cannot see. Making them consistent means giving them restore-then-focus too — a behavior change with its own risks (what should Close Window do to a window in the Dock?) that does not belong in a release-gate fix. The divergence is expressed in the type and asserted by a test, not left to a comment.

The reach rule reads `isVisible || isMiniaturized`, so **widening never admits an ordered-out window** — both flags are `false` there. The other three eligibility conjuncts (lifecycle, registry window, registered manager) are untouched.

## Evidence for the AppKit premise

The whole fix rests on how AppKit reports a miniaturized window, which #1507 asked to verify. Measured with a small AppKit probe on this machine:

```
ordered-front:  isVisible=true  isMiniaturized=false   in NSApp.windows: true
miniaturized:   isVisible=false isMiniaturized=true    in NSApp.windows: true
deminiaturized: isVisible=true  isMiniaturized=false
ordered-out:    isVisible=false isMiniaturized=false
```

```
ProductName:    macOS
ProductVersion: 27.0
BuildVersion:   26A5416b
```

macOS 26 was not reachable from this machine, so the rule is written against **both** flags rather than trusting either one: `.onScreenOrDock` admits a Dock window through `isMiniaturized` even on a runtime that disagrees about `isVisible`, and `.onScreenOnly` refuses it either way. The macOS 26 row still belongs in #1490's manual matrix.

## Tests

New `WindowRoutingReachTests` — an exhaustive truth table over both reaches, plus the two regressions by name (a Dock window is reachable; a widened reach still refuses an ordered-out window) and an assertion that the two reaches diverge **only** on a window in the Dock.

New "Windows in the Dock" section in `AgentInboxHostOptionsTests`:

- a project window in the Dock is a candidate (with the `isVisible == false` precondition asserted, not assumed);
- a Dock window whose project was closed is still refused — widening the reach widened nothing else;
- a lone minimized project hosts the Inbox instead of `.createWelcomeHost` (#1507's headline shape);
- a minimized most-recent project outranks a visible Welcome, and a minimized one;
- a key on-screen project still beats a minimized project;
- a minimized Welcome is reused instead of a second one being created;
- the Inbox Welcome source finds a Dock Welcome window, and the on-screen lookup still refuses it — including through a primed cache, so a cached window is re-checked against the caller's reach.

Minimized state is staged through a `DockableWindow` subclass rather than a real `miniaturize(nil)`: the unit test host is a background application where the call never reaches the Dock, and it is animated and asynchronous where it does. The staged facts are the measured ones above.

The two coordinator tests that staged a miniaturized host kept passing, but their doc comments said they were pinning a contract production could not reach. They now describe reachable behavior — and `AgentInboxHostOptionsTests` owns the "which windows arrive here" half.

## Verification

- `PineTests/WindowRoutingReachTests`, `AgentInboxHostOptionsTests`, `AgentInboxHostRoutingTests`, `AgentInboxPresentationCoordinatorTests` — green.
- Full `PineTests` — green apart from five timing-sensitive suites (`AsyncFormatOnSave`, `TerminalPTYProcessTree`, `AgentAdapterRegistry`, `MultiProjectAgentJourney`, `WindowLifecycle`) that failed while a second `xcodebuild` was running on the same machine and all passed on a clean re-run. Untouched by this diff.
- `swiftlint` clean on every changed file.
- No UI tests were run locally (the maintainer is working on this machine); CI owns those shards.

## Follow-up noticed, not fixed here

`hideWelcome()` skips a minimized Welcome window — its loop filters on `window.isVisible` — so a Welcome window in the Dock survives opening a project. Pre-existing, out of scope for this fix, and not made worse by it: the Welcome candidate only wins when no project window can host the Inbox. Happy to file it if you want it tracked.
