### PR TITLE
test(agent): cover Agent Inbox focus return, the last of #1491's criteria

### DIFF
--- a/Pine/Agent/AgentInboxFocusRestoration.swift
+++ b/Pine/Agent/AgentInboxFocusRestoration.swift
@@ -1,0 +1,159 @@
+//
+//  AgentInboxFocusRestoration.swift
+//  Pine
+//
+//  Where keyboard focus goes when the Agent Inbox popover closes (#1491).
+//
+
+import AppKit
+
+/// Why an Inbox popover went away.
+///
+/// It is the only thing that decides whether the window that hosted it takes
+/// keyboard focus back, so it is recorded per presentation rather than
+/// inferred at close time — by then the popover has already been key and the
+/// window system no longer remembers who asked.
+enum AgentInboxDismissalCause: Equatable {
+    /// Escape, a click outside, the toolbar button, ⇧⌘I. The user is still
+    /// exactly where they were, so the host takes focus back.
+    case userDismissedInPlace
+    /// A successful navigation or recovery moved the user to another session
+    /// (``AgentInboxActionOutcome/dismiss``). The window they were sent to
+    /// owns focus now.
+    case navigatedAway
+    /// The anchor was demounted with the popover open — the window is closing,
+    /// or SwiftUI rebuilt the toolbar. There is no host left to return to.
+    case anchorDetached
+}
+
+/// The window a closing Inbox popover may hand keyboard focus back to,
+/// reduced to what the anchor does with it.
+///
+/// `NSWindow` conforms, so production restores focus in the very window the
+/// popover was anchored in. Tests substitute a double: the unit test host is a
+/// background application with no key window, where `makeKeyAndOrderFront` and
+/// first-responder changes driven by key status cannot be observed at all.
+@MainActor
+protocol AgentInboxFocusHost: AnyObject {
+    /// False once the host has left the screen — closed, hidden, or
+    /// miniaturized — while the Inbox was open. Focus is never forced into one.
+    var canTakeFocus: Bool { get }
+    /// The responder worth returning to when the popover closes, read before
+    /// the popover takes key.
+    func captureFocusedResponder() -> NSResponder?
+    /// Makes the host key again and puts keyboard focus back on `responder`
+    /// when it is still a legitimate target inside this window.
+    func returnFocus(to responder: NSResponder?)
+}
+
+extension NSWindow: AgentInboxFocusHost {
+    /// The same on-screen rule every other in-place routing decision uses. A
+    /// window in the Dock is deliberately refused here even though the Inbox
+    /// *presentation* path accepts one (#1507): presenting deminiaturizes its
+    /// host first and shows the user where the work landed, while pulling a
+    /// window out of the Dock merely to give it focus back undoes a choice the
+    /// user made while the popover was open.
+    var canTakeFocus: Bool {
+        WindowRoutingReach.onScreenOnly.admitsWindow(
+            isVisible: isVisible,
+            isMiniaturized: isMiniaturized
+        )
+    }
+
+    func captureFocusedResponder() -> NSResponder? {
+        AgentInboxFocusRestoration.restorableResponder(
+            firstResponder,
+            in: self
+        )
+    }
+
+    func returnFocus(to responder: NSResponder?) {
+        // Ordering the host front is the whole restoration when nothing
+        // focusable was recorded: AppKit already returns key to a transient
+        // popover's parent, and this makes that explicit for the paths — a
+        // deminiaturized host, a host raised past an auxiliary window — where
+        // the popover's parent is not where the user came from.
+        makeKeyAndOrderFront(nil)
+        guard let target = AgentInboxFocusRestoration.restorableResponder(
+            responder,
+            in: self
+        ) else { return }
+        makeFirstResponder(target)
+    }
+}
+
+/// The two rules behind returning focus after the Inbox closes: whether to
+/// return it at all, and what inside the host is still a legitimate target.
+enum AgentInboxFocusRestoration {
+    enum Decision: Equatable {
+        /// Make the host key again and put focus back where it was.
+        case restoreHostFocus
+        /// Leave focus exactly where the dismissal put it.
+        case leaveFocusAlone
+    }
+
+    /// - Parameters:
+    ///   - cause: why the popover closed. Only an in-place dismissal restores;
+    ///     a navigation is the user asking to be somewhere else, and a detach
+    ///     has no host left.
+    ///   - hostCanTakeFocus: whether the host is still on screen. A window the
+    ///     user closed, hid, or minimized while the Inbox was open must not be
+    ///     ordered back to the front to receive focus.
+    ///   - isApplicationActive: whether Pine is still frontmost. A `.transient`
+    ///     popover also closes when the user clicks into another application,
+    ///     and `makeKeyAndOrderFront` on an inactive app marks the window to
+    ///     become key on the next activation — so restoring here would take
+    ///     focus the moment the user comes back, after they chose to leave.
+    static func decision(
+        cause: AgentInboxDismissalCause,
+        hostCanTakeFocus: Bool,
+        isApplicationActive: Bool
+    ) -> Decision {
+        guard cause == .userDismissedInPlace,
+              hostCanTakeFocus,
+              isApplicationActive else { return .leaveFocusAlone }
+        return .restoreHostFocus
+    }
+
+    /// The responder focus may be handed to inside `window`, or `nil` when
+    /// there is none worth restoring.
+    ///
+    /// Two things are filtered out. A view that is no longer in this exact
+    /// window: SwiftUI rebuilds view trees freely and the Inbox stays open
+    /// across those passes, so a recorded view can be demounted or moved to
+    /// another window by the time the popover closes, and
+    /// `makeFirstResponder` on it would put keyboard focus somewhere the user
+    /// cannot see. And a field editor: while a control is being edited the
+    /// window's first responder is the one shared `NSTextView` AppKit lends
+    /// out, not the control, so the control it is currently installed in is
+    /// the stable target — AppKit re-lends the editor to it.
+    ///
+    /// The window itself is not a target. That is simply "nothing was
+    /// focused", which ``AgentInboxFocusHost/returnFocus(to:)`` already
+    /// produces by ordering the window front.
+    static func restorableResponder(
+        _ responder: NSResponder?,
+        in window: NSWindow
+    ) -> NSResponder? {
+        guard let view = responder as? NSView, view.window === window else {
+            return nil
+        }
+        guard let editor = view as? NSTextView, editor.isFieldEditor else {
+            return view
+        }
+        return enclosingControl(of: editor)
+    }
+
+    /// The control a field editor is currently installed in. AppKit nests the
+    /// shared editor inside the control's own clip view, so the owner is found
+    /// by walking up — and every ancestor of a view already established to be
+    /// in `window` is in that same window.
+    private static func enclosingControl(of view: NSView) -> NSControl? {
+        var candidate = view.superview
+        while let current = candidate {
+            if let control = current as? NSControl { return control }
+            candidate = current.superview
+        }
+        return nil
+    }
+}

--- a/Pine/Agent/AgentInboxFocusRestoration.swift
+++ b/Pine/Agent/AgentInboxFocusRestoration.swift
@@ -78,7 +78,22 @@ extension NSWindow: AgentInboxFocusHost {
             responder,
             in: self
         ) else { return }
