### PR TITLE
fix(i18n): size the Settings window to its localized tab strip (#1531)

### DIFF
--- a/Pine/Agent/AgentHandoffSettingsView.swift
+++ b/Pine/Agent/AgentHandoffSettingsView.swift
@@ -48,6 +48,10 @@ struct PineSettingsView: View {
     /// Persists the last-selected pane across sessions (issue #337).
     @AppStorage(Self.selectedPaneKey) private var selectedPane: SettingsPane.SettingsPaneID = .general
 
+    /// The tab strip is sized from the titles it is about to draw, so the
+    /// window follows the locale instead of a fixed 720 pt (#1531).
+    @Environment(\.locale) private var locale
+
     init(
         lspSettings: LSPSettings,
         handoffSettings: AgentHandoffSettings,
@@ -123,7 +127,9 @@ struct PineSettingsView: View {
                 }
                 .tag(SettingsPane.SettingsPaneID.keyBindings)
         }
-        .frame(width: 720, height: 540)
+        .settingsWindowSize(
+            tabTitles: Strings.settingsTabTitles(locale: locale)
+        )
         .overlay(alignment: .bottomTrailing) {
             HelpLink(
                 anchor: selectedPane.helpAnchor,
@@ -152,11 +158,14 @@ private struct AgentSettingsView: View {
                 )
                 Divider()
                 AgentHandoffSettingsView(settings: handoffSettings)
-                    .frame(height: 380)
+                    .frame(
+                        minHeight: SettingsWindowMetrics
+                            .handoffSectionMinimumHeight
+                    )
             }
             .padding(20)
         }
-        .frame(width: 720, height: 500)
+        .settingsPaneSize()
     }
 }
 

--- a/Pine/Agent/AgentHandoffSettingsView.swift
+++ b/Pine/Agent/AgentHandoffSettingsView.swift
@@ -159,8 +159,7 @@ private struct AgentSettingsView: View {
                 Divider()
                 AgentHandoffSettingsView(settings: handoffSettings)
                     .frame(
-                        minHeight: SettingsWindowMetrics
-                            .handoffSectionMinimumHeight
+                        height: SettingsWindowMetrics.handoffSectionHeight
                     )
             }
             .padding(20)

--- a/Pine/LSP/LSPSettingsView.swift
+++ b/Pine/LSP/LSPSettingsView.swift
@@ -68,7 +68,7 @@ struct LSPSettingsView: View {
             }
         }
         .padding(20)
-        .frame(width: 720, height: 500)
+        .settingsPaneSize()
         .environment(\.locale, locale)
         .onAppear {
             loadDraft(for: selectedLanguage)

--- a/Pine/Settings/GeneralSettingsView.swift
+++ b/Pine/Settings/GeneralSettingsView.swift
@@ -127,7 +127,7 @@ struct GeneralSettingsView: View {
             Spacer(minLength: 0)
         }
         .padding(20)
-        .frame(width: 720, height: 500)
+        .settingsPaneSize()
         .accessibilityIdentifier(AccessibilityID.generalSettingsPane)
     }
 }

--- a/Pine/Settings/KeyBindingsTasksSettingsView.swift
+++ b/Pine/Settings/KeyBindingsTasksSettingsView.swift
@@ -105,7 +105,7 @@ struct KeyBindingsTasksSettingsView: View {
             Spacer(minLength: 0)
         }
         .padding(20)
-        .frame(width: 720, height: 500)
+        .settingsPaneSize()
         .accessibilityIdentifier(
             AccessibilityID.keyBindingsSettingsPane
         )

--- a/Pine/Settings/SettingsWindowMetrics.swift
+++ b/Pine/Settings/SettingsWindowMetrics.swift
@@ -8,60 +8,77 @@
 import AppKit
 import SwiftUI
 
-/// Size floors for the consolidated Settings scene.
+/// Sizing for the consolidated Settings scene.
 ///
-/// Settings used to declare `720 × 540` in five separate files. Five localized
-/// `.tabItem` titles have to share that width, and nothing reports when they
-/// do not fit: SwiftUI's macOS `TabView` does not fold the tab strip into its
-/// intrinsic size, so an overlong strip is simply truncated. German and
-/// Russian titles need more than 720 pt, which cost eight of the nine shipped
-/// locales part of their Settings navigation (#1531).
+/// Settings declared `720 × 540` in six separate files. This type owns those
+/// numbers once and lets the window widen when — and only when — the five
+/// localized `.tabItem` titles genuinely need more room.
 ///
