### PR TITLE
fix(terminal): move focus into the search bar on Cmd+F

### DIFF
--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -2131,6 +2131,11 @@ enum Strings {
     // MARK: - Terminal Search
 
     static let terminalSearchPlaceholder: LocalizedStringKey = "terminal.search.placeholder"
+    /// Same catalog key as ``terminalSearchPlaceholder``, resolved eagerly for
+    /// the AppKit query field, which takes a `String` placeholder.
+    static var terminalSearchPlaceholderString: String {
+        String(localized: "terminal.search.placeholder")
+    }
     static let menuFindInTerminal: LocalizedStringKey = "menu.findInTerminal"
     static let menuSendToTerminal: LocalizedStringKey = "menu.sendToTerminal"
     static let menuToggleTerminalZoom: LocalizedStringKey = "menu.toggleTerminalZoom"

--- a/Pine/TerminalBarView.swift
+++ b/Pine/TerminalBarView.swift
@@ -303,6 +303,13 @@ struct TerminalSearchBarContainer: View {
                 caseSensitive: Bindable(terminalState).isSearchCaseSensitive,
                 matchCount: terminalState.activeTab?.searchMatches.count ?? 0,
                 currentMatch: terminalState.activeTab?.currentMatchIndex ?? -1,
+                focusRequestID: terminalState.searchFocusRequestID,
+                onFocusResult: { requestID, succeeded in
+                    terminalState.acknowledgeSearchFocusRequest(
+                        requestID,
+                        succeeded: succeeded
+                    )
+                },
                 onNext: {
                     terminalState.activeTab?.nextMatch()
                 },
@@ -310,9 +317,7 @@ struct TerminalSearchBarContainer: View {
                     terminalState.activeTab?.previousMatch()
                 },
                 onDismiss: {
-                    terminalState.isSearchVisible = false
-                    terminalState.terminalSearchQuery = ""
-                    terminalState.activeTab?.clearSearch()
+                    terminalState.dismissSearch()
                 }
             )
         }
