### PR TITLE
test: fix the six flaky tests the detector surfaced

### DIFF
--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -1627,12 +1627,25 @@ final class ProjectManager {
             return []
         }
         let entries = await recoveryManager.pendingRecoveryEntriesOffMainActor()
+        await recoveryOfferListingSeam()
         guard !didAnswerRecoveryOffer, !isRestoringRecoveryOffer else {
             return []
         }
         let live = Set(allTabs.map(\.id))
         return entries.filter { !live.contains($0.0) }
     }
+
+    /// Injected suspension inside ``pendingRecoveryOffer()``, between the
+    /// listing and the re-read of the suppression flags. No-op in production.
+    ///
+    /// The re-read exists because the listing suspends and the flags can
+    /// change while it runs — a Recover All starting, or the user answering
+    /// the sheet. Testing that without a seam means racing the scheduler with
+    /// `Task.yield()` and hoping the listing has not already finished, which
+    /// is exactly how the test covering it failed one run in three (#1518).
+    /// Same shape as `workspaceFilesystemValidationSeam`.
+    @ObservationIgnored
+    var recoveryOfferListingSeam: @Sendable () async -> Void = {}
 
     /// Records that the user has answered this project's recovery offer, by
     /// recovering, discarding, or closing the sheet without choosing.

--- a/PineTests/BackgroundProjectLifecycleTests.swift
+++ b/PineTests/BackgroundProjectLifecycleTests.swift
@@ -243,13 +243,17 @@ struct BackgroundProjectLifecycleTests {
         try #require(tab.isProcessRunning)
         let sentinel = "pine-scrollback-\(UUID().uuidString)"
         try #require(tab.sendText("\(sentinel)\n"))
-        for _ in 0..<100 {
-            await tab.search(for: sentinel)
-            if !tab.searchMatches.isEmpty { break }
-            try? await Task.sleep(for: .milliseconds(5))
-        }
-        try #require(!tab.searchMatches.isEmpty)
-        let matchCount = tab.searchMatches.count
+        // The sentinel reaches the scrollback twice — the PTY echoes the line,
+        // then `cat` writes it back — and the two arrive independently. Taking
+        // the count at the first non-empty search recorded 1 on a slow runner
+        // and 2 by the time the assertion below re-searched, which is how this
+        // test failed with `2 == 1` one run in three (#1518). Wait for the
+        // scrollback to settle instead of racing it: what this test is about
+        // is that reclamation does not change the count, not what the count is.
+        let matchCount = try #require(
+            await settledMatchCount(for: sentinel, in: tab),
+            "The sentinel never reached the terminal scrollback"
+        )
 
         registry.closeProjectWindow(directory)
         registry.runBackgroundReclamationPassForTesting()
@@ -269,6 +273,37 @@ struct BackgroundProjectLifecycleTests {
         #expect(tab.isProcessRunning)
         await tab.search(for: sentinel)
         #expect(tab.searchMatches.count == matchCount)
+    }
+
+    /// The number of scrollback matches for `sentinel` once it stops
+    /// changing, or `nil` if nothing ever arrived.
+    ///
+    /// "Settled" is a value that survives `stableChecks` consecutive searches.
+    /// A terminal writes asynchronously through a PTY, so any single search is
+    /// a sample of an animation, not a measurement.
+    private func settledMatchCount(
+        for sentinel: String,
+        in tab: TerminalTab,
+        within duration: Duration = .seconds(10),
+        stableChecks: Int = 5
+    ) async -> Int? {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: duration)
+        var lastCount = 0
+        var stable = 0
+        while clock.now < deadline {
+            await tab.search(for: sentinel)
+            let count = tab.searchMatches.count
+            if count > 0, count == lastCount {
+                stable += 1
+                if stable >= stableChecks { return count }
+            } else {
+                stable = 0
+            }
+            lastCount = count
+            try? await clock.sleep(for: .milliseconds(10))
+        }
+        return lastCount > 0 ? lastCount : nil
     }
 
     @Test("dirty project is retained when recovery is unavailable")