-        makeFirstResponder(target)
+        // `makeFirstResponder` answers `false` when the target — or the
+        // responder currently holding focus — refuses the change, and that
+        // answer is deliberately not acted on. There is no better second
+        // choice: the window is already front and key, the recorded responder
+        // is the only place the user was, and forcing focus somewhere else
+        // would invent a destination they never asked for. AppKit's own
+        // fallback is the right one — focus stays with whoever refused to give
+        // it up, or with the window itself, which reads as "nothing focused"
+        // and is exactly what the popover's parent window would have shown
+        // anyway. The refusal is a no-op, not a failure to recover from.
+        //
+        // If that ever needs to become visible, the honest fix is for
+        // ``AgentInboxFocusHost/returnFocus(to:)`` to return the result and
+        // for the coordinator to log it — not to retry, and not to pick a
+        // different responder.
+        _ = makeFirstResponder(target)
     }
 }
 

--- a/Pine/Agent/AgentInboxPopoverCoordinator.swift
+++ b/Pine/Agent/AgentInboxPopoverCoordinator.swift
@@ -63,10 +63,17 @@ final class AgentInboxPopoverCoordinator: NSObject, NSPopoverDelegate,
         Context
     ) -> (any AgentInboxPopoverHandle)?
 
+    /// How the anchor's window is reached for focus work. `NSWindow` conforms
+    /// to ``AgentInboxFocusHost``, so production hands back the window itself.
+    typealias FocusHostResolver =
+        @MainActor (NSWindow) -> any AgentInboxFocusHost
+
     private typealias State = AgentInboxPopoverPresentationState
 
     private let router: AgentInboxPopoverRouter
     private let makePopover: PopoverFactory
+    private let resolveFocusHost: FocusHostResolver
+    private let isApplicationActive: @MainActor () -> Bool
     private weak var anchor: AgentInboxPopoverAnchorView?
     private weak var registeredWindow: NSWindow?
     private var isPresented: Binding<Bool>?
@@ -100,6 +107,24 @@ final class AgentInboxPopoverCoordinator: NSObject, NSPopoverDelegate,
     /// ``lastWrittenIsPresented``: that one remembers a write SwiftUI has
     /// already been given, this one a write still on its way.
     private var isCloseSettling = false
+    /// Why the popover on screen is going away, recorded as the dismissal
+    /// happens rather than inferred once it is over.
+    ///
+    /// By the time a close settles the popover has been key and is gone, so
+    /// nothing left on screen distinguishes "the user pressed Escape" from
+    /// "a successful navigation moved them into another window". The default
+    /// is the in-place dismissal because that is what every path AppKit
+    /// handles by itself — Escape, an outside click — arrives as.
+    private var dismissalCause = AgentInboxDismissalCause.userDismissedInPlace
+    /// The window the popover on screen was anchored in.
+    ///
+    /// Held weakly and read back at close time rather than resolved then: by
+    /// then the anchor may have moved, and keeping a closing `NSWindow` alive
+    /// for the runloop turn a close takes is precisely the lifetime this type
+    /// must not extend.
+    private weak var focusHostWindow: NSWindow?
+    /// What owned keyboard focus in that window before the popover appeared.
+    private weak var focusedResponderBeforePresentation: NSResponder?
 
     /// How many may land before the anchor stops waiting for a close
     /// notification that is not coming.
@@ -146,10 +171,16 @@ final class AgentInboxPopoverCoordinator: NSObject, NSPopoverDelegate,
     init(
         router: AgentInboxPopoverRouter = .shared,
         makePopover: @escaping PopoverFactory = AgentInboxPopoverCoordinator
-            .makeSystemPopover
+            .makeSystemPopover,
+        resolveFocusHost: @escaping FocusHostResolver = { $0 },
+        isApplicationActive: @escaping @MainActor () -> Bool = {
+            NSApp.isActive
+        }
     ) {
         self.router = router
         self.makePopover = makePopover
+        self.resolveFocusHost = resolveFocusHost
+        self.isApplicationActive = isApplicationActive
     }
 
     /// The production popover: a transient, Liquid-Glass-friendly `NSPopover`
@@ -296,6 +327,9 @@ final class AgentInboxPopoverCoordinator: NSObject, NSPopoverDelegate,
             router.unregister(self, from: registeredWindow)
         }
         registeredWindow = nil
+        // The window is closing, or SwiftUI has rebuilt the toolbar out from
+        // under this anchor. Either way there is no host left worth raising.
+        dismissalCause = .anchorDetached
         apply(state.anchorDidDetach())
         anchor = nil
     }
@@ -354,6 +388,7 @@ final class AgentInboxPopoverCoordinator: NSObject, NSPopoverDelegate,
                 bindingIsPresented: self.bindingIsPresented,
                 isPopoverShown: self.isPopoverShown
             ))
+            self.returnFocusToHost()
         }
     }
 
@@ -411,11 +446,64 @@ final class AgentInboxPopoverCoordinator: NSObject, NSPopoverDelegate,
         // Something newer is on screen, so the close no longer speaks for this
         // anchor: the binding the popover was built against is the live one.
         isCloseSettling = false
+        recordFocusToReturnTo(in: anchor.window)
         state.popoverWillShow()
         handle.showPopover(from: anchor)
     }
 
