### PR TITLE
fix(tests): stop repository-scanning guards from passing on an empty scan

### DIFF
--- a/PineTests/DestructiveShortcutPolicyTests.swift
+++ b/PineTests/DestructiveShortcutPolicyTests.swift
@@ -1161,26 +1161,12 @@ struct DestructiveShortcutPolicyTests {
     }
 
     private static func productionSources() throws -> [Source] {
-        let root = repositoryRoot().appendingPathComponent("Pine")
-        // Deliberately no `.skipsHiddenFiles`: that option treats every file
-        // as hidden when any ancestor directory is (agents run this repo from
-        // `.claude/worktrees/…`), which would silently reduce the whole scan
-        // to zero files and turn this guard into a test that always passes.
-        let enumerator = try #require(
-            FileManager.default.enumerator(
-                at: root,
-                includingPropertiesForKeys: [.isRegularFileKey]
-            )
+        // The enumeration this suite introduced now lives in
+        // `ProductionSourceScan`, so the hidden-ancestor trap and the
+        // non-empty guard are written once rather than per suite (#1508).
+        let urls = try ProductionSourceScan.swiftFileURLs(
+            under: repositoryRoot().appendingPathComponent("Pine")
         )
-        let urls = enumerator.compactMap { $0 as? URL }
-            .filter { $0.pathExtension == "swift" }
-            .filter { url in
-                !url.pathComponents
-                    .dropFirst(root.pathComponents.count)
-                    .contains { $0.hasPrefix(".") }
-            }
-            .sorted { $0.path < $1.path }
-        #expect(!urls.isEmpty, "Production sources must be discoverable")
 
         return try urls.map {
             Source(

--- a/PineTests/DialogPresentationCoordinatorTests.swift
+++ b/PineTests/DialogPresentationCoordinatorTests.swift
@@ -1023,12 +1023,10 @@ struct DialogFlowRegressionTests {
         let repositoryRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
-        let sourceRoot = repositoryRoot.appendingPathComponent("Pine")
-        let enumerator = try #require(
-            FileManager.default.enumerator(
-                at: sourceRoot,
-                includingPropertiesForKeys: nil
-            )
+        // Never a bare enumeration: a guard that scans the tree has to fail,
+        // not pass, when the scan comes back empty (#1508).
+        let sourceURLs = try ProductionSourceScan.swiftFileURLs(
+            under: repositoryRoot.appendingPathComponent("Pine")
         )
         let forbiddenAPIs = [
             "runModal(",
@@ -1040,8 +1038,7 @@ struct DialogFlowRegressionTests {
             "panel.begin(completionHandler:",
         ]
         var offenders: [String] = []
-        for case let fileURL as URL in enumerator
-        where fileURL.pathExtension == "swift" {
+        for fileURL in sourceURLs {
             let source = try String(contentsOf: fileURL, encoding: .utf8)
             for forbiddenAPI in forbiddenAPIs where source.contains(forbiddenAPI) {
                 offenders.append(

--- a/PineTests/LocalizationCatalogCompletenessTests.swift
+++ b/PineTests/LocalizationCatalogCompletenessTests.swift
@@ -151,16 +151,15 @@ struct LocalizationCatalogCompletenessTests {
     private func sourceReferences(
         projectRoot: URL
     ) throws -> [SourceReference] {
-        let sourceRoot = projectRoot.appendingPathComponent("Pine")
-        let fileManager = FileManager.default
-        let enumerator = try #require(fileManager.enumerator(
-            at: sourceRoot,
-            includingPropertiesForKeys: [.isRegularFileKey],
-            options: [.skipsHiddenFiles]
-        ))
-        let sourceURLs = enumerator.compactMap { $0 as? URL }
-            .filter { $0.pathExtension == "swift" }
-            .sorted { $0.path < $1.path }
+        // Not a local enumeration: `.skipsHiddenFiles` used to live here, and
+        // every file in an agent worktree under `.claude/worktrees/…` carries
+        // the `UF_HIDDEN` flag, so this guard scanned zero files and passed
+        // vacuously wherever it was actually run (#1508).
+        // `ProductionSourceScan` also refuses to return an empty list, so a
+        // completeness test can never again pass by scanning nothing.
+        let sourceURLs = try ProductionSourceScan.swiftFileURLs(
+            under: projectRoot.appendingPathComponent("Pine")
+        )
 
         let localizedKeyExpression = try NSRegularExpression(
             pattern:

--- a/PineTests/ProductionSourceScan.swift
+++ b/PineTests/ProductionSourceScan.swift
@@ -1,0 +1,121 @@
+//
+//  ProductionSourceScan.swift
+//  PineTests
+//
+//  One correct way to enumerate production sources from a test (#1508).
+//
+
+import Foundation
+
+/// Finds the production Swift files a repository-scanning guard reads.
+///
+/// Guards that scan the tree — "no application-modal calls", "every key is in
+/// the catalog", "no destructive shortcut" — are only as good as the file list
+/// they start from. Two ways of getting that list wrong make such a guard pass
+/// while checking nothing, and both are silent:
+///
+/// - `FileManager.DirectoryEnumerationOptions.skipsHiddenFiles` drops every
+///   item carrying the `UF_HIDDEN` filesystem flag, and in an agent worktree
+///   under `.claude/worktrees/…` that flag is set on the files themselves —
+///   measured in one such checkout: 183 of 184 entries in `Pine/` are flagged
+///   hidden, and the enumeration returns **zero** `.swift` files while the
+///   same scan of the primary checkout returns 324. That is #1508: the
+///   localization completeness test was green everywhere it was looked at and
+///   vacuous everywhere it actually ran.
+///
+///   (The flag is what matters, not the dotted ancestor name: a directory
+///   literally named `.claude/worktrees/wt/Sources` created without the flag
+///   enumerates normally.)
+/// - a moved or renamed directory produces an empty enumeration rather than an
+///   error.
+///
+/// So this type never passes `.skipsHiddenFiles` — it excludes hidden files by
+/// name instead, which is a property of the repository rather than of where the
+/// repository happens to be checked out — and it refuses to return an empty
+/// list. A completeness guard that finds no inputs must fail, not pass,
+/// whatever the reason.
+enum ProductionSourceScan {
+    struct EmptyScanError: Error, CustomStringConvertible {
+        let root: URL
+
+        var description: String {
+            """
+            No Swift sources found under \(root.path). A guard that scans the \
+            repository cannot pass on an empty scan — check the path, and do \
+            not use .skipsHiddenFiles (every file in an agent worktree under \
+            .claude/worktrees/… carries the UF_HIDDEN flag, so that option \
+            reduces the whole scan to nothing).
+            """
+        }
+    }
+
+    struct RepositoryRootNotFoundError: Error, CustomStringConvertible {
+        let startingFrom: String
+
+        var description: String {
+            "No Pine.xcodeproj in any ancestor of \(startingFrom)."
+        }
+    }
+
+    /// The repository root, found by walking up from a test source file until
+    /// `Pine.xcodeproj` appears.
+    ///
+    /// Located by content rather than by a fixed number of
+    /// `deletingLastPathComponent()` calls, so a suite that moves into a
+    /// subdirectory does not silently start scanning the wrong tree.
+    static func repositoryRoot(
+        from file: String = #filePath
+    ) throws -> URL {
+        var candidate = URL(fileURLWithPath: file)
+            .deletingLastPathComponent()
+            .standardizedFileURL
+        while candidate.path != "/" {
+            let project = candidate.appendingPathComponent("Pine.xcodeproj")
+            if FileManager.default.fileExists(atPath: project.path) {
+                return candidate
+            }
+            candidate = candidate.deletingLastPathComponent()
+        }
+        throw RepositoryRootNotFoundError(startingFrom: file)
+    }
+
+    /// Every `.swift` file under `Pine/`, sorted, never empty.
+    static func productionSwiftFileURLs(
+        from file: String = #filePath
+    ) throws -> [URL] {
+        try swiftFileURLs(
+            under: repositoryRoot(from: file)
+                .appendingPathComponent("Pine")
+        )
+    }
+
+    /// Every `.swift` file under `root`, sorted by path.
+    ///
+    /// Hidden files and directories below `root` are excluded **by name**
+    /// (`.build/`, `.DS_Store`), never by the `UF_HIDDEN` flag: the name says
+    /// something about the repository, the flag only says something about the
+    /// checkout it was copied into.
+    ///
+    /// - Throws: ``EmptyScanError`` when the scan finds nothing.
+    static func swiftFileURLs(under root: URL) throws -> [URL] {
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey]
+        ) else {
+            throw EmptyScanError(root: root)
+        }
+        let rootComponentCount = root.standardizedFileURL.pathComponents.count
+        let urls = enumerator.compactMap { $0 as? URL }
+            .filter { $0.pathExtension == "swift" }
+            .filter { url in
+                !url.standardizedFileURL.pathComponents
+                    .dropFirst(rootComponentCount)
+                    .contains { $0.hasPrefix(".") }
+            }
+            .sorted { $0.path < $1.path }
+        guard !urls.isEmpty else {
+            throw EmptyScanError(root: root)
+        }
+        return urls
+    }
+}

--- a/PineTests/ProductionSourceScanTests.swift
+++ b/PineTests/ProductionSourceScanTests.swift
@@ -1,0 +1,269 @@
+//
+//  ProductionSourceScanTests.swift
+//  PineTests
+//
+//  The enumeration every repository-scanning guard depends on (#1508).
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Production source scan")
+struct ProductionSourceScanTests {
+    // MARK: - The hidden-file trap
+
+    /// The defect in one assertion, staged the way it really occurs.
+    ///
+    /// It is not the dotted ancestor name that empties the scan — a directory
+    /// named `.worktrees` containing ordinary files enumerates fine. It is the
+    /// `UF_HIDDEN` filesystem flag, which in an agent worktree under
+    /// `.claude/worktrees/…` is set on the source files themselves. With that
+    /// flag set, `.skipsHiddenFiles` returns nothing at all.
+    @Test("files carrying the hidden flag are still scanned")
+    func hiddenFlagDoesNotEmptyTheScan() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let root = try fixture.makeTree(
+            underHiddenAncestor: true,
+            files: ["Alpha.swift", "Beta.swift"],
+            markingFilesHidden: true
+        )
+
+        // The option that caused #1508, demonstrated rather than described.
+        #expect(fixture.swiftFilesSkippingHidden(under: root).isEmpty)
+
+        let scanned = try ProductionSourceScan.swiftFileURLs(under: root)
+        #expect(scanned.map(\.lastPathComponent) == ["Alpha.swift", "Beta.swift"])
+    }
+
+    /// The control for the test above: same dotted ancestor, no flag. The
+    /// enumeration is unaffected, which is why "hidden ancestor" alone is not
+    /// the explanation and the fix must not rely on it being one.
+    @Test("a dotted ancestor alone does not empty the old enumeration")
+    func dottedAncestorAloneIsHarmless() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let root = try fixture.makeTree(
+            underHiddenAncestor: true,
+            files: ["Alpha.swift"],
+            markingFilesHidden: false
+        )
+
+        #expect(fixture.swiftFilesSkippingHidden(under: root).count == 1)
+        #expect(try ProductionSourceScan.swiftFileURLs(under: root).count == 1)
+    }
+
+    /// The distinction the scan has to make: hidden *below* the root is the
+    /// caller's own build detritus and stays excluded; hidden *above* it is
+    /// none of the scan's business.
+    @Test("hidden directories below the root are still excluded")
+    func hiddenDescendantsAreExcluded() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let root = try fixture.makeTree(
+            underHiddenAncestor: false,
+            files: ["Visible.swift", ".build/Generated.swift", ".hidden.swift"]
+        )
+
+        let scanned = try ProductionSourceScan.swiftFileURLs(under: root)
+
+        #expect(scanned.map(\.lastPathComponent) == ["Visible.swift"])
+    }
+
+    @Test("both rules apply at once: hidden ancestor, hidden descendant")
+    func hiddenAncestorAndDescendantTogether() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let root = try fixture.makeTree(
+            underHiddenAncestor: true,
+            files: ["Kept.swift", ".derived/Dropped.swift"]
+        )
+
+        let scanned = try ProductionSourceScan.swiftFileURLs(under: root)
+
+        #expect(scanned.map(\.lastPathComponent) == ["Kept.swift"])
+    }
+
+    // MARK: - Failing closed
+
+    /// The important half of #1508: whatever the enumeration options end up
+    /// being, a completeness guard that finds no inputs must fail.
+    @Test("an empty directory is an error, not an empty list")
+    func emptyScanThrows() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let root = try fixture.makeTree(
+            underHiddenAncestor: false,
+            files: []
+        )
+
+        #expect(throws: ProductionSourceScan.EmptyScanError.self) {
+            try ProductionSourceScan.swiftFileURLs(under: root)
+        }
+    }
+
+    @Test("a directory with no Swift files is an error too")
+    func nonSwiftContentThrows() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let root = try fixture.makeTree(
+            underHiddenAncestor: false,
+            files: ["README.md", "Info.plist"]
+        )
+
+        #expect(throws: ProductionSourceScan.EmptyScanError.self) {
+            try ProductionSourceScan.swiftFileURLs(under: root)
+        }
+    }
+
+    @Test("a missing directory is an error, not an empty list")
+    func missingRootThrows() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let missing = try fixture
+            .makeTree(underHiddenAncestor: false, files: ["Kept.swift"])
+            .appendingPathComponent("NoSuchDirectory", isDirectory: true)
+
+        #expect(throws: ProductionSourceScan.EmptyScanError.self) {
+            try ProductionSourceScan.swiftFileURLs(under: missing)
+        }
+    }
+
+    // MARK: - Repository root
+
+    /// Found by content, so a suite that moves into a subdirectory does not
+    /// silently scan the wrong tree — which is how a fixed number of
+    /// `deletingLastPathComponent()` calls fails.
+    @Test("the repository root is located by Pine.xcodeproj, not by depth")
+    func repositoryRootIsFoundByContent() throws {
+        let root = try ProductionSourceScan.repositoryRoot()
+
+        #expect(FileManager.default.fileExists(
+            atPath: root.appendingPathComponent("Pine.xcodeproj").path
+        ))
+        #expect(FileManager.default.fileExists(
+            atPath: root.appendingPathComponent("Pine/PineApp.swift").path
+        ))
+    }
+
+    @Test("a path outside any checkout has no repository root")
+    func noRepositoryRootOutsideTheCheckout() {
+        #expect(
+            throws: ProductionSourceScan.RepositoryRootNotFoundError.self
+        ) {
+            try ProductionSourceScan.repositoryRoot(from: "/tmp/nowhere.swift")
+        }
+    }
+
+    // MARK: - The real tree
+
+    /// The scan that every guard in this target actually performs. The count
+    /// is deliberately a floor rather than an exact number — this asserts the
+    /// scan reaches the production tree, not how large the tree is.
+    @Test("the production scan finds Pine's sources from this test file")
+    func productionScanReachesTheRealTree() throws {
+        let urls = try ProductionSourceScan.productionSwiftFileURLs()
+
+        #expect(urls.count > 100)
+        #expect(urls.contains { $0.lastPathComponent == "PineApp.swift" })
+        #expect(urls.allSatisfy { $0.pathExtension == "swift" })
+        // Sorted, so a guard reporting offenders reports them in a stable
+        // order run to run.
+        #expect(urls.map(\.path) == urls.map(\.path).sorted())
+    }
+
+    /// The scan must be complete wherever it runs — CI's plain checkout, a
+    /// developer's clone, or an agent worktree whose files are flagged hidden.
+    /// This asserts the invariant that distinguishes the two enumerations
+    /// without assuming which environment the suite is in: the correct scan
+    /// never returns fewer files than the one that skips hidden items.
+    @Test("the production scan loses nothing the old enumeration kept")
+    func productionScanIsNeverSmallerThanTheOldOne() throws {
+        let sourceRoot = try ProductionSourceScan.repositoryRoot()
+            .appendingPathComponent("Pine")
+        let skippingHidden = FileManager.default.enumerator(
+            at: sourceRoot,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )?.compactMap { $0 as? URL }
+            .filter { $0.pathExtension == "swift" } ?? []
+
+        let scanned = try ProductionSourceScan.productionSwiftFileURLs()
+
+        #expect(scanned.count >= skippingHidden.count)
+        // In an agent worktree the right-hand side is 0 and the left is the
+        // whole tree; in a plain checkout the two agree.
+        #expect(scanned.count > 100)
+    }
+
+    // MARK: - Fixture
+
+    private final class Fixture {
+        private let base: URL
+
+        init() throws {
+            base = FileManager.default.temporaryDirectory
+                .resolvingSymlinksInPath()
+                .appendingPathComponent(
+                    "PineSourceScan-\(UUID().uuidString)",
+                    isDirectory: true
+                )
+            try FileManager.default.createDirectory(
+                at: base,
+                withIntermediateDirectories: true
+            )
+        }
+
+        /// The `.swift` files the pre-#1508 enumeration would have found.
+        func swiftFilesSkippingHidden(under root: URL) -> [URL] {
+            FileManager.default.enumerator(
+                at: root,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )?.compactMap { $0 as? URL }
+                .filter { $0.pathExtension == "swift" } ?? []
+        }
+
+        /// Builds a tree of empty files, optionally below a dotted directory
+        /// and optionally carrying the `UF_HIDDEN` flag an agent worktree
+        /// puts on every file, and returns the root a scan is pointed at.
+        func makeTree(
+            underHiddenAncestor: Bool,
+            files: [String],
+            markingFilesHidden: Bool = false
+        ) throws -> URL {
+            let container = underHiddenAncestor
+                ? base.appendingPathComponent(".worktrees", isDirectory: true)
+                : base
+            let root = container.appendingPathComponent(
+                "Sources",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(
+                at: root,
+                withIntermediateDirectories: true
+            )
+            for file in files {
+                let url = root.appendingPathComponent(file)
+                try FileManager.default.createDirectory(
+                    at: url.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                FileManager.default.createFile(atPath: url.path, contents: Data())
+                if markingFilesHidden {
+                    var hidden = url
+                    var values = URLResourceValues()
+                    values.isHidden = true
+                    try hidden.setResourceValues(values)
+                }
+            }
+            return root
+        }
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: base)
+        }
+    }
+}