--- a/PineTests/FileSystemWatcherTests.swift
+++ b/PineTests/FileSystemWatcherTests.swift
@@ -92,51 +92,112 @@ struct FileSystemWatcherTests {
 
     // MARK: - Stale generation is discarded
 
-    @Test("Restarting watch increments generation and cancels pending debounce")
+    /// Restarting the watch must cancel the old directory's pending debounce
+    /// and stop delivering its events, while the new directory still works.
+    ///
+    /// This used to assert "at most one callback in the 800 ms after the
+    /// switch", which is not a property FSEvents offers: one write can surface
+    /// as several events far enough apart to survive a 300 ms debounce, and it
+    /// did — `callbackCount - countAfterSwitch → 2` on CI, one run in three
+    /// (#1518). Counting callbacks in a time box measures the filesystem's
+    /// mood, so each half is now asserted on its own and waited for by
+    /// condition rather than by clock.
+    ///
+    /// **What this covers, and what it does not.** `stopOnQueue()` defends
+    /// delivery twice: `debounceWorkItem?.cancel()` drops a work item that has
+    /// not run, and the `activeGeneration` check drops one that was already
+    /// dequeued and is running. Only the first is observable from here —
+    /// deleting the generation check leaves this test green, which is worth
+    /// knowing rather than implying otherwise. Reaching the second would mean
+    /// stopping the watcher in the instant between `asyncAfter` firing the
+    /// work item and its body reading the generation, which no test can hit
+    /// deliberately without a seam in `FileSystemWatcher`. The name says
+    /// "cancels the pending debounce" because that is what is proved.
+    @Test("Restarting watch cancels the old directory's pending debounce")
     @MainActor
     func staleGenerationDiscarded() async throws {
         let dir1 = try makeTempDirectory()
         let dir2 = try makeTempDirectory()
         defer { cleanup(dir1); cleanup(dir2) }
 
-        // Use two separate counters to distinguish dir1 vs dir2 callbacks.
-        // We verify that after switching to dir2, any callback that fires
-        // is from the new generation (dir2), not the old one (dir1).
         var callbackCount = 0
         let watcher = FileSystemWatcher(debounceInterval: 0.3) {
             callbackCount += 1
         }
+        defer { watcher.stop() }
 
-        // Watch dir1, create event — starts a debounce timer
+        // Phase A — prove the stream on dir1 is live. Without this the rest
+        // of the test could pass by watching nothing at all.
         watcher.watch(directory: dir1)
-        try "old".write(
-            to: dir1.appendingPathComponent("old.txt"),
+        try "first".write(
+            to: dir1.appendingPathComponent("first.txt"),
             atomically: true,
             encoding: .utf8
         )
+        #expect(
+            await waitForCallback(atLeast: 1, count: { callbackCount }),
+            "The watcher must deliver events for the directory it watches"
+        )
 
-        // Switch to dir2 — this calls stopOnQueue (cancels debounce,
-        // increments generation) then starts a new stream on dir2.
+        // Phase B — an event on dir1 immediately followed by a switch. The
+        // pending debounce belongs to the old generation and must never fire,
+        // however long we wait.
+        let countBeforeSwitch = callbackCount
+        try "stale".write(
+            to: dir1.appendingPathComponent("stale.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
         watcher.watch(directory: dir2)
 
-        // Record count after switching — any dir1 debounce should be cancelled
-        let countAfterSwitch = callbackCount
+        // Comfortably past the 300 ms debounce: if the old generation were
+        // still armed, this is when it would fire.
+        try await Task.sleep(for: .milliseconds(900))
+        #expect(
+            callbackCount == countBeforeSwitch,
+            "A debounce pending on the old directory fired after the switch"
+        )
 
-        // Create event in dir2 to get a reliable callback from the new generation
+        // Phase C — the watcher is not merely dead: the new directory still
+        // delivers. (Phase B alone would also pass on a broken watcher.)
         try "new".write(
             to: dir2.appendingPathComponent("new.txt"),
             atomically: true,
             encoding: .utf8
         )
+        #expect(
+            await waitForCallback(
+                atLeast: countBeforeSwitch + 1,
+                count: { callbackCount }
+            ),
+            "Events in the newly watched directory must still be delivered"
+        )
+    }
 
-        try await Task.sleep(for: .milliseconds(800))
-
-        watcher.stop()
-
-        // We should see at most one callback from dir2.
-        // The dir1 event should have been cancelled by the generation bump.
-        // (Without generation protection, we'd see 2+ callbacks)
-        #expect(callbackCount - countAfterSwitch <= 1)
+    /// Waits until the callback counter reaches `atLeast`, on a wall-clock
+    /// deadline. Returns `false` on timeout so the caller records the failure.
+    ///
+    /// The deadline is generous on purpose. FSEvents delivery is not prompt
+    /// under load — the stream carries its own latency (the debounce interval
+    /// passed to `FSEventStreamCreate`) on top of a daemon shared with every
+    /// other suite in the run. A 5-second deadline failed once during a full
+    /// local `PineTests` run while passing every isolated run, which is the
+    /// same trap this file's tests were in to begin with. Waiting on a
+    /// condition costs nothing when the event arrives on time; only a genuine
+    /// regression pays the full deadline.
+    @MainActor
+    private func waitForCallback(
+        atLeast target: Int,
+        within duration: Duration = .seconds(20),
+        count: @MainActor () -> Int
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: duration)
+        while clock.now < deadline {
+            if count() >= target { return true }
+            try? await clock.sleep(for: .milliseconds(10))
+        }
+        return count() >= target
     }
 
     // MARK: - Retained self lifecycle