@@ -348,7 +353,9 @@ struct TerminalSearchObserver: ViewModifier {
                 // storage and trigger the exclusivity abort — same class of
                 // bug fixed across the other .onReceive handlers in this PR.
                 DispatchQueue.main.async {
-                    terminalState.isSearchVisible = true
+                    // Reveals the bar AND claims first responder for its
+                    // field; the two must move together (#1523).
+                    terminalState.presentSearch()
                 }
             }
             .onChange(of: terminalState.terminalSearchQuery) { _, newQuery in

--- a/Pine/TerminalPaneState.swift
+++ b/Pine/TerminalPaneState.swift
@@ -57,6 +57,12 @@ final class TerminalPaneState {
     var terminalSearchQuery = ""
     var isSearchCaseSensitive = false
 
+    /// Identity of the live request for first responder inside the search
+    /// field, or `nil` when nothing is waiting on AppKit. A fresh identity per
+    /// ⌘F lets a repeat press re-focus a bar that is already open, and stops a
+    /// stale AppKit completion from consuming a later request (#1523).
+    private(set) var searchFocusRequestID: UUID?
+
     var activeTab: TerminalTab? {
         guard let id = activeTerminalID else { return nil }
         return terminalTabs.first { $0.id == id }
@@ -70,6 +76,48 @@ final class TerminalPaneState {
     ) {
         self.themeSettings = themeSettings
         self.cursorSettings = cursorSettings
+    }
+
+    /// Opens the terminal search bar and directs first responder into its
+    /// query field.
+    ///
+    /// The terminal's own pending focus request is cancelled first: ⌘F is
+    /// frequently pressed right after the pane is created or a tab switched,
+    /// and leaving that request live would let SwiftTerm reclaim first
+    /// responder immediately after the field took it — the exact symptom
+    /// reported in #1523, where the bar appeared but typing went to the shell.
+    func presentSearch() {
+        isSearchVisible = true
+        pendingFocusTabID = nil
+        searchFocusRequestID = UUID()
+    }
+
+    /// Consumes the AppKit result of the live search-field focus request.
+    ///
+    /// - Returns: `true` only when this was the live request and AppKit
+    ///   confirmed first responder.
+    @discardableResult
+    func acknowledgeSearchFocusRequest(
+        _ requestID: UUID,
+        succeeded: Bool
+    ) -> Bool {
+        guard searchFocusRequestID == requestID else { return false }
+        searchFocusRequestID = nil
+        return succeeded
+    }
+
+    /// Closes the search bar, clears the query and its highlights, and hands
+    /// first responder back to the terminal that owned it before ⌘F.
+    ///
+    /// A no-op when the bar is already closed, so an Escape aimed at anything
+    /// else cannot yank focus into the terminal.
+    func dismissSearch() {
+        guard isSearchVisible else { return }
+        isSearchVisible = false
+        terminalSearchQuery = ""
+        searchFocusRequestID = nil
+        activeTab?.clearSearch()
+        pendingFocusTabID = activeTerminalID
     }
 
     /// Consumes the terminal result of a bounded AppKit focus request.

--- a/Pine/TerminalSearchBar.swift
+++ b/Pine/TerminalSearchBar.swift
@@ -15,6 +15,10 @@ struct TerminalSearchBar: View {
     @Binding var caseSensitive: Bool
     var matchCount: Int
     var currentMatch: Int
+    /// Non-nil while ⌘F is asking AppKit for first responder in the query
+    /// field. See ``TerminalPaneState/searchFocusRequestID``.
+    var focusRequestID: UUID?
+    var onFocusResult: (UUID, Bool) -> Void
     var onNext: () -> Void
     var onPrevious: () -> Void
     var onDismiss: () -> Void
@@ -25,19 +29,22 @@ struct TerminalSearchBar: View {
                 .foregroundStyle(.secondary)
                 .imageScale(.small)
 
-            TextField(Strings.terminalSearchPlaceholder, text: $query)
-                .textFieldStyle(.plain)
-                .onSubmit { onNext() }
-                // Shift+Enter navigates to the previous match
-                .onKeyPress(.return, phases: .down) { press in
-                    if press.modifiers.contains(.shift) {
-                        onPrevious()
-                        return .handled
+            // AppKit-backed: SwiftUI focus does not take first responder
+            // away from SwiftTerm's sibling NSView, and Return / Shift+Return
+            // / Escape have to reach the field editor to work at all (#1523).
+            TerminalSearchField(
+                text: $query,
+                focusRequestID: focusRequestID,
+                onCommand: { command in
+                    switch command {
+                    case .findNext: onNext()
+                    case .findPrevious: onPrevious()
+                    case .dismiss: onDismiss()
                     }
-                    return .ignored
-                }
-                .accessibilityIdentifier(AccessibilityID.terminalSearchField)
-                .frame(minWidth: 120)
+                },
+                onFocusResult: onFocusResult
+            )
+            .frame(minWidth: 120)
 
             if !query.isEmpty {
                 matchLabel

--- a/Pine/TerminalSearchField.swift
+++ b/Pine/TerminalSearchField.swift
@@ -1,0 +1,162 @@
+//
+//  TerminalSearchField.swift
+//  Pine
+//
+//  AppKit-backed query field for the terminal search bar (issue #1523).
+//
+
+import AppKit
+import SwiftUI
+
+/// Keyboard commands the terminal search field answers.
+///
+/// Mapping lives here, as a pure function of the field-editor selector and
+/// the shift modifier, so the binding can be verified without a window, a
+/// live field editor, or a synthesised `NSEvent`.
+enum TerminalSearchFieldCommand: Equatable {
+    case findNext
+    case findPrevious
+    case dismiss
+
+    /// Returns the command for an AppKit field-editor selector, or `nil` when
+    /// the key is none of the search bar's business and must keep its default
+    /// text-editing behaviour.
+    static func forSelector(
+        _ selector: Selector,
+        shiftPressed: Bool
+    ) -> TerminalSearchFieldCommand? {
+        switch selector {
+        case #selector(NSResponder.insertNewline(_:)),
+             #selector(NSResponder.insertNewlineIgnoringFieldEditor(_:)):
+            // Return walks the matches forward, Shift+Return backward. The
+            // second selector is included because AppKit routes a modified
+            // Return through it under some key-binding configurations.
+            return shiftPressed ? .findPrevious : .findNext
+        case #selector(NSResponder.cancelOperation(_:)):
+            return .dismiss
+        default:
+            return nil
+        }
+    }
+}
+
+/// `NSTextField` that owns the focus request bridging SwiftUI's search state
+/// to AppKit's first responder.
+///
+/// SwiftTerm's terminal view is a sibling `NSView` in the same window and
+/// holds first responder for the pane. SwiftUI focus does not reliably take
+/// it away from an AppKit view that never gives it up, so the field claims
+/// first responder itself — the same approach `WelcomeSearchField` already
+/// uses for the recent-projects filter.
+final class TerminalSearchFieldView: NSTextField {
+    /// Retains the claim until AppKit can actually evaluate it: the field is
+    /// created in the same SwiftUI pass that reveals the bar and is not in a
+    /// window yet on the first `updateNSView`.
+    let focusCoordinator = AppKitFocusRequestCoordinator()
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        focusCoordinator.hostDidMoveToWindow(self)
+    }
+}
+
+/// SwiftUI wrapper for the terminal search query field.
+struct TerminalSearchField: NSViewRepresentable {
+    @Binding var text: String
+    /// Non-nil while the bar is asking for first responder. Each ⌘F issues a
+    /// fresh identity so a repeat press re-focuses an already open bar.
+    var focusRequestID: UUID?
+    var onCommand: (TerminalSearchFieldCommand) -> Void
+    var onFocusResult: (UUID, Bool) -> Void
+
+    func makeNSView(context: Context) -> TerminalSearchFieldView {
+        let field = TerminalSearchFieldView()
+        field.delegate = context.coordinator
+        field.placeholderString = Strings.terminalSearchPlaceholderString
+        field.isBordered = false
+        field.isBezeled = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.font = .systemFont(ofSize: NSFont.systemFontSize)
+        field.lineBreakMode = .byTruncatingTail
+        field.usesSingleLineMode = true
+        field.cell?.wraps = false
+        field.cell?.isScrollable = true
+        // Let the surrounding HStack drive the width instead of the query text.
+        field.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        field.setAccessibilityIdentifier(AccessibilityID.terminalSearchField)
+        return field
+    }
+
+    func updateNSView(_ field: TerminalSearchFieldView, context: Context) {
+        context.coordinator.text = $text
+        context.coordinator.onCommand = onCommand
+        if field.stringValue != text {
+            field.stringValue = text
+        }
+        field.focusCoordinator.update(
+            requestID: focusRequestID,
+            hostView: field,
+            targetView: field,
+            onResult: onFocusResult
+        )
+    }
+
+    static func dismantleNSView(
+        _ field: TerminalSearchFieldView,
+        coordinator: Coordinator
+    ) {
+        field.focusCoordinator.cancel()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text, onCommand: onCommand)
+    }
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var text: Binding<String>
+        var onCommand: (TerminalSearchFieldCommand) -> Void
+        /// Reads the modifiers of the key event being dispatched. Injected so
+        /// the Shift+Return branch is testable without posting a real event.
+        var modifierFlagsProvider: () -> NSEvent.ModifierFlags = {
+            NSApp.currentEvent?.modifierFlags ?? []
+        }
+
+        init(
+            text: Binding<String>,
+            onCommand: @escaping (TerminalSearchFieldCommand) -> Void
+        ) {
+            self.text = text
+            self.onCommand = onCommand
+        }
+
+        func controlTextDidChange(_ obj: Notification) {
+            guard let field = obj.object as? NSTextField else { return }
+            text.wrappedValue = field.stringValue
+        }
+
+        func control(
+            _ control: NSControl,
+            textView: NSTextView,
+            doCommandBy commandSelector: Selector
+        ) -> Bool {
+            handleCommand(commandSelector)
+        }
+
+        /// Dispatches a field-editor selector. Returns `true` when the search
+        /// bar consumed the key, which is what stops AppKit from also
+        /// performing its default action for it.
+        @discardableResult
+        func handleCommand(_ commandSelector: Selector) -> Bool {
+            guard let command = TerminalSearchFieldCommand.forSelector(
+                commandSelector,
+                shiftPressed: modifierFlagsProvider().contains(.shift)
+            ) else {
+                return false
+            }
+            onCommand(command)
+            return true
+        }
+    }
+}

--- a/PineTests/TerminalSearchFocusTests.swift
+++ b/PineTests/TerminalSearchFocusTests.swift
@@ -1,0 +1,269 @@
+//
+//  TerminalSearchFocusTests.swift
+//  PineTests
+//
+//  Issue #1523 — ⌘F must move first responder into the terminal search
+//  field, Return/Shift+Return must navigate matches, and Escape must close
+//  the bar and hand first responder back to the terminal.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+/// Stand-in for SwiftTerm's terminal view. The production target is a
+/// `LocalProcessTerminalView`, which needs a live PTY to behave; first
+/// responder ownership is the only property under test here.
+private final class FocusAcceptingTestView: NSView {
+    override var acceptsFirstResponder: Bool { true }
+}
+
+@Suite("Terminal Search Focus")
+@MainActor
+struct TerminalSearchFocusTests {
+
+    // MARK: - Focus intent state machine
+
+    @Test("Cmd+F opens the bar, requests field focus, and cancels terminal focus")
+    func presentSearchClaimsFocusFromTerminal() throws {
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        // `addTab` leaves a pending focus request aimed at the terminal view.
+        #expect(state.pendingFocusTabID == tab.id)
+
+        state.presentSearch()
+
+        #expect(state.isSearchVisible)
+        _ = try #require(state.searchFocusRequestID)
+        // Without this the terminal's own request would win the race and the
+        // field would be revealed while the shell kept the keystrokes.
+        #expect(state.pendingFocusTabID == nil)
+        #expect(state.pendingFocusRequestID == nil)
+    }
+
+    @Test("Cmd+F while the bar is already open re-requests focus")
+    func repeatedPresentSearchIssuesDistinctRequests() throws {
+        let state = TerminalPaneState()
+        _ = state.addTab(workingDirectory: nil)
+
+        state.presentSearch()
+        let first = try #require(state.searchFocusRequestID)
+        state.presentSearch()
+        let second = try #require(state.searchFocusRequestID)
+
+        #expect(first != second)
+    }
+
+    @Test("Only the live search focus request is acknowledged")
+    func searchFocusAcknowledgementIsGenerationGuarded() throws {
+        let state = TerminalPaneState()
+        _ = state.addTab(workingDirectory: nil)
+
+        state.presentSearch()
+        let stale = try #require(state.searchFocusRequestID)
+        state.presentSearch()
+        let live = try #require(state.searchFocusRequestID)
+
+        #expect(!state.acknowledgeSearchFocusRequest(stale, succeeded: true))
+        #expect(state.searchFocusRequestID == live)
+
+        #expect(state.acknowledgeSearchFocusRequest(live, succeeded: true))
+        #expect(state.searchFocusRequestID == nil)
+    }
+
+    @Test("A failed focus attempt is consumed but reported as failure")
+    func failedSearchFocusRequestIsConsumed() throws {
+        let state = TerminalPaneState()
+        _ = state.addTab(workingDirectory: nil)
+        state.presentSearch()
+        let requestID = try #require(state.searchFocusRequestID)
+
+        #expect(!state.acknowledgeSearchFocusRequest(requestID, succeeded: false))
+        #expect(state.searchFocusRequestID == nil)
+    }
+
+    @Test("Escape closes the bar, clears the query, and re-focuses the terminal")
+    func dismissSearchReturnsFocusToTerminal() throws {
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        state.presentSearch()
+        state.terminalSearchQuery = "needle"
+        _ = try #require(state.searchFocusRequestID)
+
+        state.dismissSearch()
+
+        #expect(!state.isSearchVisible)
+        #expect(state.terminalSearchQuery.isEmpty)
+        #expect(state.searchFocusRequestID == nil)
+        #expect(state.pendingFocusTabID == tab.id)
+        #expect(state.pendingFocusRequestID != nil)
+    }
+
+    @Test("Dismissing an already-closed bar never steals focus")
+    func dismissSearchWhileClosedIsANoOp() {
+        let state = TerminalPaneState()
+        _ = state.addTab(workingDirectory: nil)
+        state.pendingFocusTabID = nil
+
+        state.dismissSearch()
+
+        #expect(!state.isSearchVisible)
+        #expect(state.pendingFocusTabID == nil)
+        #expect(state.pendingFocusRequestID == nil)
+    }
+
+    // MARK: - Field editor key bindings
+
+    @Test("Return finds next, Shift+Return finds previous, Escape dismisses")
+    func fieldEditorSelectorsMapToSearchCommands() {
+        #expect(
+            TerminalSearchFieldCommand.forSelector(
+                #selector(NSResponder.insertNewline(_:)),
+                shiftPressed: false
+            ) == .findNext
+        )
+        #expect(
+            TerminalSearchFieldCommand.forSelector(
+                #selector(NSResponder.insertNewline(_:)),
+                shiftPressed: true
+            ) == .findPrevious
+        )
+        // AppKit routes Shift/Option+Return through this selector on some
+        // key-binding configurations; the direction rule must not change.
+        #expect(
+            TerminalSearchFieldCommand.forSelector(
+                #selector(NSResponder.insertNewlineIgnoringFieldEditor(_:)),
+                shiftPressed: true
+            ) == .findPrevious
+        )
+        #expect(
+            TerminalSearchFieldCommand.forSelector(
+                #selector(NSResponder.cancelOperation(_:)),
+                shiftPressed: false
+            ) == .dismiss
+        )
+        // Escape must dismiss regardless of a stray modifier.
+        #expect(
+            TerminalSearchFieldCommand.forSelector(
+                #selector(NSResponder.cancelOperation(_:)),
+                shiftPressed: true
+            ) == .dismiss
+        )
+    }
+
+    @Test("Unrelated field editor commands stay with AppKit")
+    func unrelatedSelectorsAreNotIntercepted() {
+        #expect(
+            TerminalSearchFieldCommand.forSelector(
+                #selector(NSResponder.insertTab(_:)),
+                shiftPressed: false
+            ) == nil
+        )
+        #expect(
+            TerminalSearchFieldCommand.forSelector(
+                #selector(NSResponder.deleteBackward(_:)),
+                shiftPressed: false
+            ) == nil
+        )
+        #expect(
+            TerminalSearchFieldCommand.forSelector(
+                #selector(NSResponder.moveLeft(_:)),
+                shiftPressed: false
+            ) == nil
+        )
+    }
+
+    @Test("The field delegate dispatches the mapped command and consumes the key")
+    func delegateDispatchesMappedCommands() {
+        var commands: [TerminalSearchFieldCommand] = []
+        let field = TerminalSearchFieldView()
+        let coordinator = TerminalSearchField.Coordinator(
+            text: .constant(""),
+            onCommand: { commands.append($0) }
+        )
+        var shift = false
+        coordinator.modifierFlagsProvider = { shift ? [.shift] : [] }
+
+        #expect(coordinator.handleCommand(#selector(NSResponder.insertNewline(_:))))
+        shift = true
+        #expect(coordinator.handleCommand(#selector(NSResponder.insertNewline(_:))))
+        shift = false
+        #expect(coordinator.handleCommand(#selector(NSResponder.cancelOperation(_:))))
+        // Not ours — AppKit keeps its default behaviour.
+        #expect(!coordinator.handleCommand(#selector(NSResponder.deleteBackward(_:))))
+
+        #expect(commands == [.findNext, .findPrevious, .dismiss])
+        #expect(field.acceptsFirstResponder)
+    }
+
+    // MARK: - Real AppKit first responder round trip
+
+    @Test("First responder moves into the field on Cmd+F and back on Escape")
+    func firstResponderRoundTripBetweenTerminalAndSearchField() throws {
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let contentView = try #require(window.contentView)
+        let terminalStandIn = FocusAcceptingTestView(
+            frame: NSRect(x: 0, y: 0, width: 400, height: 160)
+        )
+        let field = TerminalSearchFieldView(
+            frame: NSRect(x: 0, y: 160, width: 400, height: 24)
+        )
+        contentView.addSubview(terminalStandIn)
+        contentView.addSubview(field)
+        defer { window.orderOut(nil) }
+
+        // Before ⌘F the terminal owns first responder.
+        #expect(window.makeFirstResponder(terminalStandIn))
+        #expect(window.firstResponder === terminalStandIn)
+
+        // ⌘F — production drives the very same coordinator from updateNSView.
+        state.presentSearch()
+        let searchRequestID = try #require(state.searchFocusRequestID)
+        field.focusCoordinator.update(
+            requestID: searchRequestID,
+            hostView: field,
+            targetView: field,
+            onResult: { requestID, succeeded in
+                state.acknowledgeSearchFocusRequest(requestID, succeeded: succeeded)
+            }
+        )
+        #expect(field.focusCoordinator.attemptNow())
+
+        // The window's first responder is the field editor, a descendant of
+        // the search field — typing now lands in the query, not the shell.
+        let editor = try #require(window.firstResponder as? NSView)
+        #expect(editor.isDescendant(of: field))
+        #expect(!editor.isDescendant(of: terminalStandIn))
+        #expect(state.searchFocusRequestID == nil)
+
+        // Escape.
+        state.dismissSearch()
+        let terminalRequestID = try #require(state.pendingFocusRequestID)
+        let terminalFocus = AppKitFocusRequestCoordinator()
+        terminalFocus.update(
+            requestID: terminalRequestID,
+            hostView: contentView,
+            targetView: terminalStandIn,
+            onResult: { requestID, succeeded in
+                state.acknowledgeFocusRequest(
+                    requestID: requestID,
+                    for: tab.id,
+                    succeeded: succeeded
+                )
+            }
+        )
+        #expect(terminalFocus.attemptNow())
+        #expect(window.firstResponder === terminalStandIn)
+        #expect(state.pendingFocusTabID == nil)
+    }
+}