+    /// Records where keyboard focus has to come back to, *before* the popover
+    /// is shown.
+    ///
+    /// An `NSPopover` takes key away from its host as it appears, so the same
+    /// read taken afterwards answers about the popover rather than about the
+    /// user. This is also where a new presentation supersedes the record of
+    /// the one before it — the cause resets to the in-place dismissal, which
+    /// is what Escape and an outside click arrive as.
+    private func recordFocusToReturnTo(in window: NSWindow?) {
+        dismissalCause = .userDismissedInPlace
+        focusHostWindow = window
+        focusedResponderBeforePresentation = window
+            .map(resolveFocusHost)?
+            .captureFocusedResponder()
+    }
+
+    /// Hands keyboard focus back to the window the popover was anchored in,
+    /// one runloop turn after AppKit reported the close.
+    ///
+    /// Deferred with the SwiftUI half rather than performed inside the close
+    /// notification: raising a window from inside AppKit's own close is the
+    /// same re-entrancy the binding write avoids, and the turn is what lets a
+    /// newer request overtake this one — a popover that is on screen again by
+    /// then owns focus, and this dismissal no longer speaks for the window.
+    private func returnFocusToHost() {
+        guard !isPopoverShown else { return }
+        let cause = dismissalCause
+        let responder = focusedResponderBeforePresentation
+        let host = focusHostWindow.map(resolveFocusHost)
+        // Defence in depth, and knowingly uncovered: no path calls this twice
+        // for one presentation — `retireClosedPopover()` is the only caller,
+        // it drops the popover reference synchronously, and only
+        // `presentIfReady()`, which re-records, can set that reference again.
+        // Keeping the record retired means a future second caller finds
+        // nothing to replay rather than raising a window twice.
+        dismissalCause = .userDismissedInPlace
+        focusHostWindow = nil
+        focusedResponderBeforePresentation = nil
+        guard let host,
+              AgentInboxFocusRestoration.decision(
+                  cause: cause,
+                  hostCanTakeFocus: host.canTakeFocus,
+                  isApplicationActive: isApplicationActive()
+              ) == .restoreHostFocus else { return }
+        host.returnFocus(to: responder)
+    }
+
+    /// The content's own dismissal, which the Inbox performs for exactly one
+    /// reason: ``AgentInboxActionOutcome/dismiss`` — the user reached the
+    /// session they asked for. That window is key now, so this close must not
+    /// pull focus back to the one the popover was anchored in.
     private func dismiss() {
+        dismissalCause = .navigatedAway
         apply(state.contentRequestedDismiss(
             bindingIsPresented: bindingIsPresented
         ))

--- a/Pine/Agent/AgentInboxPresentationCoordinator.swift
+++ b/Pine/Agent/AgentInboxPresentationCoordinator.swift
@@ -266,16 +266,20 @@ final class AgentInboxPresentationCoordinator {
     /// Restores a miniaturized host before raising it: an `NSPopover` shown
     /// relative to an anchor inside a miniaturized window has nowhere to draw.
     ///
-    /// The restore branch is a protocol guarantee, not a reachable production
-    /// path today. `AppDelegate` projects project-window eligibility through
-    /// `NSWindow.isVisible`, which reads `false` while a window is in the
-    /// Dock, so a miniaturized *project* window is never selected: the request
-    /// silently falls through to Welcome instead of returning the user to the
-    /// project they minimized. A minimized *Welcome* window is restored today,
-    /// but by `ensureWelcomeVisible()` on the create path rather than here.
-    /// #1491's "minimized hosts are restored before presentation" is therefore
-    /// unmet for project windows, and no test here claims otherwise; widening
-    /// eligibility changes where ⇧⌘I lands and belongs in its own change (#1507).
+    /// The restore branch is reachable since #1516. `AppDelegate` projects
+    /// Inbox host eligibility through ``WindowRoutingReach/onScreenOrDock`` for
+    /// both project and Welcome windows, so a window sitting in the Dock is a
+    /// candidate and arrives here miniaturized — this is what returns the user
+    /// to the project they minimized instead of opening a second Welcome
+    /// window. Before that widening the branch was a protocol guarantee only,
+    /// and #1491's "minimized hosts are restored before presentation" described
+    /// behavior no code could perform (#1507).
+    ///
+    /// Focus is only sent *into* the host here. Where it goes when the popover
+    /// closes again is the anchor's decision, in
+    /// ``AgentInboxFocusRestoration`` — this workflow is over by then, and the
+    /// window that hosted the popover is the only object that still knows what
+    /// owned keyboard focus before it appeared.
     private func prepare(
         _ host: any AgentInboxHosting,
         in environment: any AgentInboxHostEnvironment

--- a/PineTests/AgentInboxFocusRestorationTests.swift
+++ b/PineTests/AgentInboxFocusRestorationTests.swift
@@ -1,0 +1,452 @@
+//
+//  AgentInboxFocusRestorationTests.swift
+//  PineTests
+//
+//  Where keyboard focus lands once the Agent Inbox popover goes away (#1491).
+//
+//  Two halves, both pure enough to run without a window server: the rule that
+//  decides whether the host takes focus back at all, and the rule that decides
+//  which responder inside it is still a legitimate target.
+//
+
+import AppKit
+import Testing
+
+@testable import Pine
+
+@Suite("Agent Inbox focus restoration rule")
+@MainActor
+struct AgentInboxFocusRestorationRuleTests {
+    /// The whole truth table, so no combination is decided by accident.
+    ///
+    /// Only one row restores: the user dismissed the Inbox in place, the host
+    /// window is still on screen, and Pine is still the active application.
+    /// Every other row leaves focus exactly where the dismissal put it.
+    @Test(
+        "the host takes focus back only for an in-place dismissal it can serve",
+        arguments: [
+            (AgentInboxDismissalCause.userDismissedInPlace, true, true,
+             AgentInboxFocusRestoration.Decision.restoreHostFocus),
+            (.userDismissedInPlace, true, false, .leaveFocusAlone),
+            (.userDismissedInPlace, false, true, .leaveFocusAlone),
+            (.userDismissedInPlace, false, false, .leaveFocusAlone),
+            (.navigatedAway, true, true, .leaveFocusAlone),
+            (.navigatedAway, true, false, .leaveFocusAlone),
+            (.navigatedAway, false, true, .leaveFocusAlone),
+            (.navigatedAway, false, false, .leaveFocusAlone),
+            (.anchorDetached, true, true, .leaveFocusAlone),
+            (.anchorDetached, true, false, .leaveFocusAlone),
+            (.anchorDetached, false, true, .leaveFocusAlone),
+            (.anchorDetached, false, false, .leaveFocusAlone),
+        ]
+    )
+    func focusDecisionTruthTable(
+        cause: AgentInboxDismissalCause,
+        hostCanTakeFocus: Bool,
+        isApplicationActive: Bool,
+        expected: AgentInboxFocusRestoration.Decision
+    ) {
+        #expect(
+            AgentInboxFocusRestoration.decision(
+                cause: cause,
+                hostCanTakeFocus: hostCanTakeFocus,
+                isApplicationActive: isApplicationActive
+            ) == expected,
+            """
+            \(cause), canTakeFocus=\(hostCanTakeFocus), \
+            active=\(isApplicationActive)
+            """
+        )
+    }
+
+    /// The one row that is easy to get backwards.
+    ///
+    /// A successful navigation or recovery has just moved the user into
+    /// another project window. Returning focus to the window that hosted the
+    /// popover would take it straight back off the session they asked for —
+    /// the popover's own dismissal undoing the action that caused it.
+    @Test("a navigating dismissal never pulls focus off its destination")
+    func navigationKeepsItsDestination() {
+        #expect(
+            AgentInboxFocusRestoration.decision(
+                cause: .navigatedAway,
+                hostCanTakeFocus: true,
+                isApplicationActive: true
+            ) == .leaveFocusAlone
+        )
+    }
+
+    /// A transient popover closes when the user clicks into another
+    /// application. `makeKeyAndOrderFront` on an inactive app marks the window
+    /// to become key on the next activation, so restoring here would hand
+    /// Pine's window focus the moment the user comes back — after they chose
+    /// to leave.
+    @Test("a dismissal that left the app never reclaims focus")
+    func inactiveApplicationIsLeftAlone() {
+        #expect(
+            AgentInboxFocusRestoration.decision(
+                cause: .userDismissedInPlace,
+                hostCanTakeFocus: true,
+                isApplicationActive: false
+            ) == .leaveFocusAlone
+        )
+    }
+
+    /// A host that closed, hid, or went to the Dock while the Inbox was open
+    /// is not a focus destination: raising it would resurrect a window the
+    /// user has just put away.
+    @Test("a host that left the screen is never raised to take focus back")
+    func offScreenHostIsNeverRaised() {
+        #expect(
+            AgentInboxFocusRestoration.decision(
+                cause: .userDismissedInPlace,
+                hostCanTakeFocus: false,
+                isApplicationActive: true
+            ) == .leaveFocusAlone
+        )
+    }
+}
+
+@Suite("Agent Inbox focus restoration targets", .serialized)
+@MainActor
+struct AgentInboxFocusRestorationTargetTests {
+    /// The ordinary case: the editor, sidebar, or terminal view that owned
+    /// keyboard focus when the Inbox opened is still in its window.
+    @Test("a responder still installed in the window is restorable")
+    func liveResponderIsRestorable() throws {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+        let view = fixture.addContentView()
+
+        #expect(
+            AgentInboxFocusRestoration.restorableResponder(
+                view,
+                in: fixture.window
+            ) === view
+        )
+    }
+
+    /// SwiftUI rebuilds view trees freely, and the Inbox stays open across
+    /// those passes. `makeFirstResponder` on a demounted view moves keyboard
+    /// focus to an object that is no longer on screen — the window then has a
+    /// first responder the user cannot see or type into.
+    @Test("a responder demounted while the Inbox was open is refused")
+    func demountedResponderIsRefused() {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+        let view = fixture.addContentView()
+        view.removeFromSuperview()
+
+        #expect(
+            AgentInboxFocusRestoration.restorableResponder(
+                view,
+                in: fixture.window
+            ) == nil
+        )
+    }
+
+    /// The multi-window guard. A view that moved into another window belongs
+    /// to that window's responder chain now, and focusing it from here would
+    /// be this window reaching into another one.
+    @Test("a responder that moved to another window is refused")
+    func responderInAnotherWindowIsRefused() {
+        let fixture = Fixture()
+        let other = Fixture()
+        defer {
+            fixture.cleanup()
+            other.cleanup()
+        }
+        let view = other.addContentView()
+
+        #expect(
+            AgentInboxFocusRestoration.restorableResponder(
+                view,
+                in: fixture.window
+            ) == nil
+        )
+    }
+
+    /// "Nothing was focused" is a real state — a window whose first responder
+    /// is the window itself. It must not be restored as if it were a view,
+    /// because raising the window already produces exactly that.
+    @Test("the window itself is not a restoration target")
+    func theWindowItselfIsNotATarget() {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+
+        #expect(
+            AgentInboxFocusRestoration.restorableResponder(
+                fixture.window,
+                in: fixture.window
+            ) == nil
+        )
+    }
+
+    @Test("nothing to restore stays nothing")
+    func nilResponderStaysNil() {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+
+        #expect(
+            AgentInboxFocusRestoration.restorableResponder(
+                nil,
+                in: fixture.window
+            ) == nil
+        )
+    }
+
+    /// The case a naive `firstResponder` round-trip gets wrong.
+    ///
+    /// While the user is typing in a text field — project search, inline
+    /// rename, the branch filter — the window's first responder is the shared
+    /// field editor, not the field. AppKit lends that one text view to
+    /// whichever control is editing, so restoring the editor object hands
+    /// focus to a view the window may have already re-lent elsewhere. The
+    /// control that hosts it is the stable target, and AppKit re-installs the
+    /// editor into it.
+    @Test("a field editor is restored through the control that hosts it")
+    func fieldEditorIsRestoredThroughItsControl() {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+        let field = fixture.addTextField()
+        let editor = fixture.installFieldEditor(in: field)
+
+        #expect(
+            AgentInboxFocusRestoration.restorableResponder(
+                editor,
+                in: fixture.window
+            ) === field
+        )
+    }
+
+    /// The same rule with nothing to redirect to. A field editor that is not
+    /// inside a control has no stable owner, so focus is left alone rather
+    /// than pinned to a text view AppKit is free to move.
+    @Test("a field editor with no control behind it is refused")
+    func fieldEditorWithoutAControlIsRefused() {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+        let editor = NSTextView(
+            frame: NSRect(x: 0, y: 0, width: 80, height: 20)
+        )
+        editor.isFieldEditor = true
+        fixture.window.contentView?.addSubview(editor)
+
+        #expect(
+            AgentInboxFocusRestoration.restorableResponder(
+                editor,
+                in: fixture.window
+            ) == nil
+        )
+    }
+
+    /// A plain `NSTextView` — Pine's own editor — is not a field editor and is
+    /// restored directly. Without the `isFieldEditor` test the rule would
+    /// redirect every editor focus through a delegate that is not a view.
+    @Test("a document text view is restored directly, not through a delegate")
+    func documentTextViewIsRestoredDirectly() {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+        let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 40, height: 20))
+        fixture.window.contentView?.addSubview(textView)
+
+        #expect(
+            AgentInboxFocusRestoration.restorableResponder(
+                textView,
+                in: fixture.window
+            ) === textView
+        )
+    }
+
+    // MARK: - The NSWindow conformance
+
+    /// `canTakeFocus` is the production reading of "this host is still a place
+    /// focus can go". An off-screen window — closed or hidden — is not.
+    @Test("an off-screen window reports it cannot take focus")
+    func offScreenWindowCannotTakeFocus() {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+
+        #expect(!fixture.window.isVisible)
+        #expect(!fixture.window.canTakeFocus)
+    }
+
+    /// The other side of the same rule, so "cannot take focus" is not simply
+    /// what this type always answers.
+    @Test("a window on screen reports it can take focus")
+    func onScreenWindowCanTakeFocus() {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+        fixture.window.orderFront(nil)
+
+        #expect(fixture.window.canTakeFocus)
+    }
+
+    /// The deliberate divergence from Inbox host *selection*.
+    ///
+    /// Presenting the Inbox accepts a window in the Dock and deminiaturizes it
+    /// first (#1507), which shows the user where the work landed. Returning
+    /// focus after a dismissal shows nothing, so pulling a window the user
+    /// minimized *while the Inbox was open* back out would undo that choice
+    /// silently. `isVisible` alone cannot express this — AppKit reports
+    /// `false` for a Dock window and for a closed one alike.
+    @Test("a window the user sent to the Dock cannot take focus back")
+    func dockedWindowCannotTakeFocus() {
+        let window = DockableWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled, .closable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        window.orderFront(nil)
+        #expect(window.canTakeFocus)
+
+        window.isInDock = true
+
+        #expect(window.isMiniaturized)
+        #expect(!window.canTakeFocus)
+    }
+
+    /// Returning focus orders the host front even when nothing focusable was
+    /// recorded. A host raised past an auxiliary window, or restored from the
+    /// Dock, is not necessarily the window AppKit hands key back to when a
+    /// transient popover closes.
+    @Test("returning focus orders the host window front")
+    func returningFocusOrdersTheHostFront() {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+        #expect(!fixture.window.isVisible)
+
+        fixture.window.returnFocus(to: nil)
+
+        #expect(fixture.window.isVisible)
+    }
+
+    /// The window's own capture reads through the same restorability rule, so
+    /// a window with nothing focused records nothing rather than recording
+    /// itself.
+    @Test("a window with nothing focused captures nothing")
+    func idleWindowCapturesNothing() {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+
+        #expect(fixture.window.firstResponder === fixture.window)
+        #expect(fixture.window.captureFocusedResponder() == nil)
+    }
+
+    /// The round trip production actually performs: capture the focused view
+    /// before presenting, hand focus to something else, and put it back.
+    @Test("a captured view is the one focus returns to")
+    func capturedViewIsReturnedTo() throws {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+        let view = fixture.addFocusableView()
+        let other = fixture.addFocusableView()
+
+        #expect(fixture.window.makeFirstResponder(view))
+        let captured = try #require(fixture.window.captureFocusedResponder())
+        #expect(captured === view)
+
+        #expect(fixture.window.makeFirstResponder(other))
+        fixture.window.returnFocus(to: captured)
+
+        #expect(fixture.window.firstResponder === view)
+    }
+
+    /// A view that went away while the Inbox was open must not be forced back
+    /// into the responder chain; the window is simply left as it is.
+    @Test("returning focus to a demounted view changes nothing")
+    func returningToADemountedViewIsANoOp() {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+        let view = fixture.addFocusableView()
+        let survivor = fixture.addFocusableView()
+
+        #expect(fixture.window.makeFirstResponder(view))
+        view.removeFromSuperview()
+        #expect(fixture.window.makeFirstResponder(survivor))
+
+        fixture.window.returnFocus(to: view)
+
+        #expect(fixture.window.firstResponder === survivor)
+    }
+
+    // MARK: - Fixture
+
+    @MainActor
+    private final class Fixture {
+        let window: NSWindow
+
+        init() {
+            window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            window.contentView = NSView(
+                frame: NSRect(x: 0, y: 0, width: 320, height: 240)
+            )
+        }
+
+        @discardableResult
+        func addContentView() -> NSView {
+            let view = NSView(frame: NSRect(x: 0, y: 0, width: 40, height: 20))
+            window.contentView?.addSubview(view)
+            return view
+        }
+
+        @discardableResult
+        func addFocusableView() -> NSView {
+            let view = FocusableView(
+                frame: NSRect(x: 0, y: 0, width: 40, height: 20)
+            )
+            window.contentView?.addSubview(view)
+            return view
+        }
+
+        @discardableResult
+        func addTextField() -> NSTextField {
+            let field = NSTextField(
+                frame: NSRect(x: 0, y: 0, width: 80, height: 20)
+            )
+            window.contentView?.addSubview(field)
+            return field
+        }
+
+        /// Reproduces the hierarchy AppKit builds while a control is being
+        /// edited — the shared field editor nested inside the control's own
+        /// clip view — without depending on a key window to start editing.
+        func installFieldEditor(in control: NSControl) -> NSTextView {
+            let clip = NSClipView(frame: control.bounds)
+            let editor = NSTextView(frame: control.bounds)
+            editor.isFieldEditor = true
+            clip.documentView = editor
+            control.addSubview(clip)
+            return editor
+        }
+
+        func cleanup() {
+            window.orderOut(nil)
+        }
+    }
+
+    /// A view AppKit will actually hand first-responder status to without a
+    /// key window behind it.
+    private final class FocusableView: NSView {
+        override var acceptsFirstResponder: Bool { true }
+    }
+
+    /// A window that can be put in the Dock without a window server, matching
+    /// what AppKit reports there: `isMiniaturized == true` and
+    /// `isVisible == false`. Measured on macOS 27.0 and recorded in
+    /// ``WindowRoutingReach``.
+    private final class DockableWindow: NSWindow {
+        var isInDock = false
+
+        override var isMiniaturized: Bool { isInDock }
+
+        override var isVisible: Bool { isInDock ? false : super.isVisible }
+    }
+}

