### PR TITLE
fix(concurrency): give background work its own autorelease pool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,7 @@ Pine uses GCD for background work, bridged to async/await via `withCheckedContin
 - CPU-intensive work dispatched to background: syntax highlighting (`com.pine.syntax-highlight` serial queue), git operations (`DispatchQueue.global` with `DispatchGroup` for parallel branch/status/branches), project search (`TaskGroup` with sliding-window concurrency), file tree loading (`DispatchQueue.global`)
 - **Never block main thread** with file I/O, regex computation, or git process execution
 - Generation tokens (`HighlightGeneration`, `WorkspaceManager.loadGeneration`, `FileSystemWatcher.activeGeneration`) prevent stale async results from overwriting newer ones — always check generation before applying results
+- **Background work owns its autorelease pool** (#1509). A `DispatchQueue.global()` work item runs with no pool in place, so every autoreleased Foundation/AppKit temporary it produces is parked in libobjc's thread-wide fallback pool and stays alive until the worker thread is destroyed. `runOnBackground` (`Pine/Concurrency/BackgroundDispatch.swift`) wraps its body in `autoreleasepool` on both the success and the error path — prefer it over a raw `DispatchQueue.global().async`, and wrap the body yourself where a raw dispatch is unavoidable. Verify with `OBJC_DEBUG_MISSING_POOLS=YES`: "autoreleased with no pool in place" lines are the regression signal
 
 **Debounce values** (centralised in `UITimings.Debounce` / `UITimings.Render`):
 - Syntax highlight on edit: 100ms (`Debounce.edit`)
@@ -239,6 +240,14 @@ How the maintainer works day-to-day. Documents intent and handoff conventions fo
 - A full `xcodebuild build` is run **before opening a PR**.
 - Run locally: `swiftlint` + the unit tests in `PineTests` that cover the touched area.
 - **UI tests (`PineUITests`, 7 shards) run only on CI** — almost never locally.
+
+**Local runs on the macOS 27 beta are not a pass/fail signal** — CI is (#1509). Two known standing differences on that runtime, both unrelated to whatever diff is in the tree: `AgentInboxToolbarButtonSnapshotTests` fails all four cases because the baselines are recorded on the macOS 26 CI runner and the beta renders that view ~3% differently; and `ApplicationLifecycleProcessTests.quitCrashAndRelaunchJourney()` fails with `terminal-child-unavailable` when several agents run `xcodebuild` at once, because its wait for the spawned terminal child is bounded at 5s. Confirm a local failure on an idle machine before blaming a diff for it.
+
+**Diagnosing a test-host crash on the macOS 27 beta** (#1509):
+- Trust `~/Library/Logs/DiagnosticReports/`, not the console log — the beta drops log lines badly. Reports rotate into `Retired/` and only about twenty are kept there, so **copy a report out the moment you see the crash**; the two incidents #1509 was opened on were already gone by the time it was triaged.
+- Record the OS **build**, not the marketing version: `sw_vers` → `BuildVersion`, matched against `osVersion.build` in the `.ips`. `/var/log/install.log` (`Previous System Version … Current System Version …`) says when the machine changed builds, which is the first thing to check before calling a crash reproducible or fixed.
+- Inject `objc`/malloc diagnostics by copying the generated `.xctestrun` and editing `TestConfigurations → TestTargets → EnvironmentVariables`, then `xcodebuild test-without-building -xctestrun <copy>`. Keep the copy **in the same directory as the original** — the file's `__TESTROOT__` placeholders resolve relative to it. Useful keys: `OBJC_DEBUG_POOL_ALLOCATION=YES` (halts on an out-of-order pool pop), `OBJC_DEBUG_MISSING_POOLS=YES`, `OBJC_DISABLE_AUTORELEASE_COALESCING=YES`, `MallocScribble=1`, `NSZombieEnabled=YES`.
+- For a crash in `objc_autoreleasePoolPop` → `AutoreleasePoolPage::releaseUntil` → `objc_release`, the registers `x22 = 0xa1a1a1a1`, `x23 = 0xf00ffffffffffff` and `x24 = 0xa3a3a3a3a3a3a3a3` are **not** evidence of anything — they are loop-invariant constants (pool-page magic, pointer mask, SCRIBBLE byte) materialised in `releaseUntil`'s prologue on every single pool pop. Read `x0`/`x21` (the object being released), the word at `[x0]` (its `isa`), and confirm `far == (isa & 0x7ffffffffff8) + 0x20`. Reaching `releaseUntil` at all means libobjc already validated the page magic, so the pool page itself was intact.
 
 ### Working with AI agents
 - Typical handoff: **"реши issue #N"** (solve issue #N) — the agent reads the issue **and all its comments** in full, then plans, implements, writes tests, and opens a PR.

--- a/Pine/Concurrency/BackgroundDispatch.swift
+++ b/Pine/Concurrency/BackgroundDispatch.swift
@@ -19,6 +19,16 @@ import Foundation
 /// once the result is ready. The closure is `@Sendable`, so callers must pass
 /// in pure values rather than capturing actor-isolated state.
 ///
+/// The body runs inside an explicit `autoreleasepool` (#1509). Global dispatch
+/// queues install no pool of their own, so without one every autoreleased
+/// Foundation/AppKit temporary the body produces — `NSURL`, `NSString`,
+/// bridged `CharacterSet`, git and file-enumeration byproducts — lands in
+/// libobjc's thread-wide fallback pool and stays alive until the worker thread
+/// is destroyed. A full `PineTests` run under `OBJC_DEBUG_MISSING_POOLS=YES`
+/// logs thousands of "autoreleased with no pool in place - just leaking"
+/// warnings for exactly this reason. Draining per call also keeps each pool
+/// small, which bounds the work a single `objc_autoreleasePoolPop` has to do.
+///
 /// - Parameters:
 ///   - qos: Quality of service of the global queue. Defaults to `.userInitiated`
 ///     to match Pine's existing call sites.
@@ -31,7 +41,10 @@ func runOnBackground<T: Sendable>(
 ) async -> T {
     await withCheckedContinuation { continuation in
         DispatchQueue.global(qos: qos).async {
-            continuation.resume(returning: work())
+            // Resume outside the pool: the continuation must not run with this
+            // pool still on the stack.
+            let value = autoreleasepool { work() }
+            continuation.resume(returning: value)
         }
     }
 }
@@ -40,6 +53,10 @@ func runOnBackground<T: Sendable>(
 
 /// Throwing variant of `runOnBackground(qos:_:)`. Errors thrown by `work` are
 /// propagated through the continuation and surface to the awaiting caller.
+///
+/// The body runs inside an explicit `autoreleasepool` for the reason described
+/// on the non-throwing variant (#1509). The pool drains on the error path too,
+/// so a throwing body cannot strand its temporaries on the worker thread.
 ///
 /// - Parameters:
 ///   - qos: Quality of service of the global queue. Defaults to `.userInitiated`.
@@ -54,7 +71,9 @@ func runOnBackground<T: Sendable>(
     try await withCheckedThrowingContinuation { continuation in
         DispatchQueue.global(qos: qos).async {
             do {
-                let result = try work()
+                // Resume outside the pool: the continuation must not run with
+                // this pool still on the stack.
+                let result = try autoreleasepool { try work() }
                 continuation.resume(returning: result)
             } catch {
                 continuation.resume(throwing: error)

--- a/PineTests/BackgroundDispatchTests.swift
+++ b/PineTests/BackgroundDispatchTests.swift
@@ -227,6 +227,68 @@ struct BackgroundDispatchTests {
         }
         #expect(counter.value == 1)
     }
+
+    // MARK: - Autorelease pool hygiene (#1509)
+
+    // `DispatchQueue.global()` work items run with **no** autorelease pool in
+    // place. Anything the body autoreleases — every Foundation/AppKit bridge
+    // that returns an autoreleased instance — is then parked in libobjc's
+    // thread-wide fallback pool and stays alive until the dispatch worker
+    // thread itself is torn down. A full `PineTests` run under
+    // `OBJC_DEBUG_MISSING_POOLS=YES` logs thousands of
+    // "autoreleased with no pool in place - just leaking" warnings because of
+    // this. `runOnBackground` is Pine's single background-work choke point, so
+    // it owns the pool.
+    //
+    // The probe below makes that observable: `Unmanaged.autorelease()` hands
+    // the object to the current pool, so the object is deallocated when — and
+    // only when — a pool drains.
+
+    @Test("Non-throwing variant drains autoreleased objects before returning")
+    func nonThrowingDrainsAutoreleasePool() async {
+        let deallocations = AtomicCounter()
+        _ = await runOnBackground {
+            let probe = AutoreleaseProbe(deallocations: deallocations)
+            _ = Unmanaged.passRetained(probe).autorelease()
+        }
+        #expect(deallocations.value == 1)
+    }
+
+    @Test("Throwing variant drains autoreleased objects before returning")
+    func throwingDrainsAutoreleasePool() async throws {
+        let deallocations = AtomicCounter()
+        _ = try await runOnBackground { () -> Int in
+            let probe = AutoreleaseProbe(deallocations: deallocations)
+            _ = Unmanaged.passRetained(probe).autorelease()
+            return 1
+        }
+        #expect(deallocations.value == 1)
+    }
+
+    @Test("Throwing variant drains the pool even when the body throws")
+    func throwingDrainsAutoreleasePoolOnError() async {
+        let deallocations = AtomicCounter()
+        await #expect(throws: SentinelError.self) {
+            try await runOnBackground { () -> Int in
+                let probe = AutoreleaseProbe(deallocations: deallocations)
+                _ = Unmanaged.passRetained(probe).autorelease()
+                throw SentinelError(code: 1509)
+            }
+        }
+        #expect(deallocations.value == 1)
+    }
+
+    @Test("Every closure gets its own drain, not one shared at thread death")
+    func repeatedCallsEachDrainTheirOwnPool() async {
+        let deallocations = AtomicCounter()
+        for _ in 0..<8 {
+            _ = await runOnBackground {
+                let probe = AutoreleaseProbe(deallocations: deallocations)
+                _ = Unmanaged.passRetained(probe).autorelease()
+            }
+        }
+        #expect(deallocations.value == 8)
+    }
 }
 
 // MARK: - Test helpers
@@ -251,4 +313,19 @@ nonisolated final class AtomicCounter: @unchecked Sendable {
         defer { lock.unlock() }
         return storedValue
     }
+}
+
+/// Object whose `deinit` records into an ``AtomicCounter``. Handed to
+/// `Unmanaged.autorelease()` so its deallocation observes exactly one thing:
+/// whether an autorelease pool drained while the closure body was on the
+/// stack. `NSObject` because `objc_autorelease` is the mechanism under test.
+nonisolated final class AutoreleaseProbe: NSObject, @unchecked Sendable {
+    private let deallocations: AtomicCounter
+
+    init(deallocations: AtomicCounter) {
+        self.deallocations = deallocations
+        super.init()
+    }
+
+    deinit { deallocations.increment() }
 }


### PR DESCRIPTION
## What this is

A **collateral fix** for a real defect found while diagnosing #1509. It is **not** a fix for the `objc_autoreleasePoolPop` segfault — that crash's origin is still unattributed, and #1509 stays open. See [the diagnosis comment](https://github.com/batonogov/pine/issues/1509) for the forensics.

## The defect

`runOnBackground` is Pine's single documented choke point for leaving an actor to do CPU-bound or blocking work — 19 call sites across 9 files. It dispatched straight onto a global queue.

A `DispatchQueue.global()` work item runs with **no autorelease pool in place**. Everything the body autoreleases — `NSURL` from file enumeration, bridged `CharacterSet`, git byproducts — is handed to libobjc's thread-wide fallback pool and stays alive until the dispatch worker thread is destroyed. Pine had no `autoreleasepool` anywhere in the app target.

Verified standalone before touching anything:

```
$ OBJC_DEBUG_MISSING_POOLS=YES ./poolcheck
objc[40145]: MISSING POOLS: (0x16d873000) Object 0x102c0b460 of class poolcheck.Probe
             autoreleased with no pool in place - just leaking