### PR DESCRIPTION
Closes #1523

## Problem

⌘F (Terminal → Find in Terminal) revealed the terminal search bar but never claimed first responder. The field stayed unfocused, so Return, Shift+Return and Escape inside it were unreachable and typed characters went to the shell. The feature was mouse-only.

## Root cause

Two independent defects, both required for the bug:

1. **Nothing claimed first responder.** The `.findInTerminal` handler only flipped `terminalState.isSearchVisible`; the field had no focus binding at all.
2. **The terminal was still holding a focus request.** ⌘F is typically pressed shortly after a pane is created or a tab switched, and `TerminalPaneState.pendingFocusTabID` is still live from that. Fixing only (1) would leave the field focused for one runloop before SwiftTerm's own pending request reclaimed first responder — the fix would look correct and fail in the real sequence.

## Approach

**Focus intent lives in `TerminalPaneState`** — a plain, AppKit-free seam:

- `presentSearch()` reveals the bar, **cancels the terminal's pending focus request**, and issues a fresh `searchFocusRequestID`. A fresh identity per ⌘F means a repeat press re-focuses an already open bar.
- `dismissSearch()` closes the bar, clears the query and its highlights, and hands a fresh focus request back to the active terminal tab. It is a no-op when the bar is already closed, so an Escape aimed at anything else cannot yank focus into the terminal.
- `acknowledgeSearchFocusRequest(_:succeeded:)` consumes the AppKit result under a generation guard, matching the existing `acknowledgeFocusRequest` contract.