--- a/PineTests/SparkleUpdaterTests.swift
+++ b/PineTests/SparkleUpdaterTests.swift
@@ -150,17 +150,14 @@ struct SparkleUpdaterTests {
         in sourceRoot: URL,
         excluding excludedFile: URL? = nil
     ) throws -> String {
-        guard let enumerator = FileManager.default.enumerator(
-            at: sourceRoot,
-            includingPropertiesForKeys: nil,
-            options: []
-        ) else {
-            throw CocoaError(.fileReadUnknown)
-        }
+        // An empty scan would make every "the source does not contain X"
+        // assertion below trivially true, so the scan throws instead (#1508).
+        let sourceURLs = try ProductionSourceScan.swiftFileURLs(
+            under: sourceRoot
+        )
 
         var source = ""
-        for case let fileURL as URL in enumerator
-        where fileURL.pathExtension == "swift" {
+        for fileURL in sourceURLs {
             guard fileURL.standardizedFileURL
                 != excludedFile?.standardizedFileURL else {
                 continue


### PR DESCRIPTION
Closes #1508.

## The mechanism is not quite what the issue says — and the difference matters

#1508 attributes the empty scan to `.skipsHiddenFiles` treating a file as hidden when **any ancestor** is. I could not reproduce that, so I measured it:

```
count  isHidden(root)   path
    1  false            /tmp/…/plain/Sources
    1  false            /tmp/…/hidden-parent/.worktrees/Sources
    1  false            /tmp/…/hidden-grandparent/.claude/worktrees/wt/Sources
  324  false            <repo>/Pine
    0  true             <repo>/.claude/worktrees/fix-1508-localization-scan/Pine
```

A dotted ancestor changes nothing. What empties the scan is the `UF_HIDDEN` **filesystem flag**, which an agent worktree carries on every file:

```
$ ls -lO .claude/worktrees/fix-1508-localization-scan/Pine
drwxr-xr-x@ 185 fedor staff hidden ...
$ ls -lO Pine | awk '$5=="hidden"' | wc -l
     183      # of 184 entries
```

Same practical outcome — zero files, a vacuous guard — but the fix has to be "do not filter on the hidden flag", not "watch out for dotted directories". Both facts are pinned by tests so this cannot drift back.

## Proof the guard was vacuous, and now is not

Run from a worktree under `.claude/worktrees/`, with one key deleted from `Localizable.xcstrings`:

| enumeration | result | duration |
|---|---|---|
| pre-fix (`.skipsHiddenFiles`) | **PASSES** | 0.104 s |
| this diff | **FAILS** — "Missing localization catalog entries" | 7.775 s |

The duration is its own tell: the old one was fast because it read nothing.

## The change

`ProductionSourceScan` — one enumeration for every guard that reads the repository:

- **no `.skipsHiddenFiles`.** Hidden files are excluded **by name** (`.build/`, `.DS_Store`), which is a property of the repository rather than of the checkout it happens to sit in;
- **an empty result throws.** This is the important half of #1508: whatever the options end up being, a completeness guard that finds no inputs must fail rather than pass;
- **the repository root is found by walking up to `Pine.xcodeproj`,** not by a fixed number of `deletingLastPathComponent()` calls, so a suite that moves into a subdirectory cannot silently scan the wrong tree.

## Audit of the other scanners

Per #1508's ask, every test that both walks the repository (`#filePath`) and enumerates a directory:

| Suite | Was it affected? | Now |
|---|---|---|
| `LocalizationCatalogCompletenessTests` | **yes** — the reported defect | shared scan |
| `DestructiveShortcutPolicyTests` (#1503) | no — already avoided the option deliberately | shared scan, duplicate removed |
| `DialogPresentationCoordinatorTests` | no hidden-file trap, but **no non-empty guard**: it asserts production Swift does *not* contain `runModal(` etc., which an empty scan makes trivially true | shared scan |
| `SparkleUpdaterTests` | same shape — concatenates all sources and asserts absences | shared scan |
| `GrammarModelTests` | already asserts `!files.isEmpty` | unchanged |

No `.skipsHiddenFiles` remains in `PineTests/` or `PineUITests/` outside documentation of the trap. The two production uses (`BreadcrumbProvider`, `ProjectSearchProvider`) are deliberate — they filter what the *user* sees in their own project — and are untouched.

## Tests

`ProductionSourceScanTests` — 9 tests:

- files carrying the hidden flag are still scanned (with the old enumeration asserted empty in the same test);
- **control:** a dotted ancestor alone does not empty the old enumeration — the assertion that keeps the explanation honest;
- hidden directories *below* the root are still excluded, including both rules at once;
- empty directory, no-Swift directory, and missing directory each throw rather than returning `[]`;
- the repository root is found by content; a path outside any checkout throws;
- the real production scan reaches `Pine/`, is sorted, and never returns fewer files than the old enumeration would have — an invariant that holds in a plain checkout and in a flagged worktree alike, so the suite does not have to guess which one it is in.

## Verification

- `ProductionSourceScanTests`, `LocalizationCatalogCompletenessTests`, `DestructiveShortcutPolicyTests`, `SparkleUpdaterTests`, `DialogPresentationCoordinatorTests` — 67 tests, green.
- Mutation proof above, both directions.
- `swiftlint` clean on every changed file.
- No UI tests run locally (maintainer is working on this machine).

## Note for CI

This guard has effectively never run against real input outside CI. If it turns up a genuine missing key on some lane, that is the guard working for the first time, not a regression from this diff.