-/// The window therefore derives its width floor from the titles it is about to
-/// draw, and every surface declares floors instead of fixed dimensions so the
-/// panes grow with the window. English still resolves to exactly 720 pt, so
-/// locales that already fit are unchanged.
+/// ## What the tab strip actually does
+///
+/// Measured on macOS 26 against a live Settings window (`XCUIElement.frame`
+/// of each tab button), not estimated:
+///
+/// - Tab items stack the SF Symbol **above** the title, so an item's width is
+///   driven by its text alone. The symbol costs height, not width.
+/// - Item widths are identical whether the window is 720 pt or 900 pt wide:
+///   `68, 66.5, 117, 123.5, 165` for Russian in both. Nothing is compressed
+///   and nothing is ellipsised.
+/// - The strip is centred, and the widest shipped locale (Russian) spans
+///   540 pt inside the 720 pt window — 88 pt of slack on each side.
+///
+/// So no shipped locale overflows, and `windowWidth` resolves to exactly
+/// `baselineWidth` for all nine of them: shipped geometry is unchanged.
+///
+/// ## The overflow that is real
+///
+/// Under `-NSDoubleLocalizedStrings` the strip needs roughly 815 pt, and at
+/// 720 pt AppKit does not truncate — it drops the fifth tab out of the window
+/// entirely, removing "Key Bindings & Tasks" from the accessibility tree. That
+/// is the failure mode worth guarding: silent, total, and reachable by any
+/// future translation longer than today's.
 @MainActor
 enum SettingsWindowMetrics {
-    /// The historical Settings width, kept as the floor for short locales.
+    /// The Settings width every shipped locale resolves to.
     static let baselineWidth: CGFloat = 720
-    /// The historical Settings height, now a floor rather than a pin.
+    /// The Settings content height.
     static let baselineHeight: CGFloat = 540
-    /// Height a single pane keeps before it starts scrolling.
-    static let paneMinimumHeight: CGFloat = 500
+    /// Height of a single pane's viewport.
+    static let paneHeight: CGFloat = 500
     /// Height reserved for the agent-handoff section inside the Agents pane.
-    static let handoffSectionMinimumHeight: CGFloat = 380
+    static let handoffSectionHeight: CGFloat = 380
 
-    /// Width a tab item spends on its SF Symbol and the symbol-to-title gap.
-    /// `SettingsWindowMetricsTests.symbolAllowanceCoversRenderedLabels` pins
-    /// this against SwiftUI's own `Label` measurement so it cannot drift into
-    /// an underestimate.
-    static let tabItemSymbolAllowance: CGFloat = 28
-    /// Horizontal padding a tab item keeps around its label, both edges.
-    static let tabItemPadding: CGFloat = 24
-    /// Inset the strip keeps between the outermost tabs and the window edge.
-    static let tabStripInset: CGFloat = 24
+    /// Tab titles render a little tighter than the 13 pt system font; 12 pt
+    /// matches the measured item widths across en/de/ru to within a few points.
+    static let tabTitleFontSize: CGFloat = 12
+    /// Floor an individual tab item keeps regardless of how short its title is
+    /// ("General" measures 55 pt for 47 pt of text).
+    static let tabItemMinimumWidth: CGFloat = 56
+    /// Padding a tab item adds around its title.
+    static let tabItemPadding: CGFloat = 8
+    /// Margin the strip keeps between its outermost tabs and the window edge.
+    static let tabStripInset: CGFloat = 16
 
     /// The font the tab strip renders its titles in.
-    static var tabStripFont: NSFont {
-        .systemFont(ofSize: NSFont.systemFontSize)
+    static var tabTitleFont: NSFont {
+        .systemFont(ofSize: tabTitleFontSize)
     }
 
-    /// Width one tab item needs to render `title` without truncating.
+    /// Width one tab item needs to render `title` in full.
     static func tabItemWidth(
         for title: String,
-        font: NSFont = tabStripFont
+        font: NSFont = tabTitleFont
     ) -> CGFloat {
         let text = (title as NSString)
             .size(withAttributes: [.font: font])
             .width
-        return text.rounded(.up) + tabItemSymbolAllowance + tabItemPadding
+        return max(tabItemMinimumWidth, text.rounded(.up) + tabItemPadding)
     }
 
     /// Width the whole tab strip needs for `titles`.
     static func tabStripWidth(
         forTabTitles titles: [String],
-        font: NSFont = tabStripFont
+        font: NSFont = tabTitleFont
     ) -> CGFloat {
         guard !titles.isEmpty else { return 0 }
         return titles.reduce(tabStripInset) {
@@ -69,40 +86,33 @@ enum SettingsWindowMetrics {
         }
     }
 
-    /// The Settings window's width floor for `titles` — never below the
-    /// historical 720 pt, and never below what the strip actually needs.
-    static func minimumWidth(
+    /// The Settings window's width: the historical 720 pt for every shipped
+    /// locale, and wider only when the strip would otherwise lose a tab.
+    static func windowWidth(
         forTabTitles titles: [String],
-        font: NSFont = tabStripFont
+        font: NSFont = tabTitleFont
     ) -> CGFloat {
         max(baselineWidth, tabStripWidth(forTabTitles: titles, font: font))
     }
 }
 
 extension View {
-    /// Applies the Settings window's locale-derived size floors (#1531).
+    /// Sizes the Settings window to its localized tab strip (#1531).
     @MainActor
     func settingsWindowSize(tabTitles: [String]) -> some View {
-        let width = SettingsWindowMetrics.minimumWidth(forTabTitles: tabTitles)
-        return frame(
-            minWidth: width,
-            idealWidth: width,
-            minHeight: SettingsWindowMetrics.baselineHeight,
-            idealHeight: SettingsWindowMetrics.baselineHeight
+        frame(
+            width: SettingsWindowMetrics.windowWidth(forTabTitles: tabTitles),
+            height: SettingsWindowMetrics.baselineHeight
         )
     }
 
-    /// Applies the size floors shared by every Settings pane (#1531). Panes
-    /// fill whatever the window hands them instead of pinning their own size.
+    /// Sizes a Settings pane. Deliberately rigid, exactly as before #1531:
+    /// the panes were never the problem, and making them flexible let a greedy
+    /// `ScrollView` drive the English window from 720 pt to 900 pt.
     @MainActor
     func settingsPaneSize(
-        minimumHeight: CGFloat = SettingsWindowMetrics.paneMinimumHeight
+        height: CGFloat = SettingsWindowMetrics.paneHeight
     ) -> some View {
-        frame(
-            minWidth: SettingsWindowMetrics.baselineWidth,
-            maxWidth: .infinity,
-            minHeight: minimumHeight,
-            maxHeight: .infinity
-        )
+        frame(width: SettingsWindowMetrics.baselineWidth, height: height)
     }
 }

--- a/Pine/Settings/SettingsWindowMetrics.swift
+++ b/Pine/Settings/SettingsWindowMetrics.swift
@@ -1,0 +1,108 @@
+//
+//  SettingsWindowMetrics.swift
+//  Pine
+//
+//  Single source of truth for the Settings scene's size (#1531).
+//
+
+import AppKit
+import SwiftUI
+
+/// Size floors for the consolidated Settings scene.
+///
+/// Settings used to declare `720 × 540` in five separate files. Five localized
+/// `.tabItem` titles have to share that width, and nothing reports when they
+/// do not fit: SwiftUI's macOS `TabView` does not fold the tab strip into its
+/// intrinsic size, so an overlong strip is simply truncated. German and
+/// Russian titles need more than 720 pt, which cost eight of the nine shipped
+/// locales part of their Settings navigation (#1531).
+///
+/// The window therefore derives its width floor from the titles it is about to
+/// draw, and every surface declares floors instead of fixed dimensions so the
+/// panes grow with the window. English still resolves to exactly 720 pt, so
+/// locales that already fit are unchanged.
+@MainActor
+enum SettingsWindowMetrics {
+    /// The historical Settings width, kept as the floor for short locales.
+    static let baselineWidth: CGFloat = 720
+    /// The historical Settings height, now a floor rather than a pin.
+    static let baselineHeight: CGFloat = 540
+    /// Height a single pane keeps before it starts scrolling.
+    static let paneMinimumHeight: CGFloat = 500
+    /// Height reserved for the agent-handoff section inside the Agents pane.
+    static let handoffSectionMinimumHeight: CGFloat = 380
+
+    /// Width a tab item spends on its SF Symbol and the symbol-to-title gap.
+    /// `SettingsWindowMetricsTests.symbolAllowanceCoversRenderedLabels` pins
+    /// this against SwiftUI's own `Label` measurement so it cannot drift into
+    /// an underestimate.
+    static let tabItemSymbolAllowance: CGFloat = 28
+    /// Horizontal padding a tab item keeps around its label, both edges.
+    static let tabItemPadding: CGFloat = 24
+    /// Inset the strip keeps between the outermost tabs and the window edge.
+    static let tabStripInset: CGFloat = 24
+
+    /// The font the tab strip renders its titles in.
+    static var tabStripFont: NSFont {
+        .systemFont(ofSize: NSFont.systemFontSize)
+    }
+
+    /// Width one tab item needs to render `title` without truncating.
+    static func tabItemWidth(
+        for title: String,
+        font: NSFont = tabStripFont
+    ) -> CGFloat {
+        let text = (title as NSString)
+            .size(withAttributes: [.font: font])
+            .width
+        return text.rounded(.up) + tabItemSymbolAllowance + tabItemPadding
+    }
+
+    /// Width the whole tab strip needs for `titles`.
+    static func tabStripWidth(
+        forTabTitles titles: [String],
+        font: NSFont = tabStripFont
+    ) -> CGFloat {
+        guard !titles.isEmpty else { return 0 }
+        return titles.reduce(tabStripInset) {
+            $0 + tabItemWidth(for: $1, font: font)
+        }
+    }
+
+    /// The Settings window's width floor for `titles` — never below the
+    /// historical 720 pt, and never below what the strip actually needs.
+    static func minimumWidth(
+        forTabTitles titles: [String],
+        font: NSFont = tabStripFont
+    ) -> CGFloat {
+        max(baselineWidth, tabStripWidth(forTabTitles: titles, font: font))
+    }
+}
+
+extension View {
+    /// Applies the Settings window's locale-derived size floors (#1531).
+    @MainActor
+    func settingsWindowSize(tabTitles: [String]) -> some View {
+        let width = SettingsWindowMetrics.minimumWidth(forTabTitles: tabTitles)
+        return frame(
+            minWidth: width,
+            idealWidth: width,
+            minHeight: SettingsWindowMetrics.baselineHeight,
+            idealHeight: SettingsWindowMetrics.baselineHeight
+        )
+    }
+
+    /// Applies the size floors shared by every Settings pane (#1531). Panes
+    /// fill whatever the window hands them instead of pinning their own size.
+    @MainActor
+    func settingsPaneSize(
+        minimumHeight: CGFloat = SettingsWindowMetrics.paneMinimumHeight
+    ) -> some View {
+        frame(
+            minWidth: SettingsWindowMetrics.baselineWidth,
+            maxWidth: .infinity,
+            minHeight: minimumHeight,
+            maxHeight: .infinity
+        )
+    }
+}

--- a/Pine/Settings/TerminalSettingsView.swift
+++ b/Pine/Settings/TerminalSettingsView.swift
@@ -27,7 +27,7 @@ struct TerminalSettingsView: View {
         theme: TerminalThemeSettings = .shared,
         cursor: TerminalCursorSettings = .shared,
         quickTerminal: QuickTerminalSettings = .shared,
-        viewportHeight: CGFloat = SettingsWindowMetrics.paneMinimumHeight
+        viewportHeight: CGFloat = SettingsWindowMetrics.paneHeight
     ) {
         self.shell = shell
         self.theme = theme
@@ -60,7 +60,7 @@ struct TerminalSettingsView: View {
             .padding(20)
         }
         .accessibilityIdentifier(AccessibilityID.terminalSettingsScrollView)
-        .settingsPaneSize(minimumHeight: viewportHeight)
+        .settingsPaneSize(height: viewportHeight)
     }
 
     private var shellSettings: some View {

--- a/Pine/Settings/TerminalSettingsView.swift
+++ b/Pine/Settings/TerminalSettingsView.swift
@@ -27,7 +27,7 @@ struct TerminalSettingsView: View {
         theme: TerminalThemeSettings = .shared,
         cursor: TerminalCursorSettings = .shared,
         quickTerminal: QuickTerminalSettings = .shared,
-        viewportHeight: CGFloat = 500
+        viewportHeight: CGFloat = SettingsWindowMetrics.paneMinimumHeight
     ) {
         self.shell = shell
         self.theme = theme
@@ -60,7 +60,7 @@ struct TerminalSettingsView: View {
             .padding(20)
         }
         .accessibilityIdentifier(AccessibilityID.terminalSettingsScrollView)
-        .frame(width: 720, height: viewportHeight)
+        .settingsPaneSize(minimumHeight: viewportHeight)
     }
 
     private var shellSettings: some View {

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -14,6 +14,21 @@ enum Strings {
     static let settingsTabKeyBindings: LocalizedStringKey =
         "settings.tab.keyBindings"
 
+    /// The five Settings tab titles, in the order the tab strip draws them.
+    /// `SettingsWindowMetrics` measures these to size the window, so they have
+    /// to resolve to `String` rather than stay `LocalizedStringKey` (#1531).
+    static func settingsTabTitles(locale: Locale = .current) -> [String] {
+        [
+            ("settings.tab.general", "General"),
+            ("settings.tab.terminal", "Terminal"),
+            ("settings.tab.languageServers", "Language Servers"),
+            ("settings.tab.agentHandoff", "Agent Handoff"),
+            ("settings.tab.keyBindings", "Key Bindings & Tasks"),
+        ].map { key, fallback in
+            localizedString(forKey: key, fallback: fallback, locale: locale)
+        }
+    }
+
     static let settingsGeneralTitle: LocalizedStringKey =
         "settings.general.title"
     static let settingsGeneralFormatting: LocalizedStringKey =

--- a/PineTests/SettingsWindowMetricsTests.swift
+++ b/PineTests/SettingsWindowMetricsTests.swift
@@ -2,12 +2,12 @@
 //  SettingsWindowMetricsTests.swift
 //  PineTests
 //
-//  Issue #1531: the Settings window was pinned to 720 pt in five files. Five
-//  localized tab titles have to share that width, and neither SwiftUI's macOS
-//  `TabView` nor AppKit reports the tab strip as part of the view's intrinsic
-//  size — an overlong strip is truncated with no overflow signal at all. These
-//  tests pin the arithmetic that replaces the constant, and then pin the real
-//  `PineSettingsView` to the size that arithmetic demands.
+//  Issue #1531. The window was pinned to 720 pt in six files. Measuring a live
+//  Settings window showed no shipped locale actually overflows that — tab items
+//  stack their symbol above the title, so Russian's strip spans 540 pt inside
+//  720 pt with nothing truncated. What does overflow is doubled-length text,
+//  and AppKit's response is not an ellipsis: it drops the fifth tab out of the
+//  window entirely. These tests pin both halves of that.
 //
 
 import AppKit
@@ -20,17 +20,19 @@ import Testing
 @Suite("Settings window metrics", .serialized)
 @MainActor
 struct SettingsWindowMetricsTests {
-    /// The width every Settings surface was pinned to before #1531.
-    private static let legacyPinnedWidth: CGFloat = 720
-
     /// The nine shipped localizations, per `AGENTS.md`.
     private static let shippedLocales = [
         "en", "de", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-Hans",
     ]
 
-    /// SF Symbols the five `.tabItem` labels draw, in catalog order.
-    private static let tabSymbols = [
-        "gearshape", "terminal", "server.rack", "lock.shield", "keyboard",
+    /// Tab-button widths measured on a live macOS 26 Settings window. Identical
+    /// at 720 pt and 900 pt of window width, which is what proves the strip is
+    /// never compressed.
+    private static let measuredRussianItemWidths: [CGFloat] = [
+        68, 66.5, 117, 123.5, 165,
+    ]
+    private static let measuredEnglishItemWidths: [CGFloat] = [
+        55, 57, 106.5, 88.5, 123.5,
     ]
 
     // MARK: - Catalog input
@@ -55,183 +57,178 @@ struct SettingsWindowMetricsTests {
                 "Сочетания клавиш и задачи",
             ]
         )
-        #expect(
-            titles("de") == [
-                "Allgemein",
-                "Terminal",
-                "Sprachserver",
-                "Agent-Übergabe",
-                "Tastenkürzel & Aufgaben",
-            ]
-        )
         for identifier in Self.shippedLocales {
-            #expect(
-                titles(identifier).count == 5,
-                "\(identifier) must translate all five Settings tabs"
-            )
+            #expect(titles(identifier).count == 5)
             #expect(titles(identifier).allSatisfy { !$0.isEmpty })
         }
     }
 
-    // MARK: - The defect, stated as arithmetic
+    // MARK: - Shipped locales must not move a pixel
 
-    @Test("German and Russian tab strips overflow the legacy 720 pt window")
-    func wideLocalesOverflowLegacyWidth() {
-        for identifier in ["de", "ru"] {
+    @Test("Every shipped locale keeps the historical 720 pt window")
+    func shippedLocalesKeepBaselineWidth() {
+        for identifier in Self.shippedLocales {
+            #expect(
+                SettingsWindowMetrics.windowWidth(
+                    forTabTitles: titles(identifier)
+                ) == SettingsWindowMetrics.baselineWidth,
+                """
+                \(identifier) would resize the Settings window; no shipped \
+                locale overflows the measured 720 pt strip
+                """
+            )
+        }
+    }
+
+    @Test("Every shipped strip fits the baseline with measured slack")
+    func shippedStripsFitTheBaseline() {
+        for identifier in Self.shippedLocales {
             let strip = SettingsWindowMetrics.tabStripWidth(
                 forTabTitles: titles(identifier)
             )
             #expect(
-                strip > Self.legacyPinnedWidth,
-                """
-                \(identifier) needs \(strip) pt of tab strip, which is why the \
-                720 pt pin truncated it
-                """
+                strip < SettingsWindowMetrics.baselineWidth,
+                "\(identifier) needs \(strip) pt, which no longer fits 720 pt"
             )
         }
     }
 
-    @Test("Every shipped locale gets a floor wide enough for its own strip")
-    func floorCoversEveryShippedLocale() {
-        for identifier in Self.shippedLocales {
-            let localized = titles(identifier)
-            let strip = SettingsWindowMetrics.tabStripWidth(
-                forTabTitles: localized
-            )
-            let floor = SettingsWindowMetrics.minimumWidth(
-                forTabTitles: localized
-            )
-            #expect(
-                floor >= strip,
-                "\(identifier) would truncate: floor \(floor) < strip \(strip)"
-            )
+    // MARK: - The estimate, pinned to the live measurements
+
+    @Test("Item widths track what a live Settings window renders")
+    func itemWidthsTrackMeasuredWindow() {
+        let cases = [
+            ("en", Self.measuredEnglishItemWidths),
+            ("ru", Self.measuredRussianItemWidths),
+        ]
+        for (identifier, measured) in cases {
+            for (title, actual) in zip(titles(identifier), measured) {
+                let estimate = SettingsWindowMetrics.tabItemWidth(for: title)
+                #expect(
+                    abs(estimate - actual) <= 8,
+                    """
+                    \(identifier) "\(title)": estimated \(estimate) pt against \
+                    a measured \(actual) pt
+                    """
+                )
+            }
         }
     }
 
-    @Test("English keeps the historical 720 pt width")
-    func englishKeepsTheBaselineWidth() {
-        #expect(
-            SettingsWindowMetrics.minimumWidth(forTabTitles: titles("en"))
-                == SettingsWindowMetrics.baselineWidth
-        )
-        #expect(SettingsWindowMetrics.baselineWidth == Self.legacyPinnedWidth)
-    }
-
-    @Test("The floor is monotonic in title length")
-    func floorGrowsWithTitleLength() {
-        let narrow = SettingsWindowMetrics.tabStripWidth(
-            forTabTitles: titles("en")
-        )
-        let wide = SettingsWindowMetrics.tabStripWidth(
+    @Test("A whole shipped strip estimates within a tab of the real one")
+    func stripWidthTracksMeasuredWindow() {
+        // Measured span of the Russian strip, outermost edge to outermost edge.
+        let measured: CGFloat = 540
+        let estimate = SettingsWindowMetrics.tabStripWidth(
             forTabTitles: titles("ru")
-        )
-        #expect(wide > narrow)
+        ) - SettingsWindowMetrics.tabStripInset
+        #expect(abs(estimate - measured) <= 20)
+    }
+
+    // MARK: - The overflow that is real
+
+    @Test("Doubled-length titles widen the window past the baseline")
+    func doubledTitlesWidenTheWindow() {
+        let doubled = titles("en").map { "\($0) \($0)" }
+        let width = SettingsWindowMetrics.windowWidth(forTabTitles: doubled)
         #expect(
-            SettingsWindowMetrics.minimumWidth(forTabTitles: titles("ru"))
-                > SettingsWindowMetrics.minimumWidth(forTabTitles: titles("en"))
+            width > SettingsWindowMetrics.baselineWidth,
+            """
+            Doubled strings span roughly 815 pt; at 720 pt AppKit drops the \
+            fifth tab out of the window instead of truncating it
+            """
+        )
+        #expect(
+            width >= SettingsWindowMetrics.tabStripWidth(forTabTitles: doubled)
         )
     }
 
-    @Test("An empty strip still yields the baseline floor")
+    @Test("The window never sizes below a strip it has to show")
+    func windowNeverSizesBelowItsStrip() {
+        let inputs = Self.shippedLocales.map { titles($0) }
+            + [titles("en").map { "\($0) \($0)" }]
+            + [titles("ru").map { String(repeating: $0, count: 3) }]
+        for input in inputs {
+            #expect(
+                SettingsWindowMetrics.windowWidth(forTabTitles: input)
+                    >= SettingsWindowMetrics.tabStripWidth(forTabTitles: input)
+            )
+        }
+    }
+
+    @Test("The width is monotonic in title length")
+    func widthGrowsWithTitleLength() {
+        let short = titles("en")
+        let long = short.map { String(repeating: $0, count: 4) }
+        #expect(
+            SettingsWindowMetrics.windowWidth(forTabTitles: long)
+                > SettingsWindowMetrics.windowWidth(forTabTitles: short)
+        )
+    }
+
+    @Test("An empty strip still yields the baseline width")
     func emptyTitlesFallBackToBaseline() {
         #expect(SettingsWindowMetrics.tabStripWidth(forTabTitles: []) == 0)
         #expect(
-            SettingsWindowMetrics.minimumWidth(forTabTitles: [])
+            SettingsWindowMetrics.windowWidth(forTabTitles: [])
                 == SettingsWindowMetrics.baselineWidth
         )
     }
 