deallocCount after closure (no explicit pool): 0
deallocCount after closure (explicit pool):    1
```

## The change

Both variants wrap the body in `autoreleasepool` and resume the continuation **outside** it — a continuation must not run with the pool still on the stack. The throwing variant drains on the error path too, since `autoreleasepool` pops via `defer`.

## Measured effect

Two full `PineTests` runs under `OBJC_DEBUG_MISSING_POOLS=YES`, same commit apart from this change:

```
total "autoreleased with no pool in place"   19670 -> 17264
NSURL                                         1142 ->   164
__NSCFNumber                                   522 ->   158
```

The classes that actually flow through the helper drop by ~86%.

The remaining 17264 comes from ten Pine dispatch surfaces that bypass the helper — six raw `DispatchQueue.global(...).async` sites (`ExternalFileFormatter`, `UserTaskRunStore`, `GitCommand`, `GitFetcher` ×3) and four custom `DispatchQueue(label:)` queues (`FileSystemWatcher`, `ExternalToolResolver`, `LSPClient`, `AgentHistoryStore`), none declaring `autoreleaseFrequency: .workItem` — plus AppKit/Metal internals where `NSPathStore` dominates. **Deliberately out of scope here**; tracked separately so "we fixed autorelease" does not become a false sense of closure.

## Tests

Four regression tests in `BackgroundDispatchTests`, written before the fix. They assert the closure's autoreleased objects are already deallocated by the time `runOnBackground` returns, using an `NSObject` probe handed to `Unmanaged.autorelease()`.

Red before the fix:

```
✘ Test "Throwing variant drains autoreleased objects before returning" recorded an issue
  at BackgroundDispatchTests.swift:265:9: Expectation failed: deallocations.value == 1