--- a/PineTests/AgentInboxFocusReturnTests.swift
+++ b/PineTests/AgentInboxFocusReturnTests.swift
@@ -1,0 +1,489 @@
+//
+//  AgentInboxFocusReturnTests.swift
+//  PineTests
+//
+//  Where keyboard focus goes when the Agent Inbox popover closes — the last
+//  of #1491's acceptance criteria, and the one with no production code before
+//  this suite.
+//
+//  `AgentInboxFocusRestorationRuleTests` pins the rule as a value. This suite
+//  pins the wiring around it: what the anchor records, when it records it, and
+//  which dismissal it acts on. Both halves are needed — a coordinator that
+//  captures the wrong responder, or captures it after the popover has taken
+//  focus, satisfies the rule perfectly and still returns the user nowhere.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+@Suite("Agent Inbox focus return", .serialized)
+@MainActor
+struct AgentInboxFocusReturnTests {
+    // MARK: - The dismissals that return focus
+
+    /// Escape and a click outside are handled by AppKit itself: the popover is
+    /// `.transient`, so the anchor only ever learns about them through the
+    /// close notification. Focus has to come back to the window the user was
+    /// working in, on the responder they were working in.
+    @Test("an outside click or Escape returns focus to the host responder")
+    func appKitCloseReturnsFocusToTheHost() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        fixture.mount()
+        let editor = fixture.focusHost.focusedResponder
+
+        fixture.coordinator.presentAgentInbox()
+        let popover = try #require(fixture.popovers.last)
+
+        fixture.dismissFromAppKit(popover)
+        await fixture.settle()
+
+        #expect(fixture.focusHost.returnedResponders.count == 1)
+        #expect((fixture.focusHost.returnedResponders.first ?? nil) === editor)
+    }
+
+    /// The toolbar button and ⇧⌘I both close the Inbox by lowering the
+    /// SwiftUI binding, which reaches AppKit as an anchor-started close rather
+    /// than an AppKit-started one. The user has not gone anywhere, so this is
+    /// the same in-place dismissal.
+    @Test("closing from the toolbar returns focus to the host responder")
+    func bindingCloseReturnsFocusToTheHost() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        fixture.mount()
+        let editor = fixture.focusHost.focusedResponder
+
+        fixture.coordinator.presentAgentInbox()
+        let popover = try #require(fixture.popovers.last)
+
+        fixture.isPresented = false
+        fixture.update()
+        popover.isPopoverVisible = false
+        fixture.coordinator.popoverDidClose(sender: popover)
+        await fixture.settle()
+
+        #expect(fixture.focusHost.returnedResponders.count == 1)
+        #expect((fixture.focusHost.returnedResponders.first ?? nil) === editor)
+    }
+
+    /// The window is asked to take focus back exactly once per dismissal.
+    /// SwiftUI re-renders constantly while a close animates, and every one of
+    /// those passes reaches the same close path; a restore per pass would
+    /// yank the window forward repeatedly.
+    ///
+    /// - Note: this pins the *once*, but not the record retirement inside
+    ///   `returnFocusToHost()`. Deleting those three lines leaves this suite
+    ///   green, because nothing calls `returnFocusToHost()` twice for one
+    ///   presentation: `retireClosedPopover()` is its only caller, it clears
+    ///   the popover reference synchronously, and only `presentIfReady()` —
+    ///   which re-records — can set that reference again. The retirement is
+    ///   therefore defence in depth against a future second caller, and it is
+    ///   not covered. Written here rather than implied away.
+    @Test("a dismissal returns focus once, not once per SwiftUI pass")
+    func focusIsReturnedOncePerDismissal() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        fixture.mount()
+
+        fixture.coordinator.presentAgentInbox()
+        let popover = try #require(fixture.popovers.last)
+
+        fixture.isPresented = false
+        fixture.update()
+        popover.isPopoverVisible = false
+        fixture.coordinator.popoverDidClose(sender: popover)
+        for _ in 0..<8 { fixture.update() }
+        await fixture.settle()
+        for _ in 0..<8 { fixture.update() }
+        await fixture.settle()
+
+        #expect(fixture.focusHost.returnedResponders.count == 1)
+    }
+
+    /// Two full cycles: the second dismissal must restore too. The cause and
+    /// the captured responder are per-presentation state, and a version that
+    /// forgets to reset them leaves the second Escape doing nothing.
+    @Test("every open and dismiss cycle returns focus again")
+    func everyCycleReturnsFocus() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        fixture.mount()
+
+        for cycle in 0..<3 {
+            let expected = fixture.moveFocus(to: "responder-\(cycle)")
+            fixture.coordinator.presentAgentInbox()
+            let popover = try #require(fixture.popovers.last)
+
+            fixture.dismissFromAppKit(popover)
+            await fixture.settle()
+            fixture.update()
+
+            #expect(
+                fixture.focusHost.returnedResponders.count == cycle + 1,
+                "Cycle \(cycle) did not return focus"
+            )
+            #expect(
+                (fixture.focusHost.returnedResponders.last ?? nil) === expected,
+                "Cycle \(cycle) returned focus to the wrong responder"
+            )
+        }
+    }
+
+    // MARK: - The dismissals that must not
+
+    /// The dismissal that would be actively harmful to restore.
+    ///
+    /// The Inbox closes on a *successful* navigation or recovery, which has
+    /// just made another project window key. Returning focus to the window
+    /// that hosted the popover would undo the very action the user took —
+    /// they would land back where they started with the Inbox gone.
+    @Test("a successful navigation keeps focus on the window it moved to")
+    func navigatingDismissalLeavesFocusAlone() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        fixture.mount()
+
+        fixture.coordinator.presentAgentInbox()
+        let popover = try #require(fixture.popovers.last)
+        let context = try #require(fixture.contexts.last)
+
+        // What `AgentInboxActionOutcome.dismiss` reaches the anchor through.
+        context.onDismiss()
+        popover.isPopoverVisible = false
+        fixture.coordinator.popoverDidClose(sender: popover)
+        await fixture.settle()
+
+        #expect(fixture.focusHost.returnedResponders.isEmpty)
+    }
+
+    /// An anchor demounted with the Inbox open — the window is closing, or
+    /// SwiftUI rebuilt the toolbar out from under it. There is no host left to
+    /// return to, and raising one would fight the teardown.
+    @Test("a detached anchor never returns focus to the window it left")
+    func detachedAnchorLeavesFocusAlone() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        fixture.mount()
+
+        fixture.coordinator.presentAgentInbox()
+        let popover = try #require(fixture.popovers.last)
+
+        fixture.coordinator.detach()
+        popover.isPopoverVisible = false
+        fixture.coordinator.popoverDidClose(sender: popover)
+        await fixture.settle()
+
+        #expect(fixture.focusHost.returnedResponders.isEmpty)
+    }
+
+    /// The host went off screen while the Inbox was open — closed, hidden, or
+    /// minimized to the Dock. Restoring would order a window the user just put
+    /// away back to the front.
+    @Test("a host that left the screen is never raised to take focus back")
+    func offScreenHostIsNeverRaised() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        fixture.mount()
+
+        fixture.coordinator.presentAgentInbox()
+        let popover = try #require(fixture.popovers.last)
+
+        fixture.focusHost.canTakeFocus = false
+        fixture.dismissFromAppKit(popover)
+        await fixture.settle()
+
+        #expect(fixture.focusHost.returnedResponders.isEmpty)
+    }
+
+    /// A `.transient` popover also closes when the user clicks into another
+    /// application. Pine is no longer active, and a window told to become key
+    /// there takes focus the moment the user comes back to Pine — after they
+    /// chose to leave it.
+    @Test("a dismissal that left the application never reclaims focus")
+    func inactiveApplicationLeavesFocusAlone() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        fixture.mount()
+
+        fixture.coordinator.presentAgentInbox()
+        let popover = try #require(fixture.popovers.last)
+
+        fixture.isApplicationActive = false
+        fixture.dismissFromAppKit(popover)
+        await fixture.settle()
+
+        #expect(fixture.focusHost.returnedResponders.isEmpty)
+    }
+
+    /// A close settles a whole runloop turn after AppKit reports it, and a new
+    /// request can open the Inbox again inside that turn. The popover on
+    /// screen owns focus; the finished close no longer speaks for the window.
+    @Test("a close that settles under a newer popover leaves focus alone")
+    func settledCloseUnderANewerPopoverLeavesFocusAlone() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        fixture.mount()
+
+        fixture.coordinator.presentAgentInbox()
+        let first = try #require(fixture.popovers.last)
+
+        fixture.dismissFromAppKit(first)
+        // ⇧⌘I again, inside the turn the close still owes its write.
+        fixture.coordinator.presentAgentInbox()
+        await fixture.settle()
+
+        #expect(fixture.popovers.count == 2)
+        #expect(fixture.focusHost.returnedResponders.isEmpty)
+    }
+
+    // MARK: - What gets recorded, and when
+
+    /// The ordering the whole feature rests on.
+    ///
+    /// An `NSPopover` takes key away from its host window as it appears, so a
+    /// capture made after the show reads the popover's own state rather than
+    /// the user's. The record has to be taken before the popover is on screen.
+    @Test("focus is recorded before the popover is shown")
+    func focusIsRecordedBeforeTheShow() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        fixture.mount()
+
+        fixture.coordinator.presentAgentInbox()
+
+        #expect(fixture.journal == ["capture", "show"])
+    }
+
+    /// Nothing is recorded for a request that does not produce a popover, so
+    /// an anchor that never showed anything cannot later hand focus to a
+    /// responder captured for a presentation that did not happen.
+    @Test("a request that shows nothing records no focus to return to")
+    func aRequestThatShowsNothingRecordsNothing() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        // Attached but never mounted in a window: `presentIfReady` refuses.
+        fixture.coordinator.attach(to: fixture.anchor)
+
+        fixture.coordinator.presentAgentInbox()
+
+        #expect(fixture.popovers.isEmpty)
+        #expect(fixture.journal.isEmpty)
+    }
+
+    /// The window whose focus is restored is the one the popover was anchored
+    /// in, resolved from the anchor rather than from whatever is key at close
+    /// time — by then the popover itself has been key.
+    @Test("focus returns to the window the popover was anchored in")
+    func focusReturnsToTheAnchorsOwnWindow() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        fixture.mount()
+
+        fixture.coordinator.presentAgentInbox()
+        let popover = try #require(fixture.popovers.last)
+
+        fixture.dismissFromAppKit(popover)
+        await fixture.settle()
+
+        #expect(fixture.resolvedWindows.allSatisfy { $0 === fixture.window })
+        #expect(!fixture.resolvedWindows.isEmpty)
+    }
+
+    // MARK: - Fixture
+
+    @MainActor
+    final class Fixture {
+        let router = AgentInboxPopoverRouter { operation in operation() }
+        let registry: ProjectRegistry
+        let focusHost = FakeFocusHost()
+        var isApplicationActive = true
+        private(set) var popovers: [FakePopover] = []
+        private(set) var contexts: [AgentInboxPopoverCoordinator.Context] = []
+        /// The order AppKit-visible work happened in, which is the only way to
+        /// see that the capture precedes the show.
+        private(set) var journal: [String] = []
+        /// Every window handed to the focus-host resolver.
+        private(set) var resolvedWindows: [NSWindow] = []
+        var isPresented = false
+        private var snapshot = false
+        let anchor = AgentInboxPopoverAnchorView(frame: .zero)
+        let window: NSWindow
+        private let suiteName: String
+        private let defaults: UserDefaults
+        private var openedProjectWindows: [URL] = []
+
+        lazy var coordinator = AgentInboxPopoverCoordinator(
+            router: router,
+            makePopover: { [weak self] _, context in
+                guard let self else { return nil }
+                let popover = FakePopover { [weak self] event in
+                    self?.journal.append(event)
+                }
+                self.popovers.append(popover)
+                self.contexts.append(context)
+                return popover
+            },
+            resolveFocusHost: { [weak self] window in
+                guard let self else { return window }
+                self.resolvedWindows.append(window)
+                return self.focusHost
+            },
+            isApplicationActive: { [weak self] in
+                self?.isApplicationActive ?? true
+            }
+        )
+
+        init() throws {
+            suiteName = "AgentInboxFocusReturnTests.\(UUID())"
+            defaults = try #require(UserDefaults(suiteName: suiteName))
+            defaults.removePersistentDomain(forName: suiteName)
+            registry = ProjectRegistry(
+                defaults: defaults,
+                agentTasks: AgentTaskRegistry(),
+                agentDetectionProcessRunner: { _, _, _, _ in
+                    ProcessRunResult(
+                        stdout: "",
+                        stderr: "",
+                        exitCode: 0,
+                        timedOut: false
+                    )
+                },
+                agentDetectionPollInterval: 3_600,
+                agentDetectionInitialPollDelay: 3_600
+            )
+            registry.recentProjects = []
+            window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            window.contentView = NSView(
+                frame: window.contentRect(forFrameRect: window.frame)
+            )
+            focusHost.journal = { [weak self] event in
+                self?.journal.append(event)
+            }
+        }
+
+        func mount() {
+            window.contentView?.addSubview(anchor)
+            coordinator.attach(to: anchor)
+            update()
+        }
+
+        func update() {
+            snapshot = isPresented
+            coordinator.update(
+                anchor: anchor,
+                isPresented: Binding(
+                    get: { [weak self] in self?.snapshot ?? false },
+                    set: { [weak self] value in self?.isPresented = value }
+                ),
+                registry: registry,
+                openProjectWindow: { [weak self] url in
+                    self?.openedProjectWindows.append(url)
+                },
+                reduceMotion: true
+            )
+        }
+
+        /// Moves the host window's keyboard focus, as the user would by
+        /// clicking into the editor or the sidebar.
+        @discardableResult
+        func moveFocus(to name: String) -> NSResponder {
+            let responder = NamedResponder(name: name)
+            focusHost.focusedResponder = responder
+            return responder
+        }
+
+        /// Escape or a click outside: AppKit closes the popover on its own and
+        /// tells the anchor afterwards.
+        func dismissFromAppKit(_ popover: FakePopover) {
+            coordinator.popoverWillClose(sender: popover)
+            popover.isPopoverVisible = false
+            coordinator.popoverDidClose(sender: popover)
+        }
+
+        /// Lets the deferred SwiftUI-and-focus half of a close run.
+        ///
+        /// Every hop in the coordinator is a `DispatchQueue.main.async`, and
+        /// the main queue is FIFO: a continuation enqueued now resumes after
+        /// all of them. That is a real wait for the work rather than a guess
+        /// at its timing — no sleep, and no `Task.yield()` standing in for
+        /// one.
+        func settle() async {
+            await withCheckedContinuation { continuation in
+                DispatchQueue.main.async { continuation.resume() }
+            }
+        }
+
+        func cleanup() {
+            coordinator.detach()
+            anchor.removeFromSuperview()
+            window.orderOut(nil)
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+    }
+
+    /// Stands in for the host `NSWindow`'s focus behaviour, which cannot be
+    /// established from a live window here: the unit test host is a background
+    /// application, so it has no key window and `makeKeyAndOrderFront` is
+    /// unobservable.
+    @MainActor
+    final class FakeFocusHost: AgentInboxFocusHost {
+        var canTakeFocus = true
+        var focusedResponder: NSResponder? = NamedResponder(name: "editor")
+        private(set) var returnedResponders: [NSResponder?] = []
+        var journal: ((String) -> Void)?
+
+        func captureFocusedResponder() -> NSResponder? {
+            journal?("capture")
+            return focusedResponder
+        }
+
+        func returnFocus(to responder: NSResponder?) {
+            journal?("return")
+            returnedResponders.append(responder)
+        }
+    }
+
+    @MainActor
+    final class FakePopover: AgentInboxPopoverHandle {
+        var isPopoverVisible = false
+        private let journal: (String) -> Void
+
+        init(journal: @escaping (String) -> Void) {
+            self.journal = journal
+        }
+
+        func showPopover(from anchor: NSView) {
+            journal("show")
+            isPopoverVisible = true
+        }
+
+        func closePopover() {
+            journal("close")
+            isPopoverVisible = false
+        }
+    }
+
+    /// An identifiable stand-in for the editor, sidebar, or terminal view that
+    /// owned keyboard focus before the Inbox opened.
+    private final class NamedResponder: NSResponder {
+        let name: String
+
+        init(name: String) {
+            self.name = name
+            super.init()
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+    }
+}


### PR DESCRIPTION
## Diagnosis: the issue had gone stale — twelve of thirteen were already covered

I re-audited all thirteen acceptance criteria against the tree rather than
against the issue text. #1513, #1514 and #1516 landed *after* #1491 was written
and closed twelve of them:

| # | Criterion | Covered by |
|---|---|---|
| 1 | key eligible project window wins | `AgentInboxHostRoutingTests` "the key eligible project window wins" |
| 2 | key Welcome wins when no project is eligible | "the key Welcome window wins when no project is eligible" |
| 3 | auxiliary key window routes to the most recent project | "an auxiliary key window routes to the most recent project" (routing + `AgentInboxPresentationCoordinatorTests`) |
| 4 | visible Welcome is the final existing-window fallback | "a visible Welcome window is the final existing-window fallback" |
| 5 | no eligible window creates Welcome, queues exactly one request | "no eligible window creates Welcome exactly once per request", "repeated requests while Welcome mounts present exactly once" |
| 6 | minimized hosts are restored before presentation | "the hosting contract restores a host before it focuses it" + "Windows in the Dock" in `AgentInboxHostOptionsTests` (made reachable by #1516) |
| 7 | a request never opens popovers in multiple windows | "one request never opens a popover in a second window" |
| 8 | replacement and released anchors cannot receive stale requests | "a superseded anchor cannot unregister its replacement's window", "a released anchor cannot serve a queued request" |
| 9 | repeated requests do not duplicate or orphan the popover | "a rebuilt anchor inherits the request exactly once, never twice", "a burst of requests while shown produces no extra popover" |
| 10 | outside click and Escape synchronize SwiftUI state | "an outside click or Escape lowers the SwiftUI binding" |
| 11 | successful navigation or recovery dismisses the popover | "successful navigation or recovery closes and lowers the binding" |
| 12 | failed and stale routes keep the popover visible | "every failed navigation keeps the popover visible" + `AgentInboxActionOutcomeTests` |
| **13** | **focus returns to the correct host after dismissal** | **nothing — this PR** |

**Criterion 13 had no production code at all.** What shipped was whatever AppKit
does for a transient `NSPopover` whose window closes: *usually* the anchor window
becoming key again, by side effect. The within-window first responder — editor,
sidebar, terminal, a text field mid-edit — was not addressed, and the actively
harmful case was unguarded: a successful navigation makes another project window
key, and AppKit's own key restoration pulls the user straight back off the
session they just asked for.

## TDD

- `60172b1` — the tests alone. **They do not compile**: `AgentInboxDismissalCause`,
  `AgentInboxFocusRestoration`, `AgentInboxFocusHost` and the coordinator's two
  new init parameters do not exist yet. That is the intended red.
- `8e3ae7c` — the seam. All 31 turn green.
- `a1dab63` — one comment, from review.

## What was built

**`AgentInboxFocusRestoration`** — a pure rule with two halves, in the style of
`AgentInboxHostRouting` and `AgentInboxActionOutcome`:

- `decision(cause:hostCanTakeFocus:isApplicationActive:)`. Exactly one row
  restores. A successful navigation or recovery (`AgentInboxActionOutcome.dismiss`)
  never does — the window it moved the user to owns focus. A host that left the
  screen while the Inbox was open is not raised back out. An application the user
  clicked away from does not reclaim focus on its next activation, because
  `makeKeyAndOrderFront` on an inactive app marks the window to become key the
  moment they come back.
- `restorableResponder(_:in:)`. Refuses a view no longer in this exact window —
  SwiftUI rebuilds toolbars while the Inbox is open, and `makeFirstResponder` on
  a demounted view puts keyboard focus somewhere invisible — and redirects a
  field editor to the control hosting it, because AppKit lends that one shared
  text view out and it may have moved on.

**`AgentInboxFocusHost`** — the seam. `NSWindow` conforms, so production restores
focus in the very window the popover was anchored in; the unit test host is a
background application where key status and `makeKeyAndOrderFront` cannot be
observed at all, so tests substitute a double. The two AppKit facts the rule
needs enter as separate parameters so each can be falsified on its own.
`canTakeFocus` deliberately uses `WindowRoutingReach.onScreenOnly` while Inbox
host *selection* uses `.onScreenOrDock` (#1507): presenting deminiaturizes its
host and shows the user where the work landed, whereas pulling a window out of
the Dock merely to hand it focus back would silently undo a choice the user made
while the popover was open.

**`AgentInboxPopoverCoordinator`** — records the host window and its focused
responder *before* showing the popover, because the popover takes key as it
appears, and returns focus in the same deferred hop that settles the SwiftUI
write: never inside AppKit's own close notification, and never over a newer
popover that reached the screen inside that turn.

**`AgentInboxPresentationCoordinator`** — doc comment only. It still described
the miniaturized-host restore branch as structurally unreachable and criterion 6
as unmet; #1516 widened Inbox eligibility to `.onScreenOrDock` and made that
branch live, leaving the comment behind.

No sleeps, no `Task.yield()` as a wait. The only wait is `withCheckedContinuation`
over `DispatchQueue.main.async` — the main queue is FIFO, so it resumes strictly
after the coordinator's own deferred hops. That is a real wait for the work, not
a guess at its timing.

## Mutation-verified — 14 of 15 red

| # | Mutation | Result |
|---|---|---|
| M1 | `dismiss()` stops recording `.navigatedAway` | **red** |
| M2 | `detach()` stops recording `.anchorDetached` | **red** |
| M3 | rule ignores host reachability | **red** (both suites) |
| M4 | rule ignores `NSApp.isActive` | **red** (both suites) |
| M5 | rule ignores the dismissal cause | **red** (5 tests) |
| M6 | record focus *after* `showPopover` | **red** |
| M7 | drop `guard !isPopoverShown` in `returnFocusToHost` | **red** |
| M8 | never retire the record | **GREEN** — see below |
| M9 | `restorableResponder` drops the `view.window === window` test | **red** (3 tests) |
| M10 | restore the field editor itself instead of its control | **red** |
| M11 | `canTakeFocus` uses `.onScreenOrDock` | **red** |
| M12 | `returnFocus` never orders the host front | **red** |
| M13 | `returnFocus` calls `makeFirstResponder` unvalidated | **red** |
| M14 | the close never calls `returnFocusToHost` | **red** (4 tests) |
| M15 | `captureFocusedResponder` returns `firstResponder` raw | **red** |

## Honest gaps

**M8 — the record retirement is not covered, and cannot be.** Deleting the three
clearing lines in `returnFocusToHost()` leaves everything green. I checked
whether that was a weak test and it is not: `retireClosedPopover()` is the only
caller, it drops the popover reference synchronously, and only `presentIfReady()`
— which re-records — can set that reference again. Nothing calls it twice for one
presentation, so there is no path to observe. I kept the retirement as defence in
depth against a future second caller and wrote the gap into the test's doc
comment and the production comment rather than deleting the code or padding the
suite with a test that proves nothing.

**No UI tests, so the 7 UI shards are untouched.** Everything here is
establishable at the unit seam. The parts XCUITest could add — key status and
`makeKeyAndOrderFront` — are exactly what AGENTS.md's macOS 26/27 known issues
say synthetic events and a background test host cannot establish reliably.

**`await Task.yield()` in `AgentInboxPresentationCoordinator.createWelcomeHost`
is left as it is**, and filed as #1535. It is an optimization rather than a
correctness wait — the router queues the request and delivers it on registration,
and that queued path has its own tests — so it is not the #1521 shape, where a
test asserted on state a yield was hoped to have produced. But the construct
already cost one investigation, so the reasoning, the difference from #1521, and
the four conditions that would make it load-bearing are recorded in the issue.

**`makeFirstResponder`'s `Bool` is deliberately dropped** in
`NSWindow.returnFocus(to:)`, and `a1dab63` says why in place: there is no better
second choice, AppKit's own fallback is the right one, and the honest fix if it
ever needs to be visible is to return and log the result — not to retry.

## Verification

- macOS 27.0 (26A5421a), Xcode 27.0 (27A5237l), macOS SDK 27.0 (26A5406c),
  isolated `-derivedDataPath /private/tmp/pine-dd-1491`.
- `swiftlint --strict` — **0 violations, 0 serious in 804 files**.
- `xcodebuild build` — **BUILD SUCCEEDED**.
- New suites: `AgentInboxFocusRestorationRuleTests` 4 passed,
  `AgentInboxFocusRestorationTargetTests` 15 passed, `AgentInboxFocusReturnTests`
  12 passed.
- Neighbours re-run individually, all green: `AgentInboxPopoverCoordinatorTests`
  15, `AgentInboxPopoverRouterTests` 23, `AgentInboxPopoverPresentationStateTests`
  29, `AgentInboxPresentationCoordinatorTests` 21,
  `AgentInboxPopoverSystemObjectsTests` 6, `AgentInboxHostOptionsTests` 28.
- `AgentInboxToolbarButtonSnapshotTests` fails locally (4 issues) — pre-existing
  and unrelated: baselines are recorded on macOS 26 CI, this machine is macOS 27,
  the same local-only failure recorded in #1521. This diff does not touch that
  view. CI is the authority.
- Whitespace check clean.

## Ready to merge

After CI is green **and** a manual pass, since this diff changes focus behaviour:
open the Inbox and dismiss it with Escape, with a click outside, and by
navigating successfully into another project; and open it with the host window
minimized. Merge is the maintainer's.

Closes #1491