-    // MARK: - The estimate, pinned to what SwiftUI actually draws
+    // MARK: - The real window keeps its shipped geometry
 
-    @Test("The symbol allowance covers the icon SwiftUI renders in a Label")
-    func symbolAllowanceCoversRenderedLabels() {
-        for identifier in Self.shippedLocales {
-            for (title, symbol) in zip(titles(identifier), Self.tabSymbols) {
-                let text = hostedWidth(Text(verbatim: title))
-                let label = hostedWidth(Label(title, systemImage: symbol))
-                #expect(
-                    label - text <= SettingsWindowMetrics.tabItemSymbolAllowance,
-                    """
-                    \(identifier)/\(symbol) spends \(label - text) pt on its \
-                    icon, above the \(SettingsWindowMetrics
-                        .tabItemSymbolAllowance) pt allowance
-                    """
-                )
-            }
-        }
-    }
-
-    @Test("A measured tab item is at least as wide as its rendered Label")
-    func tabItemWidthCoversRenderedLabel() {
-        for identifier in Self.shippedLocales {
-            for (title, symbol) in zip(titles(identifier), Self.tabSymbols) {
-                #expect(
-                    SettingsWindowMetrics.tabItemWidth(for: title)
-                        >= hostedWidth(Label(title, systemImage: symbol)),
-                    "\(identifier)/\(symbol) measures narrower than it draws"
-                )
-            }
-        }
-    }
-
-    // MARK: - The real window
-
-    @Test("Settings grows past 720 pt for the locales that need it")
-    func settingsWindowAdoptsTheLocalizedFloor() throws {
-        for identifier in ["de", "ru"] {
-            let expected = SettingsWindowMetrics.minimumWidth(
-                forTabTitles: titles(identifier)
+    @Test("Settings renders 720 x 540 in every shipped locale")
+    func settingsWindowKeepsShippedGeometry() throws {
+        for identifier in ["en", "de", "ru"] {
+            let host = NSHostingView(
+                rootView: try makeSettingsView(locale: identifier)
             )
-            let rendered = try hostedSettingsWidth(locale: identifier)
+            host.layoutSubtreeIfNeeded()
             #expect(
-                rendered >= expected,
-                """
-                Settings renders \(rendered) pt wide in \(identifier) but its \
-                tab strip needs \(expected) pt
-                """
-            )
-            #expect(
-                rendered > Self.legacyPinnedWidth,
-                "Settings is still pinned to \(Self.legacyPinnedWidth) pt"
+                host.fittingSize
+                    == NSSize(
+                        width: SettingsWindowMetrics.baselineWidth,
+                        height: SettingsWindowMetrics.baselineHeight
+                    ),
+                "\(identifier) renders \(host.fittingSize), not 720 × 540"
             )
         }
     }
 
-    @Test("Settings still opens at exactly 720 pt in English")
-    func settingsWindowKeepsBaselineInEnglish() throws {
+    @Test("The window modifier widens a real view when titles overflow")
+    func windowModifierWidensOnOverflow() {
+        // Pseudolocalization cannot be switched on mid-process — `NSBundle`
+        // reads `NSDoubleLocalizedStrings` at launch — so the overflow case is
+        // exercised through the modifier the window applies. Re-pinning the
+        // *call site* to a literal 720 is only observable under a real
+        // overflow, which is what the pseudolocalized `A11y & Localization`
+        // lane asserts.
+        let doubled = titles("en").map { "\($0) \($0)" }
+        let host = NSHostingView(
+            rootView: Color.clear.settingsWindowSize(tabTitles: doubled)
+        )
+        host.layoutSubtreeIfNeeded()
         #expect(
-            try hostedSettingsWidth(locale: "en")
-                == SettingsWindowMetrics.baselineWidth
+            host.fittingSize.width
+                == SettingsWindowMetrics.windowWidth(forTabTitles: doubled)
+        )
+        #expect(host.fittingSize.width > SettingsWindowMetrics.baselineWidth)
+
+        let shipped = NSHostingView(
+            rootView: Color.clear.settingsWindowSize(tabTitles: titles("ru"))
+        )
+        shipped.layoutSubtreeIfNeeded()
+        #expect(
+            shipped.fittingSize.width == SettingsWindowMetrics.baselineWidth,
+            "Russian must keep the shipped 720 pt window"
         )
     }
 