**The query field becomes AppKit-backed** (`TerminalSearchField`). SwiftUI focus does not reliably take first responder away from SwiftTerm's sibling `NSView`, and the Return / Shift+Return / Escape bindings have to reach the field editor to work at all. This is the same claim pattern `WelcomeSearchField` already uses for the recent-projects filter, and it reuses `AppKitFocusRequestCoordinator`, so a bar revealed before its view joins a window still gets the bounded, generation-guarded retry.

**No `NSEvent.addLocalMonitorForEvents`.** Key handling goes through `control(_:textView:doCommandBy:)` — the ordinary AppKit responder-chain path. The AGENTS.md warning about synthetic events bypassing local monitors therefore does not apply here, which is precisely why this is provable with a unit test instead of a UI test. **No UI test was added and no shard was touched.**

Selector-to-command mapping is a pure function (`TerminalSearchFieldCommand.forSelector(_:shiftPressed:)`), so the key bindings are verifiable without a window, a live field editor, or a synthesised `NSEvent`. `insertNewlineIgnoringFieldEditor:` is handled alongside `insertNewline:` because AppKit routes a modified Return through it under some key-binding configurations.

## Acceptance criteria

- [x] ⌘F moves focus into the terminal search field; typing goes to the field, not the shell
- [x] Return finds next, Shift+Return finds previous
- [x] Escape closes the search bar and returns first responder to the terminal view
- [x] Closing the search bar restores the terminal as first responder in the same pane
- [x] Test covers focus ownership before and after ⌘F and after Escape