--- a/PineTests/LSPSettingsTests.swift
+++ b/PineTests/LSPSettingsTests.swift
@@ -801,10 +801,12 @@ struct LSPSettingsLifecycleTests {
         #expect(manager.servers["swift"]?.state == .initialized)
 
         suspended.resumeStart(true)
-        await Task.yield()
+        // The stale client's start resumes on its own executor and only then
+        // discovers it has been replaced. Waiting for the shutdown it performs
+        // is the signal; a bare `Task.yield()` is a coin flip.
+        #expect(await waitUntil { suspended.shutdownCount == 1 })
 
         #expect(suspended.opens.isEmpty)
-        #expect(suspended.shutdownCount == 1)
         #expect(manager.servers["swift"]?.state == .initialized)
         #expect(replacements.count == 1)
     }
@@ -1432,12 +1434,23 @@ struct LSPSettingsLifecycleTests {
     /// soft timeout followed by a hard subscript is how a single flaky wait
     /// takes down the whole `PineTests` process (#1506).
     @discardableResult
+    /// Waits for a condition on a wall-clock deadline.
+    ///
+    /// `Task.yield()` alone is not a wait: it re-enters the scheduler, but a
+    /// continuation parked on another executor still needs time to run, and
+    /// on a loaded machine a hundred yields can all pass before it does. That
+    /// is what made "A stale initialize cannot replace a reconfigured client"
+    /// fail one run in three on CI while passing every local run (#1518).
     private func waitUntil(
-        _ condition: @escaping @MainActor () -> Bool
+        _ condition: @escaping @MainActor () -> Bool,
+        within duration: Duration = .seconds(5)
     ) async -> Bool {
-        for _ in 0..<100 {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: duration)
+        while clock.now < deadline {
             if condition() { return true }
             await Task.yield()
+            try? await clock.sleep(for: .milliseconds(1))
         }
         Issue.record("Timed out waiting for LSP test state")
         return false

--- a/PineTests/RecoveryTerminationSweepTests.swift
+++ b/PineTests/RecoveryTerminationSweepTests.swift
@@ -1053,13 +1053,22 @@ struct RecoveryTerminationSweepTests {
         project.recoveryManager?.snapshotDirtyTabs([Self.crashedTab(in: dir)])
         #expect(await project.pendingRecoveryOffer().count == 1)
 
+        // A gate, not a `Task.yield()`. Yielding only asks the scheduler to
+        // run the task; it does not stop the task from running *past* the
+        // listing, and on a loaded machine it regularly did — the listing
+        // finished, the offer was delivered, and the answer below arrived too
+        // late to suppress anything. That is how this test failed one run in
+        // three on CI (#1518). The seam parks the task exactly where the race
+        // it describes lives: after the listing, before the flags are re-read.
+        let gate = RecoveryListingGate()
+        project.recoveryOfferListingSeam = { await gate.pause() }
+
         let inFlight = Task { @MainActor in
             await project.pendingRecoveryOffer()
         }
-        // Hands the main actor to the task above, which runs as far as its own
-        // suspension — the off-actor listing — and stops there.
-        await Task.yield()
+        await gate.waitUntilPaused()
         project.markRecoveryOfferAnswered()
+        await gate.release()
 
         #expect(
             await inFlight.value.isEmpty,
@@ -1223,5 +1232,38 @@ struct RecoveryTerminationSweepTests {
                 .filter { $0.hasSuffix(".json") }
                 .compactMap { UUID(uuidString: String($0.dropLast(5))) }
         )
+    }
+}
+
+/// Parks whoever calls ``pause()`` until ``release()``, and lets the test wait
+/// for that to have happened. Modelled on `FoldingDecodeGate` in
+/// `LSPFoldingRangeTests`.
+private actor RecoveryListingGate {
+    private var isPaused = false
+    private var pausedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func pause() async {
+        isPaused = true
+        let waiters = pausedWaiters
+        pausedWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+        await withCheckedContinuation { continuation in
+            releaseContinuation = continuation
+        }
+    }
+
+    func waitUntilPaused() async {
+        guard !isPaused else { return }
+        await withCheckedContinuation { continuation in
+            pausedWaiters.append(continuation)
+        }
+    }
+
+    func release() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
     }
 }