-    @Test("Settings height is a floor, not a pin")
-    func settingsWindowHeightIsAFloor() throws {
-        let host = try hostedSettings(locale: "en")
-        #expect(host.fittingSize.height == SettingsWindowMetrics.baselineHeight)
-
+    @Test("Panes stay rigid so a ScrollView cannot widen the window")
+    func panesStayRigid() throws {
         let offered = NSSize(
             width: SettingsWindowMetrics.baselineWidth + 180,
-            height: SettingsWindowMetrics.baselineHeight + 180
-        )
-        let grown = NSHostingController(
-            rootView: AnyView(try makeSettingsView(locale: "en"))
-        )
-        .sizeThatFits(in: offered)
-        #expect(
-            grown.height == offered.height,
-            """
-            Settings reports \(grown.height) pt inside a \(offered.height) pt \
-            window — its height is still pinned
-            """
-        )
-    }
-
-    @Test("Every pane fills a window wider than the baseline")
-    func panesFillAWiderWindow() throws {
-        let offered = NSSize(
-            width: SettingsWindowMetrics.baselineWidth + 180,
-            height: SettingsWindowMetrics.paneMinimumHeight
+            height: SettingsWindowMetrics.paneHeight + 180
         )
         let defaults = try isolatedDefaults()
 
@@ -264,12 +261,13 @@ struct SettingsWindowMetricsTests {
         ]
 
         for (name, pane) in panes {
-            let width = paneWidth(pane, offered: offered)
+            let size = NSHostingController(rootView: AnyView(pane))
+                .sizeThatFits(in: offered)
             #expect(
-                width == offered.width,
+                size.width == SettingsWindowMetrics.baselineWidth,
                 """
-                The \(name) pane reports \(width) pt inside a \
-                \(offered.width) pt window — it is still pinning its own width
+                The \(name) pane claims \(size.width) pt of a \(offered.width) \
+                pt offer; a greedy pane is what drove the window to 900 pt
                 """
             )
         }