The last one is covered by a real round trip on a live `NSWindow`: a terminal stand-in holds first responder → `presentSearch()` → the window's first responder becomes the field editor (a descendant of the search field) → `dismissSearch()` → first responder returns to the stand-in.

## Tests

`PineTests/TerminalSearchFocusTests.swift` — 10 tests, all green.

No `sleep` and no `Task.yield()` used as synchronisation. The one AppKit test drives `AppKitFocusRequestCoordinator.attemptNow()` synchronously — the same seam `TabDestinationFocusTests` already relies on.

### Mutation verification

Every guarded branch was broken in turn and the suite re-run. 12 of 12 mutations are caught.

| # | Mutation | File | Failing test(s) |
|---|---|---|---|
| M1 | `presentSearch` keeps the terminal focus request | `TerminalPaneState` | Cmd+F opens the bar… |
| M2 | `presentSearch` reuses the previous request identity | `TerminalPaneState` | re-requests focus; live request… |
| M3 | generation guard removed from `acknowledgeSearchFocusRequest` | `TerminalPaneState` | Only the live search focus request… |
| M4 | `acknowledgeSearchFocusRequest` always reports success | `TerminalPaneState` | A failed focus attempt… |
| M5 | `dismissSearch` never hands focus back to the terminal | `TerminalPaneState` | Escape closes…; round trip |
| M6 | `dismissSearch` runs even when the bar is closed | `TerminalPaneState` | Dismissing an already-closed bar… |
| M7 | `dismissSearch` leaves the query in place | `TerminalPaneState` | Escape closes the bar… |
| M8 | Return ignores the shift modifier | `TerminalSearchField` | Return finds next…; delegate dispatches… |
| M9 | `default` branch swallows every selector | `TerminalSearchField` | delegate dispatches…; Unrelated selectors… |
| M10 | Escape no longer dispatches `.dismiss` | `TerminalSearchField` | Return finds next…; delegate dispatches… |
| M11 | `handleCommand` does not consume the key | `TerminalSearchField` | delegate dispatches… |
| M12 | the field refuses first responder | `TerminalSearchField` | round trip; delegate dispatches… |