Failing tests:
	BackgroundDispatchTests.throwingDrainsAutoreleasePool()
** TEST FAILED **
```

Green after: 25/25 in the suite, stable across 6 consecutive runs.

Without the pool the guarantee is racy rather than reliably false — libdispatch's own last-resort pool sometimes drains first — which is exactly why one of the four caught it and the others did not. With the pool the drain happens before `continuation.resume`, so all four are deterministic.

## Docs

`AGENTS.md` gains three things under Concurrency Model and the local development loop:

- the rule that background work owns its autorelease pool, with `OBJC_DEBUG_MISSING_POOLS=YES` as the regression signal;
- a note that local runs on the macOS 27 beta are not a pass/fail signal, naming the two standing failures on that runtime so nobody attributes them to a diff;
- the triage recipe for the `objc_autoreleasePoolPop` crash class, including the fact that the `0xa1a1a1a1` / `0xa3a3a3a3a3a3a3a3` registers are loop-invariant constants and prove nothing — the false lead #1509 was opened on.

## Verification

- `swiftlint --strict` — 0 violations in 801 files
- `PineTests/BackgroundDispatchTests` — 25/25, 6 consecutive runs
- full `PineTests` on an idle machine, 301 s — only the 4 pre-existing `AgentInboxToolbarButtonSnapshotTests` failures, identical to unmodified `main` (baselines recorded on the macOS 26 CI runner; the beta renders that view ~3% differently)
- full `PineTests` under AddressSanitizer on `main` — zero ASan reports

Environment:

```
macOS 27.0 (26A5421a) · Xcode 27.0 (27A5237l)
macOS SDK 27.0 (26A5406c) · Apple Swift 6.4 (swiftlang-6.4.0.30.4) · arm64
```

Refs #1509