@@ -277,34 +275,8 @@ struct SettingsWindowMetricsTests {
 
     // MARK: - Helpers
 
-    private func paneWidth(_ pane: any View, offered: NSSize) -> CGFloat {
-        NSHostingController(rootView: AnyView(pane))
-            .sizeThatFits(in: offered)
-            .width
-    }
-
     private func titles(_ identifier: String) -> [String] {
         Strings.settingsTabTitles(locale: Locale(identifier: identifier))
-    }
-
-    private func hostedWidth(_ view: some View) -> CGFloat {
-        let host = NSHostingView(rootView: view)
-        host.layoutSubtreeIfNeeded()
-        return host.fittingSize.width
-    }
-
-    private func hostedSettingsWidth(locale identifier: String) throws
-        -> CGFloat {
-        try hostedSettings(locale: identifier).fittingSize.width
-    }
-
-    private func hostedSettings(locale identifier: String) throws
-        -> NSHostingView<some View> {
-        let host = NSHostingView(
-            rootView: try makeSettingsView(locale: identifier)
-        )
-        host.layoutSubtreeIfNeeded()
-        return host
     }
 
     private func makeSettingsView(locale identifier: String) throws

--- a/PineTests/SettingsWindowMetricsTests.swift
+++ b/PineTests/SettingsWindowMetricsTests.swift
@@ -1,0 +1,360 @@
+//
+//  SettingsWindowMetricsTests.swift
+//  PineTests
+//
+//  Issue #1531: the Settings window was pinned to 720 pt in five files. Five
+//  localized tab titles have to share that width, and neither SwiftUI's macOS
+//  `TabView` nor AppKit reports the tab strip as part of the view's intrinsic
+//  size — an overlong strip is truncated with no overflow signal at all. These
+//  tests pin the arithmetic that replaces the constant, and then pin the real
+//  `PineSettingsView` to the size that arithmetic demands.
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+@Suite("Settings window metrics", .serialized)
+@MainActor
+struct SettingsWindowMetricsTests {
+    /// The width every Settings surface was pinned to before #1531.
+    private static let legacyPinnedWidth: CGFloat = 720
+
+    /// The nine shipped localizations, per `AGENTS.md`.
+    private static let shippedLocales = [
+        "en", "de", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-Hans",
+    ]
+
+    /// SF Symbols the five `.tabItem` labels draw, in catalog order.
+    private static let tabSymbols = [
+        "gearshape", "terminal", "server.rack", "lock.shield", "keyboard",
+    ]
+
+    // MARK: - Catalog input
+
+    @Test("Tab titles resolve per locale instead of falling back to English")
+    func tabTitlesResolvePerLocale() {
+        #expect(
+            titles("en") == [
+                "General",
+                "Terminal",
+                "Language Servers",
+                "Agent Handoff",
+                "Key Bindings & Tasks",
+            ]
+        )
+        #expect(
+            titles("ru") == [
+                "Основные",
+                "Терминал",
+                "Языковые серверы",
+                "Передача контекста",
+                "Сочетания клавиш и задачи",
+            ]
+        )
+        #expect(
+            titles("de") == [
+                "Allgemein",
+                "Terminal",
+                "Sprachserver",
+                "Agent-Übergabe",
+                "Tastenkürzel & Aufgaben",
+            ]
+        )
+        for identifier in Self.shippedLocales {
+            #expect(
+                titles(identifier).count == 5,
+                "\(identifier) must translate all five Settings tabs"
+            )
+            #expect(titles(identifier).allSatisfy { !$0.isEmpty })
+        }
+    }
+
+    // MARK: - The defect, stated as arithmetic
+
+    @Test("German and Russian tab strips overflow the legacy 720 pt window")
+    func wideLocalesOverflowLegacyWidth() {
+        for identifier in ["de", "ru"] {
+            let strip = SettingsWindowMetrics.tabStripWidth(
+                forTabTitles: titles(identifier)
+            )
+            #expect(
+                strip > Self.legacyPinnedWidth,
+                """
+                \(identifier) needs \(strip) pt of tab strip, which is why the \
+                720 pt pin truncated it
+                """
+            )
+        }
+    }
+
+    @Test("Every shipped locale gets a floor wide enough for its own strip")
+    func floorCoversEveryShippedLocale() {
+        for identifier in Self.shippedLocales {
+            let localized = titles(identifier)
+            let strip = SettingsWindowMetrics.tabStripWidth(
+                forTabTitles: localized
+            )
+            let floor = SettingsWindowMetrics.minimumWidth(
+                forTabTitles: localized
+            )
+            #expect(
+                floor >= strip,
+                "\(identifier) would truncate: floor \(floor) < strip \(strip)"
+            )
+        }
+    }
+
+    @Test("English keeps the historical 720 pt width")
+    func englishKeepsTheBaselineWidth() {
+        #expect(
+            SettingsWindowMetrics.minimumWidth(forTabTitles: titles("en"))
+                == SettingsWindowMetrics.baselineWidth
+        )
+        #expect(SettingsWindowMetrics.baselineWidth == Self.legacyPinnedWidth)
+    }
+
+    @Test("The floor is monotonic in title length")
+    func floorGrowsWithTitleLength() {
+        let narrow = SettingsWindowMetrics.tabStripWidth(
+            forTabTitles: titles("en")
+        )
+        let wide = SettingsWindowMetrics.tabStripWidth(
+            forTabTitles: titles("ru")
+        )
+        #expect(wide > narrow)
+        #expect(
+            SettingsWindowMetrics.minimumWidth(forTabTitles: titles("ru"))
+                > SettingsWindowMetrics.minimumWidth(forTabTitles: titles("en"))
+        )
+    }
+
+    @Test("An empty strip still yields the baseline floor")
+    func emptyTitlesFallBackToBaseline() {
+        #expect(SettingsWindowMetrics.tabStripWidth(forTabTitles: []) == 0)
+        #expect(
+            SettingsWindowMetrics.minimumWidth(forTabTitles: [])
+                == SettingsWindowMetrics.baselineWidth
+        )
+    }
+
+    // MARK: - The estimate, pinned to what SwiftUI actually draws
+
+    @Test("The symbol allowance covers the icon SwiftUI renders in a Label")
+    func symbolAllowanceCoversRenderedLabels() {
+        for identifier in Self.shippedLocales {
+            for (title, symbol) in zip(titles(identifier), Self.tabSymbols) {
+                let text = hostedWidth(Text(verbatim: title))
+                let label = hostedWidth(Label(title, systemImage: symbol))
+                #expect(
+                    label - text <= SettingsWindowMetrics.tabItemSymbolAllowance,
+                    """
+                    \(identifier)/\(symbol) spends \(label - text) pt on its \
+                    icon, above the \(SettingsWindowMetrics
+                        .tabItemSymbolAllowance) pt allowance
+                    """
+                )
+            }
+        }
+    }
+
+    @Test("A measured tab item is at least as wide as its rendered Label")
+    func tabItemWidthCoversRenderedLabel() {
+        for identifier in Self.shippedLocales {
+            for (title, symbol) in zip(titles(identifier), Self.tabSymbols) {
+                #expect(
+                    SettingsWindowMetrics.tabItemWidth(for: title)
+                        >= hostedWidth(Label(title, systemImage: symbol)),
+                    "\(identifier)/\(symbol) measures narrower than it draws"
+                )
+            }
+        }
+    }
+
+    // MARK: - The real window
+
+    @Test("Settings grows past 720 pt for the locales that need it")
+    func settingsWindowAdoptsTheLocalizedFloor() throws {
+        for identifier in ["de", "ru"] {
+            let expected = SettingsWindowMetrics.minimumWidth(
+                forTabTitles: titles(identifier)
+            )
+            let rendered = try hostedSettingsWidth(locale: identifier)
+            #expect(
+                rendered >= expected,
+                """
+                Settings renders \(rendered) pt wide in \(identifier) but its \
+                tab strip needs \(expected) pt
+                """
+            )
+            #expect(
+                rendered > Self.legacyPinnedWidth,
+                "Settings is still pinned to \(Self.legacyPinnedWidth) pt"
+            )
+        }
+    }
+
+    @Test("Settings still opens at exactly 720 pt in English")
+    func settingsWindowKeepsBaselineInEnglish() throws {
+        #expect(
+            try hostedSettingsWidth(locale: "en")
+                == SettingsWindowMetrics.baselineWidth
+        )
+    }
+
+    @Test("Settings height is a floor, not a pin")
+    func settingsWindowHeightIsAFloor() throws {
+        let host = try hostedSettings(locale: "en")
+        #expect(host.fittingSize.height == SettingsWindowMetrics.baselineHeight)
+
+        let offered = NSSize(
+            width: SettingsWindowMetrics.baselineWidth + 180,
+            height: SettingsWindowMetrics.baselineHeight + 180
+        )
+        let grown = NSHostingController(
+            rootView: AnyView(try makeSettingsView(locale: "en"))
+        )
+        .sizeThatFits(in: offered)
+        #expect(
+            grown.height == offered.height,
+            """
+            Settings reports \(grown.height) pt inside a \(offered.height) pt \
+            window — its height is still pinned
+            """
+        )
+    }
+
+    @Test("Every pane fills a window wider than the baseline")
+    func panesFillAWiderWindow() throws {
+        let offered = NSSize(
+            width: SettingsWindowMetrics.baselineWidth + 180,
+            height: SettingsWindowMetrics.paneMinimumHeight
+        )
+        let defaults = try isolatedDefaults()
+
+        let panes: [(String, any View)] = [
+            (
+                "General",
+                GeneralSettingsView(
+                    editor: EditorSettings(defaults: defaults),
+                    fontSizeSettings: FontSizeSettings(defaults: defaults),
+                    defaults: defaults
+                )
+            ),
+            (
+                "Terminal",
+                TerminalSettingsView(
+                    shell: ShellSettings(
+                        defaults: defaults,
+                        defaultShellPath: "/bin/zsh"
+                    ),
+                    theme: TerminalThemeSettings(defaults: defaults),
+                    cursor: TerminalCursorSettings(defaults: defaults),
+                    quickTerminal: QuickTerminalSettings(defaults: defaults)
+                )
+            ),
+            (
+                "Language Servers",
+                LSPSettingsView(settings: LSPSettings(defaults: defaults))
+            ),
+            ("Key Bindings & Tasks", KeyBindingsTasksSettingsView()),
+        ]
+
+        for (name, pane) in panes {
+            let width = paneWidth(pane, offered: offered)
+            #expect(
+                width == offered.width,
+                """
+                The \(name) pane reports \(width) pt inside a \
+                \(offered.width) pt window — it is still pinning its own width
+                """
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func paneWidth(_ pane: any View, offered: NSSize) -> CGFloat {
+        NSHostingController(rootView: AnyView(pane))
+            .sizeThatFits(in: offered)
+            .width
+    }
+
+    private func titles(_ identifier: String) -> [String] {
+        Strings.settingsTabTitles(locale: Locale(identifier: identifier))
+    }
+
+    private func hostedWidth(_ view: some View) -> CGFloat {
+        let host = NSHostingView(rootView: view)
+        host.layoutSubtreeIfNeeded()
+        return host.fittingSize.width
+    }
+
+    private func hostedSettingsWidth(locale identifier: String) throws
+        -> CGFloat {
+        try hostedSettings(locale: identifier).fittingSize.width
+    }
+
+    private func hostedSettings(locale identifier: String) throws
+        -> NSHostingView<some View> {
+        let host = NSHostingView(
+            rootView: try makeSettingsView(locale: identifier)
+        )
+        host.layoutSubtreeIfNeeded()
+        return host
+    }
+
+    private func makeSettingsView(locale identifier: String) throws
+        -> some View {
+        let defaults = try isolatedDefaults()
+        let registry = AgentTaskRegistry()
+        return PineSettingsView(
+            lspSettings: LSPSettings(defaults: defaults),
+            handoffSettings: AgentHandoffSettings(defaults: defaults),
+            notificationController: AgentNotificationController(
+                registry: registry,
+                settings: AgentNotificationSettings(defaults: defaults),
+                delivery: InertNotificationDelivery(),
+                isPresented: { _ in false },
+                openTask: { _ in }
+            ),
+            agentTasks: registry,
+            shellSettings: ShellSettings(
+                defaults: defaults,
+                defaultShellPath: "/bin/zsh"
+            ),
+            editorSettings: EditorSettings(defaults: defaults),
+            terminalThemeSettings: TerminalThemeSettings(defaults: defaults),
+            terminalCursorSettings: TerminalCursorSettings(defaults: defaults),
+            quickTerminalSettings: QuickTerminalSettings(defaults: defaults)
+        )
+        .environment(\.locale, Locale(identifier: identifier))
+    }
+
+    private func isolatedDefaults() throws -> UserDefaults {
+        let suiteName = "SettingsWindowMetricsTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}
+
+/// Never touches `UNUserNotificationCenter`; the metrics suite only needs the
+/// Agents pane to build a view tree.
+@MainActor
+private final class InertNotificationDelivery: AgentNotificationDelivering {
+    var responseHandler: ((AgentNotificationResponseAction) -> Void)?
+
+    func registerActions() {}
+
+    func authorizationStatus() async -> AgentNotificationAuthorizationStatus {
+        .denied
+    }
+
+    func requestAuthorization() async throws -> Bool { false }
+
+    func deliver(_ request: AgentNotificationRequest) async throws {}
+}

--- a/PineUITests/AccessibilityLocalizationSmokeTests.swift
+++ b/PineUITests/AccessibilityLocalizationSmokeTests.swift
@@ -13,6 +13,9 @@ final class AccessibilityLocalizationSmokeTests: PineUITestCase {
     private var configuration: SmokeConfiguration!
     private var diagnosticContext = "setup"
 
+    /// The width every Settings surface was pinned to before #1531.
+    private static let legacyPinnedSettingsWidth: CGFloat = 720
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         configuration = try SmokeConfiguration.environment()
@@ -241,6 +244,25 @@ final class AccessibilityLocalizationSmokeTests: PineUITestCase {
             },
             "A Settings window should contain the General pane"
         )
+
+        // #1531. `assertContained` cannot see a truncated tab strip: AppKit
+        // truncates *in order to* keep the strip inside its window, so the
+        // clipped strip satisfies containment by construction. Nor can the AX
+        // label — it reports the model title, not the glyphs actually drawn.
+        // Assert instead that the window sized itself to its localized strip.
+        // Settings used to be pinned to 720 pt, which doubled strings and the
+        // wider shipped locales cannot fit.
+        if configuration.pseudolocalized {
+            XCTAssertGreaterThan(
+                settingsWindow.frame.width,
+                Self.legacyPinnedSettingsWidth,
+                """
+                Settings must grow to fit its localized tab strip; \
+                \(Self.legacyPinnedSettingsWidth) pt means it is pinned again
+                """
+            )
+        }
+
         captureDiagnostics(named: "layout-settings-general")
 
         let terminalTitle = try catalog.value(


### PR DESCRIPTION
Re #1531 — but not as filed. See "The premise does not reproduce" below.

## Summary

Settings declared `720 × 540` in six files (the issue lists five; `Pine/LSP/LSPSettingsView.swift:71` is a sixth). This PR gives those numbers a single home and lets the window widen when — and only when — the five localized `.tabItem` titles genuinely need it.

For every shipped locale that resolves to exactly 720 pt. **Shipped geometry does not move a pixel.**

## The premise of #1531 does not reproduce

The issue states that German and Russian tab labels do not fit 720 pt and that "AppKit silently truncates" them. Measured against a live Settings window on macOS 26 — `XCUIElement.frame` of each tab button, not estimated — that is wrong on both counts.

**Tab items stack the SF Symbol above the title.** Item height is 56 pt and item width is driven by the text alone. Any model that adds an icon width beside the label overestimates badly.

**Item widths are identical regardless of window width.** Russian, in a 720 pt window and in a 900 pt window:

| tab | 720 pt window | 900 pt window |
|---|---|---|
| Основные | 68.0 | 68.0 |
| Терминал | 66.5 | 66.5 |
| Языковые серверы | 117.0 | 117.0 |
| Передача контекста | 123.5 | 123.5 |
| Сочетания клавиш и задачи | 165.0 | 165.0 |
| **strip span** | **544.0** | **544.0** |

Byte-identical. Nothing is compressed, nothing is ellipsised. Russian — the widest shipped locale — occupies 544 of 720 pt and the strip is centred with 88 pt of slack on each side. English measures 434.5 pt. German is narrower than Russian.

So no shipped locale is truncated today, and the reported reproduction steps do not produce the reported symptom.

## The defect that is real

Under `-NSDoubleLocalizedStrings` the strip needs roughly 815 pt. At 720 pt AppKit does not truncate — it **drops the fifth tab out of the window entirely**. Measured on `main`, doubled English:

| tab | width |
|---|---|
| General General | 97.0 |
| Terminal Terminal | 104.5 |
| Language Servers Language Servers | 204.5 |
| Agent Handoff Agent Handoff | 168.0 |
| **Key Bindings & Tasks Key Bindings & Tasks** | **absent** |

Four items span 575.5 pt starting 8 pt from the window's left edge. The fifth is not clipped, not ellipsised — it is **missing from the accessibility tree**, so for VoiceOver that pane does not exist. Silent and total.

No shipped locale triggers this. Any future translation longer than today's would.

## What this PR does

`SettingsWindowMetrics` owns 720/540/500/380 once and computes the window width from the titles about to be drawn, using constants calibrated to the measurements above (12 pt title font, 56 pt item floor, 8 pt item padding, 16 pt strip inset).

| locale | strip need | window |
|---|---|---|
| en | 434 | **720** |
| de | ~440 | **720** |
| ru | 544 | **720** |
| es / fr / pt-BR | < 600 | **720** |
| ja / ko / zh-Hans | < 450 | **720** |
| doubled (pseudolocale) | ~815 | **~840** |

Panes stay rigid, exactly as before this issue — see the regression note. The pseudolocalized `A11y & Localization` lane gains one assertion: the Settings window must have grown past 720 pt.

## A regression this PR introduced and then removed

The first pass replaced the pins with `minWidth`/`maxWidth: .infinity` on both the window and the panes, on the theory that SwiftUI would size the window to its content. It does not: a bare macOS `TabView` reports 94×86 for English and 111×86 for Russian — the tab strip is not part of its intrinsic size, so `minWidth: 720` yields exactly 720 and nothing changes.

Worse, flexible panes let a greedy `ScrollView` drive the window:

| | main | first pass |
|---|---|---|
| Settings window | 720 × 628 | **900 × 628** |
| terminal scroll view | 720 × 500 | 900 × 540 |

180 pt of unwanted width in English, which broke `SettingsUITests.testTerminalPaneExposesThemeAndQuickTerminalControls` (scroll-calibrated). Adding `idealWidth` did not help. Panes are rigid again; they were never the problem.

**Control experiment**, same machine, same command, single test:

| branch | result |
|---|---|
| `origin/main` | passed (107 s) |
| first pass | failed (238 s), `SettingsUITests.swift:285` |
| this PR | passed (100 s) |

CI had failed all 3 iterations, so it was never flake.

## Mutation table

Baseline 13/13 green. Every mutation reverted after measuring.

| # | Mutation | Killed by | Green |
|---|---|---|---|
| M1 | Re-pin call site to `.frame(width: 720, height: 540)` | **survives — see below** | 13 |
| M2 | `windowWidth` ignores the strip | 4 tests | 8 |
| M3 | Panes greedy again (`maxWidth: .infinity`) | "Panes stay rigid…" | 11 |
| M4 | `tabItemMinimumWidth` / `tabItemPadding` → 0 | "Item widths track…" | 11 |
| M5 | Titles ignore locale | 3 tests | 9 |
| M6 | Title font 12 → 20 | 6 tests | 6 |

**M1 survives, stated plainly.** Re-pinning to a literal 720 is behaviourally identical for all nine shipped locales — that is precisely the finding — so it is observable only under real overflow, which requires the pseudolocale at *process launch*. Forcing `NSDoubleLocalizedStrings` inside the test process was attempted and removed: a `#require` guard caught that `NSBundle` reads the flag at launch, making the test vacuous. A green no-op would have closed the row dishonestly. M1 is covered by the pseudolocalized lane assertion, which does launch with the flag.

M4 initially survived too — a ±12 pt tolerance was absorbing it. Tightened to ±8 pt (the real maximum delta across en and ru is 7 pt), which kills it via the short-label case that `tabItemMinimumWidth` exists for.

## Why the `A11y & Localization` lane never caught the tab loss

The `ru-dark-both-double-length` lane rendered this on every run and could not see it. Three independent holes:

1. **Containment cannot detect overflow.** The only geometric Settings assertion is `assertContained(terminalTab, in: settingsWindow)`. A tab that has been pushed out of the window is *absent*, and `assertContained` is evaluated against the tabs that remain — the ones that are, by construction, inside. The assertion is satisfied by the very defect it was written for.
2. **The AX label is the model string.** `XCUIElement.label` returns the full title, so no label assertion distinguishes a rendered tab from a lost one.
3. **The "ru" lane never renders ru in the layout test.** `testRepresentativeAndPseudolocalizedLayouts` forces `LocaleCase(language: "en", locale: "en_US")` whenever `pseudolocalized` is set, so the double-length lane runs **English**. Russian reaches only `testSupportedLocalesRenderCriticalSurfaces`, which does existence and click checks, never geometry.

Compounding it: `PineTests/SettingsPaneSnapshotTests` renders *panes* at a hardcoded `NSSize(width: 720, height: 500)` and never renders `PineSettingsView`, so the tab strip appears in no snapshot baseline. And `captureDiagnostics` uploaded screenshots of the four-tab strip as artifacts on every run — the evidence was produced continuously and no gate read it.

The new assertion is scoped to the pseudolocale lane deliberately: the `ja-ko-zh` lane legitimately computes 720 pt, so an unconditional `> 720` would go red there.

## Verification

- `PineTests/SettingsWindowMetricsTests` — 13/13
- `PineUITests/SettingsUITests` — 4/4, including the previously failing test
- `SettingsPaneSnapshotTests`, `TerminalSettingsViewSnapshotTests`, `LSPSettingsViewSnapshotTests`, `AgentHandoffSettingsViewSnapshotTests` — 19/19, **no baselines rerecorded**
- `swiftlint --strict` — 0 violations in 808 files
- Rebased onto `ef3a1f03` (#1545, #1547, #1555 had landed)

`Pine/Localizable.xcstrings` is not touched: no new strings, the five tab keys already exist in all nine locales.

## HIG — not verified first-hand

`WebFetch` on `developer.apple.com` was blocked by network policy and a domain-restricted search returned only the page title. The HIG text was **not** read and memory was not substituted for it. The design rests on the citation quoted in #1531 itself, on `Pine/Agent/AgentCompletionBriefView.swift:31` as in-repo precedent, and above all on the measurements in this PR. The primary source remains unread.

## Acceptance criteria that are deliberately not met

#1531 asks for panes on `minWidth`/`idealWidth` and non-hardcoded pane heights. Both were written against a truncation defect that does not exist, and implementing them is what produced the 900 pt regression. The issue is being re-scoped to the tab-loss mechanism; these two criteria are dropped.

## Applicable to #1536, not done here

Two classes among its ~66 fixed sizes:

- **Containers around localizable text** — mechanical to convert. Welcome 600×400 (#1524) is here.
- **Strips of labels sharing a fixed width** — the dangerous class, because SwiftUI reports no intrinsic width for them and the failure is silent tab loss rather than visible truncation. Only this class needs measurement.

Neither is touched by this PR. The lesson generalises: for this class, reading the code produces a plausible and wrong answer. It has to be measured.

## Merge timing

**Do not merge yet** — this goes into `main` after the 2.6.0 tag.