## Verification

- `swiftlint --strict` — **0 violations across 806 files** (0.65.1, matching the CI pin from #1547)
- Full `xcodebuild build` — **BUILD SUCCEEDED**
- Neighbouring suites, one at a time: `TerminalPaneStateTests` 11/11, `TabDestinationFocusTests` 20/20, `LocalizationCatalogCompletenessTests` 4/4, `AccessibilityLocalizationMatrixTests` 2/2
- **Visual:** the bar was rendered offscreen via `SnapshotHarness.render` in light and dark, empty and with a query. Layout is unchanged from the SwiftUI version — localized placeholder, field expanding to fill the `HStack`, match count, `Aa`, chevrons, close button. No snapshot baselines were added.

## Localization

`Pine/Strings.swift` gains `terminalSearchPlaceholderString` (+5 lines) because the AppKit field takes a `String` placeholder rather than a `LocalizedStringKey`. It resolves **the same existing catalog key** `terminal.search.placeholder`.

**`Localizable.xcstrings` is not touched at all** — no new keys, no reserialization.

## Not in scope

⌘G / ⇧⌘G (Find Next/Previous) remain editor-only in a terminal window. They are gated on an editor tab existing and post notifications only `GutterTextView` observes. Wiring them to the terminal needs a maintainer policy decision about which surface wins when an editor tab and an open terminal search bar are both live, so it is filed separately rather than folded in here.

## Merge timing

**Ready to merge after the 2.6.0 tag, not before.**