--- a/PineTests/SidebarLoadingFlickerTests.swift
+++ b/PineTests/SidebarLoadingFlickerTests.swift
@@ -49,8 +49,18 @@ struct SidebarLoadingFlickerTests {
         manager.loadDirectory(url: dir)
         #expect(tracker.isLoading, "Initial loadDirectory should activate progress tracker")
 
+        // Waiting on `WorkspaceManager.isLoading` is not the same signal as
+        // the tracker: the load ends on one main-actor hop and the progress
+        // operation is ended on another, so the tracker can still be lit when
+        // the load reports done. This test used to read the tracker straight
+        // after `waitForLoadingComplete()` and blame the *refresh* below for
+        // progress the initial load had not yet put down — one failed run in
+        // three on CI, at both assertions (#1518).
         await manager.waitForLoadingComplete()
-        #expect(!tracker.isLoading, "Progress tracker should be idle after initial load")
+        #expect(
+            await waitUntilIdle(tracker),
+            "Progress tracker should be idle after initial load"
+        )
 
         // Simulate watcher-triggered refresh (what happens on file save, git status, etc.)
         manager.refreshFileTreeAsync()
@@ -61,14 +71,30 @@ struct SidebarLoadingFlickerTests {
             "refreshFileTreeAsync must not activate progress tracker (causes flicker)"
         )
 
-        // Wait for async load to complete and re-verify
-        for _ in 0..<30 {
-            try await Task.sleep(for: .milliseconds(50))
-        }
+        // …and it must stay down while the refresh actually runs, not merely
+        // in the instant after it was asked for.
+        await manager.waitForLoadingComplete()
         #expect(
             !tracker.isLoading,
             "Progress tracker must remain idle after incremental refresh completes"
         )
