### PR TITLE
fix(ci): make the flaky-test detector actually report retried tests

### DIFF
--- a/.github/scripts/detect_flaky_tests.py
+++ b/.github/scripts/detect_flaky_tests.py
@@ -19,6 +19,16 @@ import sys
 from dataclasses import dataclass
 
 
+# The `xcresulttool` schema spells the retry node "Repetition". This script
+# matched "Test Repetition" from the day it was written — a value that appears
+# in no schema version — so it reported nothing for as long as it existed
+# (#1510). The spelling is a named constant now, checked against the live
+# schema by `describe_schema_mismatch`, so a future rename fails a check
+# instead of silently emptying the report.
+REPETITION_NODE_TYPE = "Repetition"
+TEST_CASE_NODE_TYPE = "Test Case"
+
+
 @dataclass
 class FlakyTest:
     suite: str
@@ -43,6 +53,72 @@ def get_test_results(xcresult_path: str) -> dict:
     return json.loads(result.stdout)
 
 
+def get_schema_node_types(xcresult_path: str) -> list[str] | None:
+    """The `nodeType` values this `xcresulttool` documents.
+
+    Returns `None` when the schema cannot be read — an older toolchain, a
+    changed CLI, a non-JSON answer. Being unable to check is not itself a
+    reason to fail a test lane; being able to check and finding the value
+    gone is.
+    """
+    result = subprocess.run(
+        [
+            "xcrun", "xcresulttool", "get", "test-results", "tests",
+            "--schema", "--path", xcresult_path,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        schema = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    node_types = schema.get("schemas", {}).get("TestNodeType", {}).get("enum")
+    if not isinstance(node_types, list):
+        return None
+    return [value for value in node_types if isinstance(value, str)]
+
+
+def describe_schema_mismatch(node_types: list[str] | None) -> str | None:
+    """An error message when the schema no longer spells what we match on.
+
+    This is the specific guard #1510 asks for. "Zero repetition nodes found"
+    cannot be the signal: a run where nothing was retried contains no
+    `Repetition` node at all, so failing on that would fail every healthy
+    run. What is always true is that the value this script matches on has to
+    exist in the schema of the tool that produced the report.
+    """
+    if node_types is None:
+        return None
+    missing = [
+        name for name in (REPETITION_NODE_TYPE, TEST_CASE_NODE_TYPE)
+        if name not in node_types
+    ]
+    if not missing:
+        return None
+    return (
+        "Error: xcresulttool's schema no longer defines "
+        f"{', '.join(repr(name) for name in missing)}. This detector matches "
+        "test nodes by those names, so it would report no flaky tests no "
+        "matter what the run did. Update detect_flaky_tests.py against the "
+        f"current schema, which defines: {', '.join(sorted(node_types))}."
+    )
+
+
+def count_test_cases(node) -> int:
+    """How many `Test Case` nodes the report contains, at any depth."""
+    if isinstance(node, list):
+        return sum(count_test_cases(item) for item in node)
+    if not isinstance(node, dict):
+        return 0
+    total = int(node.get("nodeType") == TEST_CASE_NODE_TYPE)
+    for key in ("children", "testNodes"):
+        total += count_test_cases(node.get(key, []))
+    return total
+
+
 def find_flaky_tests(node: dict, suite_path: str = "") -> list[FlakyTest]:
     """Recursively walk test nodes to find flaky tests.
 
@@ -52,14 +128,23 @@ def find_flaky_tests(node: dict, suite_path: str = "") -> list[FlakyTest]:
     flaky = []
     node_type = node.get("nodeType", "")
     name = node.get("name", "")
-    children = node.get("children", [])
+    # `xcresulttool` names the top level `testNodes` and every level below it
+    # `children`. Reading only `children` never leaves the root object, which
+    # is the second half of why this detector reported nothing (#1510):
+    # fixing the node-type spelling alone still walked into an empty list.
+    children = [
+        child
+        for key in ("children", "testNodes")
+        for child in node.get(key, [])
+        if isinstance(child, dict)
+    ]
 
-    if node_type == "Test Case":
+    if node_type == TEST_CASE_NODE_TYPE:
         result = node.get("result", "")
         # A retried test has repetition children
         repetitions = [
             c for c in children
-            if c.get("nodeType", "") == "Test Repetition"
+            if c.get("nodeType", "") == REPETITION_NODE_TYPE
         ]
         if result == "Passed" and repetitions:
             failed_runs = sum(
@@ -139,7 +224,27 @@ def main():
         print(f"Error: xcresult not found: {xcresult_path}", file=sys.stderr)
         sys.exit(2)
 
+    schema_mismatch = describe_schema_mismatch(
+        get_schema_node_types(xcresult_path)
+    )
+    if schema_mismatch:
+        print(schema_mismatch, file=sys.stderr)
+        sys.exit(2)
+
     data = get_test_results(xcresult_path)
+
+    # A report with no test cases in it cannot support "no flaky tests
+    # detected": either nothing ran, or the node names moved again. Both are
+    # worth a red step rather than a reassuring line of output.
+    if count_test_cases(data) == 0:
+        print(
+            "Error: no 'Test Case' nodes in "
+            f"{xcresult_path}. Nothing was analysed, so this run says nothing "
+            "about flakiness.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
     flaky_tests = find_flaky_tests(data)
 
     # Always write output file (empty array when no flaky tests)

--- a/.github/scripts/test_detect_flaky_tests.py
+++ b/.github/scripts/test_detect_flaky_tests.py
@@ -3,12 +3,22 @@
 import json
 import unittest
 
+from pathlib import Path
+
 from detect_flaky_tests import (
+    REPETITION_NODE_TYPE,
+    TEST_CASE_NODE_TYPE,
     FlakyTest,
+    count_test_cases,
+    describe_schema_mismatch,
     find_flaky_tests,
     flaky_to_dicts,
     format_markdown,
     _parse_output_file,
+)
+
+RECORDED_PAYLOAD = (
+    Path(__file__).parent / "testdata" / "retried_test_payload.json"
 )
 
 
@@ -48,12 +58,12 @@ class TestFindFlakyTests(unittest.TestCase):
                     "result": "Failed",
                     "children": [
                         {
-                            "nodeType": "Test Repetition",
+                            "nodeType": "Repetition",
                             "name": "Run 1",
                             "result": "Failed",
                         },
                         {
-                            "nodeType": "Test Repetition",
+                            "nodeType": "Repetition",
                             "name": "Run 2",
                             "result": "Failed",
                         },
@@ -75,12 +85,12 @@ class TestFindFlakyTests(unittest.TestCase):
                     "result": "Passed",
                     "children": [
                         {
-                            "nodeType": "Test Repetition",
+                            "nodeType": "Repetition",
                             "name": "Run 1",
                             "result": "Failed",
                         },
                         {
-                            "nodeType": "Test Repetition",
+                            "nodeType": "Repetition",
                             "name": "Run 2",
                             "result": "Passed",
                         },
@@ -115,12 +125,12 @@ class TestFindFlakyTests(unittest.TestCase):
                                     "result": "Passed",
                                     "children": [
                                         {
-                                            "nodeType": "Test Repetition",
+                                            "nodeType": "Repetition",
                                             "name": "Run 1",
                                             "result": "Failed",
                                         },
                                         {
-                                            "nodeType": "Test Repetition",
+                                            "nodeType": "Repetition",
                                             "name": "Run 2",
                                             "result": "Passed",
                                         },
@@ -155,12 +165,12 @@ class TestFindFlakyTests(unittest.TestCase):
                     "result": "Passed",
                     "children": [
                         {
-                            "nodeType": "Test Repetition",
+                            "nodeType": "Repetition",
                             "name": "Run 1",
                             "result": "Failed",
                         },
                         {
-                            "nodeType": "Test Repetition",
+                            "nodeType": "Repetition",
                             "name": "Run 2",
                             "result": "Passed",
                         },
@@ -172,12 +182,12 @@ class TestFindFlakyTests(unittest.TestCase):
                     "result": "Failed",
                     "children": [
                         {
-                            "nodeType": "Test Repetition",
+                            "nodeType": "Repetition",
                             "name": "Run 1",
                             "result": "Failed",
                         },
                         {
-                            "nodeType": "Test Repetition",
+                            "nodeType": "Repetition",
                             "name": "Run 2",
                             "result": "Failed",
                         },
@@ -201,12 +211,12 @@ class TestFindFlakyTests(unittest.TestCase):
                     "result": "Passed",
                     "children": [
                         {
-                            "nodeType": "Test Repetition",
+                            "nodeType": "Repetition",
                             "name": "Run 1",
                             "result": "Passed",
                         },
                         {
-                            "nodeType": "Test Repetition",
+                            "nodeType": "Repetition",
                             "name": "Run 2",
                             "result": "Passed",
                         },
@@ -279,6 +289,113 @@ class TestParseOutputFile(unittest.TestCase):
     def test_flag_at_end(self):
         """--output-file at end without value should return empty string."""
         self.assertEqual(_parse_output_file(["script", "--output-file"]), "")
+
+
+class TestRecordedRetryPayload(unittest.TestCase):
+    """The regression tests for #1510, run against a real report.
+
+    Hand-written fixtures are what let this detector stay broken: they were
+    written from the same wrong assumption as the code, so they agreed with
+    it. `testdata/retried_test_payload.json` is instead the verbatim output of
+
+        xcrun xcresulttool get test-results tests --path <bundle>
+
+    for a run where one test genuinely failed and passed on retry (only the
+    machine's device id and the source path were replaced). Two independent
+    defects had to be fixed before this payload produced any output: the
+    node-type spelling, and the walk that never left the root object.
+    """
+
+    def setUp(self):
+        with open(RECORDED_PAYLOAD) as payload:
+            self.data = json.load(payload)
+
+    def test_real_retry_is_reported(self):
+        """A genuinely retried test is named, not silently dropped."""
+        flaky = find_flaky_tests(self.data)
+        self.assertEqual(len(flaky), 1)
+        self.assertEqual(flaky[0].name, "fails once, then passes on retry")
+        self.assertEqual(flaky[0].failed_runs, 1)
+        self.assertEqual(flaky[0].total_runs, 2)
+        self.assertIn("PineTests", flaky[0].suite)
+
+    def test_payload_uses_the_schema_spelling(self):
+        """The recorded report spells the node the way the script matches.
+
+        If someone re-records this fixture from a toolchain that renames the
+        node, this fails here rather than by quietly reporting nothing.
+        """
+        self.assertIn(f'"{REPETITION_NODE_TYPE}"', json.dumps(self.data))
+        self.assertNotIn("Test Repetition", json.dumps(self.data))
+
+    def test_walk_reaches_test_cases_under_test_nodes(self):
+        """The root key is `testNodes`; only walking `children` finds nothing."""
+        self.assertEqual(count_test_cases(self.data), 1)
+        self.assertEqual(count_test_cases(self.data.get("children", [])), 0)
+
+    def test_old_spelling_would_find_nothing(self):
+        """Pins the defect itself, so the fix cannot be quietly reverted."""
+        renamed = json.loads(
+            json.dumps(self.data).replace(
+                f'"{REPETITION_NODE_TYPE}"', '"Test Repetition"'
+            )
+        )
+        self.assertEqual(find_flaky_tests(renamed), [])
+
+
+class TestSchemaMismatch(unittest.TestCase):
+    """The guard that makes a future rename loud instead of silent."""
+
+    def test_schema_with_both_types_is_accepted(self):
+        self.assertIsNone(
+            describe_schema_mismatch([
+                "Test Plan", TEST_CASE_NODE_TYPE, REPETITION_NODE_TYPE,
+            ])
+        )
+
+    def test_renamed_repetition_is_reported(self):
+        message = describe_schema_mismatch(["Test Plan", TEST_CASE_NODE_TYPE])
+        self.assertIsNotNone(message)
+        self.assertIn(REPETITION_NODE_TYPE, message)
+
+    def test_renamed_test_case_is_reported(self):
+        message = describe_schema_mismatch(["Test Plan", REPETITION_NODE_TYPE])
+        self.assertIsNotNone(message)
+        self.assertIn(TEST_CASE_NODE_TYPE, message)
+
+    def test_unreadable_schema_does_not_fail_the_lane(self):
+        """Being unable to check is not evidence of a rename."""
+        self.assertIsNone(describe_schema_mismatch(None))
+
+    def test_empty_schema_is_a_mismatch(self):
+        self.assertIsNotNone(describe_schema_mismatch([]))
+
+
+class TestCountTestCases(unittest.TestCase):
+    """`count_test_cases` backs the "nothing was analysed" guard."""
+
+    def test_counts_across_both_child_keys(self):
+        data = {
+            "testNodes": [
+                {
+                    "nodeType": "Test Suite",
+                    "children": [
+                        {"nodeType": TEST_CASE_NODE_TYPE, "name": "a"},
+                        {"nodeType": TEST_CASE_NODE_TYPE, "name": "b"},
+                    ],
+                }
+            ]
+        }
+        self.assertEqual(count_test_cases(data), 2)
+
+    def test_empty_report_counts_nothing(self):
+        self.assertEqual(count_test_cases({"testNodes": []}), 0)
+
+    def test_survives_unexpected_shapes(self):
+        """A malformed report must not crash the detector before it reports."""
+        self.assertEqual(count_test_cases({"testNodes": [None, 3, "x"]}), 0)
+        self.assertEqual(count_test_cases([]), 0)
+        self.assertEqual(count_test_cases("not a node"), 0)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/testdata/retried_test_payload.json
+++ b/.github/scripts/testdata/retried_test_payload.json
@@ -1,0 +1,82 @@
+{
+  "devices": [
+    {
+      "architecture": "arm64",
+      "deviceId": "00000000-0000000000000000",
+      "deviceName": "My Mac",
+      "modelName": "MacBook Pro",
+      "osBuildNumber": "26A5416b",
+      "osVersion": "27.0",
+      "platform": "macOS"
+    }
+  ],
+  "testNodes": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "name": "Issue recorded: deliberate first-attempt failure for #1510",
+                          "nodeType": "Failure Message",
+                          "sourceLocation": {
+                            "filePath": "/Users/runner/work/pine/pine/PineTests/FlakyProbeTests.swift",
+                            "lineNumber": 22
+                          }
+                        }
+                      ],
+                      "duration": "0,00058s",
+                      "durationInSeconds": 0.0005829334259033203,
+                      "name": "First Run",
+                      "nodeIdentifier": "1",
+                      "nodeType": "Repetition",
+                      "result": "Failed"
+                    },
+                    {
+                      "duration": "0,00014s",
+                      "durationInSeconds": 0.000141143798828125,
+                      "name": "Retry 1",
+                      "nodeIdentifier": "2",
+                      "nodeType": "Repetition",
+                      "result": "Passed"
+                    }
+                  ],
+                  "details": "⚠️ Passed after 1 retry",
+                  "duration": "0,00036s",
+                  "durationInSeconds": 0.00036203861236572266,
+                  "name": "fails once, then passes on retry",
+                  "nodeIdentifier": "ZZTemporaryFlakyProbeTests/failsOnceThenPasses()",
+                  "nodeIdentifierURL": "test://com.apple.xcode/Pine/PineTests/ZZTemporaryFlakyProbeTests/failsOnceThenPasses()",
+                  "nodeType": "Test Case",
+                  "result": "Passed"
+                }
+              ],
+              "name": "Temporary flaky probe",
+              "nodeIdentifierURL": "test://com.apple.xcode/Pine/PineTests/ZZTemporaryFlakyProbeTests",
+              "nodeType": "Test Suite",
+              "result": "Passed"
+            }
+          ],
+          "name": "PineTests",
+          "nodeIdentifierURL": "test://com.apple.xcode/Pine/PineTests",
+          "nodeType": "Unit test bundle",
+          "result": "Passed"
+        }
+      ],
+      "name": "Pine",
+      "nodeType": "Test Plan",
+      "result": "Passed"
+    }
+  ],
+  "testPlanConfigurations": [
+    {
+      "configurationId": "1",
+      "configurationName": "Test Scheme Action"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,20 @@ jobs:
         working-directory: .github/scripts
         run: python3 -m unittest test_select_previous_release.py -v
 
+      # These three suites existed but were never run by any lane, which is
+      # how the flaky detector kept a defect its own tests encoded (#1510).
+      - name: Unit tests for flaky-test detection
+        working-directory: .github/scripts
+        run: python3 -m unittest test_detect_flaky_tests.py -v
+
+      - name: Unit tests for changelog HTML conversion
+        working-directory: .github/scripts
+        run: python3 -m unittest test_changelog_to_html.py -v
+
+      - name: Unit tests for performance regression checks
+        working-directory: .github/scripts
+        run: python3 -m unittest test_check_perf_regression.py -v
+
       - name: Tests for lifecycle soak workflow
         run: bash scripts/tests/test-lifecycle-soak-workflow.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ LifecycleDiagnostics/
 .pi/
 .pi-subagents/
 .pine/
+
+# Python bytecode from the .github/scripts test suites
+__pycache__/
+*.pyc


### PR DESCRIPTION
Closes #1510.

## Two defects, not one

#1510 reports the node-type typo: `detect_flaky_tests.py` matched `nodeType == "Test Repetition"`, a value that exists in **no** schema version. Confirmed locally against the live tool — the `TestNodeType` enum spells it `Repetition` in 0.1.0, 0.2.0, 0.3.0 and 0.4.0 alike.

Fixing that alone still reported nothing. The walk read only the `children` key, but `xcresulttool` names the top level `testNodes`, so the recursion never left the root object — it inspected one dict with no `children` and returned. Both defects had to go before a real bundle produced output.

This is exactly why the fix was developed against a **recorded real bundle** rather than the existing fixtures: the fixtures started at a `Test Suite` node with `children`, so they could never have exposed the second defect.

## Evidence

A deliberately flaky test (fails on first attempt, passes on retry) was run under `-retry-tests-on-failure`. The resulting bundle contains exactly two repetition nodes:

```json
{ "name": "First Run", "nodeType": "Repetition", "result": "Failed" },
{ "name": "Retry 1",   "nodeType": "Repetition", "result": "Passed" }
```

with the parent `Test Case` carrying `"details": "⚠️ Passed after 1 retry"` and `"result": "Passed"` — the precise shape the detector exists to catch.

| | before | after |
|---|---|---|
| bundle with a real retry | `No flaky tests detected.` | `Found 1 flaky test(s): … (failed 1/2 runs)` |
| healthy bundle, no retries | `No flaky tests detected.` | `No flaky tests detected.` |

A healthy run contains **no** `Repetition` nodes at all — worth stating, because it rules out the guard #1510 suggests (see below).

## Guards against a silent recurrence

- **Schema check.** The two node-type strings are named constants, verified against the live schema before the report is walked. A rename exits 2 and prints the enum it actually found. "Zero repetition nodes found" cannot be that signal — the healthy-run row above shows a correct run has none, so failing on it would fail every green lane.
- **Empty-report check.** A report with no `Test Case` nodes exits 2 instead of printing a reassuring "none detected" about a report nothing was read from. Slight behavior change: a lane whose build died before any test ran now gets a red detector step too. It was already red, and the alternative is the false reassurance this issue is about.

## Why 15 green tests coexisted with a detector that matched nothing

Every fixture in `test_detect_flaky_tests.py` spelled the node `"Test Repetition"` — written from the same wrong assumption as the code, so they agreed with it. **And the suite was never run by any CI lane.**

Both are fixed:

- fixtures corrected to the schema spelling;
- `testdata/retried_test_payload.json` — the verbatim `xcresulttool` output from the retried run above (only the device id and source path replaced), so the tests are anchored to a real report;
- new tests pin each defect: a real retry is reported; the walk reaches cases under `testNodes`; **the old spelling finds nothing**; the schema guard accepts a good enum and reports each renamed type; `count_test_cases` survives malformed input;
- the lane now runs this suite.

Mutation-checked: reverting either defect turns the suite red (5 failures for the spelling, 1 for the walk), so these tests cannot be quietly undone.

While wiring that step in, two other script suites turned out never to run either — `test_changelog_to_html` (22 tests) and `test_check_perf_regression` (27 tests). Both pass; both are now in the lane. Small scope addition, called out explicitly.

## Audit

Every other `nodeType` / `result` comparison in `detect_flaky_tests.py` and `validate_test_results.py` checked against the schema enums (`TestNodeType`, `TestResult`): `Test Case`, `Test Plan`, `Passed`, `Failed`, `Skipped`, `Expected Failure` are all correct. This was the only typo.

One judgement call left as-is: the detector treats only `result == "Passed"` as a rescued test, so a retried test that ends in `Expected Failure` (the `withKnownIssue` shape #1506 introduced) is not counted as flaky. That looks right — a known issue is not a rescue — but it is a decision, not an oversight, so it is worth a second opinion.

## Expect a backlog

The detector now tells the truth, so genuinely flaky tests will start appearing in the `flaky-summary` comment. During this work, a full local `PineTests` run under parallel load failed five timing-sensitive suites (`AsyncFormatOnSave`, `TerminalPTYProcessTree`, `AgentAdapterRegistry`, `MultiProjectAgentJourney`, `WindowLifecycle`) and all passed on a clean re-run — the same crop #1510 predicts. Triage separately; do not revert the fix.

## Verification

- `python3 -m unittest test_detect_flaky_tests.py` — 27 tests, green (was 15).
- `test_changelog_to_html`, `test_check_perf_regression` — green.
- `scripts/tests/test-xcodebuild-cli-options.sh` (asserts on this workflow's shape) — green.
- `ci.yml` parses as valid YAML with all 10 jobs intact.
- Detector run against both a real retried bundle and a healthy one, results in the table above.