+    }
+
+    /// Waits for the progress tracker to go idle on a wall-clock deadline.
+    ///
+    /// Returns `false` on timeout so the caller reports a real failure rather
+    /// than hanging the suite.
+    private func waitUntilIdle(
+        _ tracker: ProgressTracker,
+        within duration: Duration = .seconds(5)
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: duration)
+        while clock.now < deadline {
+            if !tracker.isLoading { return true }
+            try? await clock.sleep(for: .milliseconds(5))
+        }
+        return !tracker.isLoading
     }
 
     @Test("refreshFileTree (sync) does not activate progress tracker")
@@ -162,7 +188,7 @@ struct SidebarLoadingFlickerTests {
 
         manager.loadDirectory(url: dir)
         await manager.waitForLoadingComplete()
-        #expect(!tracker.isLoading)
+        #expect(await waitUntilIdle(tracker))
 
         // Simulate rapid watcher events (e.g., npm install creating many files)
         for _ in 0..<10 {
@@ -188,7 +214,7 @@ struct SidebarLoadingFlickerTests {
         // Initial load of dir1
         manager.loadDirectory(url: dir1)
         await manager.waitForLoadingComplete()
-        #expect(!tracker.isLoading)
+        #expect(await waitUntilIdle(tracker))
 
         // Incremental refresh — no progress
         manager.refreshFileTreeAsync()

--- a/PineUITests/NativeFileWindowMenuUITests.swift
+++ b/PineUITests/NativeFileWindowMenuUITests.swift
@@ -170,11 +170,21 @@ final class NativeFileWindowMenuUITests: PineUITestCase {
             openPanel.waitForExistence(timeout: 5),
             "File > Open… should present a project-window-owned sheet"
         )
+        // `waitForExistence`, not `exists`: the sheet answers before its own
+        // contents are laid out, so a bare `exists` asks the panel about a
+        // control it has not built yet. This is what made the test flaky —
+        // one failed run in the first honest flaky-detector report (#1518).
         let viewOptions = openPanel.menuButtons["View Options"].firstMatch
-        XCTAssertTrue(viewOptions.exists)
+        XCTAssertTrue(
+            viewOptions.waitForExistence(timeout: 5),
+            "The open panel should offer its View Options menu"
+        )
         viewOptions.click()
         let listView = app.menuItems["List"].firstMatch
-        XCTAssertTrue(listView.exists)
+        XCTAssertTrue(
+            listView.waitForExistence(timeout: 5),
+            "View Options should open a menu containing List"
+        )
         listView.click()
 
         let mainFilePredicate = NSPredicate(


### PR DESCRIPTION
Fixes all six tests listed in #1518. Each diagnosis comes from the **actual CI failure message**, not from inspection — I pulled the first-attempt failures out of run [32714905211](https://github.com/batonogov/pine/actions/runs/32714905211) before touching anything. That mattered: my first hypothesis for the terminal test was wrong, and the log said so.

## Diagnoses

| Test | CI said | Cause | Class |
|---|---|---|---|
| `BackgroundProjectLifecycleTests` | `(searchMatches.count → 2) == (matchCount → 1)` | sentinel reaches the scrollback **twice** (PTY echo, then `cat`); baseline taken at the first non-empty search | test race |
| `LSPSettingsTests` | `(shutdownCount → 0) == 1` | `Task.yield()` used as a wait | test race |
| `RecoveryTerminationSweepTests` | `await inFlight.value.isEmpty` | same `Task.yield()` assumption — the listing finished before the answer landed | test race |
| `SidebarLoadingFlickerTests` | `!tracker.isLoading → true`, twice | waits on `WorkspaceManager.isLoading`, asserts on `ProgressTracker` — two different signals | test race |
| `FileSystemWatcherTests` | `(callbackCount - countAfterSwitch → 2) <= 1` | asserts a property FSEvents does not offer | test race |
| `NativeFileWindowMenuUITests` | `XCTAssertTrue failed` at :174 | `exists` on a sheet that answers before its contents are laid out | test race |

All six are the test racing something. No product defect among them — which is itself worth knowing, and is why the fixes are in the tests (plus one seam).

**The terminal one is worth a note.** My first guess was the 500 ms search budget. I instrumented it and ran it under eight competing CPU hogs: the sentinel arrives in **7 ms, 2 iterations of 100**, every run. The budget was never the problem — the count was, because the line lands twice and the test recorded the baseline mid-animation. Had I "fixed" the budget, the flake would have survived and looked addressed.

## The one production change

`ProjectManager.recoveryOfferListingSeam` — an injectable suspension between the recovery listing and the re-read of the suppression flags, defaulting to a no-op. Same shape as the existing `workspaceFilesystemValidationSeam`.

The behaviour under test is precisely that the flags are re-read *after* the listing suspends. Testing it with `Task.yield()` means asking the scheduler nicely and hoping the listing has not already finished — it regularly had. With the seam the test parks the task exactly where the race lives. Per #1518's guidance, nothing was fixed with a sleep or a retry loop.

## Mutation-verified

A fix that quietly weakens a test is worse than the flake, so each one was checked by reintroducing the defect it guards:

| Mutation | Result |
|---|---|
| drop the post-listing flag re-read in `pendingRecoveryOffer()` | **red** ✔ |
| let the incremental refresh show progress (`showProgress: true`) | **red**, 5 issues ✔ |
| leave a superseded LSP client running (no `client.shutdown()`) | **red**, "Timed out waiting for LSP test state" ✔ |
| drop `FileSystemWatcher`'s `activeGeneration` check | **green** ✘ — see below |

## An honest gap, found by that mutation

Deleting the `activeGeneration` guard leaves `FileSystemWatcherTests` green — before **and** after this PR. `stopOnQueue()` defends delivery twice: `debounceWorkItem?.cancel()` drops a work item that has not run yet, and the generation check drops one that was already dequeued and is executing. Only the first is reachable from a test; hitting the second means stopping the watcher in the window between `asyncAfter` firing the item and its body reading the generation, which needs a seam in `FileSystemWatcher`.

So the test is renamed from "Restarting watch increments generation and cancels pending debounce" to **"Restarting watch cancels the old directory's pending debounce"** — what it actually proves — and the gap is written into the doc comment instead of being implied away. Happy to file a follow-up for a seam if you want the generation guard genuinely covered.

## While fixing, two more of the same shape

`SidebarLoadingFlickerTests` had two sibling tests reading the tracker in the same instant after `waitForLoadingComplete()`. They did not fail in the report, but they are the same coin flip and are fixed with it.

## Verification

- The five unit suites: 81 tests, green.
- Full local `PineTests`: none of the six appear. Remaining failures are the known local-only set — `AgentInboxToolbarButtonSnapshotTests` (baselines are recorded on macOS 26 CI; this machine is macOS 27) and six timing-sensitive suites that **all pass on a clean re-run** (111 tests, green) and failed only while the full suite was competing for the machine.
- One of my own fixes failed that full run at first — `waitForCallback` timed out at 5 s under load — so its deadline is now 20 s. Waiting on a condition costs nothing when the event is on time; only a real regression pays it.
- No UI tests run locally (maintainer is working on this machine); the UI fix is a `waitForExistence` swap and CI owns that shard.

## Expect more

These six are what one run surfaced. The suites that failed my loaded full run — `LSPProcessTransport`, `UserTaskRunner`, `AsyncFormatOnSave`, `MultiProjectAgentJourney`, `ApplicationLifecycleProcess`, `AgentAdapterRegistry` — are timing-sensitive in the same way and are plausible next entries once CI has a few more honest runs. #1518 stays open for them.
