### PR TITLE
fix(i18n): classify CLI installer cancellation by error code, not localized text

### DIFF
--- a/Pine/CLIInstaller.swift
+++ b/Pine/CLIInstaller.swift
@@ -29,6 +29,58 @@ enum CLIInstaller {
         return dest == bundled
     }
 
+    // MARK: - AppleScript outcome classification
+
+    /// What a privileged AppleScript invocation actually did.
+    ///
+    /// Derived from the error dictionary's *number*, never its message:
+    /// `NSAppleScript.errorMessage` is localized by the system, so matching it
+    /// against English prose reports a cancellation as a failure in all eight
+    /// non-English locales Pine ships (#1530).
+    enum PrivilegedScriptOutcome: Equatable {
+        case succeeded
+        case cancelled
+        case failed(message: String)
+
+        /// Only a genuine failure earns an alert. Dismissing the authorization
+        /// prompt is a normal user action and must stay silent.
+        var presentsErrorAlert: Bool {
+            if case .failed = self { return true }
+            return false
+        }
+    }
+
+    /// AppleScript error numbers that mean "the user dismissed the prompt".
+    ///
+    /// `do shell script … with administrator privileges` reports a cancelled
+    /// authorization dialog as `userCanceledErr` (-128). The Apple Event and
+    /// Authorization Services spellings of the same user action are accepted
+    /// too, so the classification never depends on which layer surfaced it.
+    static let cancellationErrorNumbers: Set<Int> = [
+        Int(userCanceledErr),          // -128
+        Int(errAEWaitCanceled),        // -1711
+        Int(errAuthorizationCanceled), // -60006
+    ]
+
+    /// Locale-invariant test for "the user cancelled the authorization prompt".
+    static func isUserCancellation(errorNumber: Int?) -> Bool {
+        guard let errorNumber else { return false }
+        return cancellationErrorNumbers.contains(errorNumber)
+    }
+
+    /// Classifies the error dictionary produced by
+    /// `NSAppleScript.executeAndReturnError`. A `nil` dictionary means the
+    /// script ran to completion.
+    static func outcome(
+        forScriptError error: NSDictionary?
+    ) -> PrivilegedScriptOutcome {
+        guard let error else { return .succeeded }
+        let number = (error[NSAppleScript.errorNumber] as? NSNumber)?.intValue
+        guard !isUserCancellation(errorNumber: number) else { return .cancelled }
+        let message = error[NSAppleScript.errorMessage] as? String
+        return .failed(message: message ?? Strings.cliErrorUnknown)
+    }
+
     // MARK: - Install / Uninstall
 
     /// Installs the CLI tool by creating a symlink.
@@ -42,8 +94,8 @@ enum CLIInstaller {
         }
         guard let scriptPath = bundledScriptPath else {
             showError(
-                title: "Installation Failed",
-                message: "Could not find the pine CLI script in the app bundle.",
+                title: Strings.cliInstallFailedTitle,
+                message: Strings.cliInstallMissingScript,
                 context: context
             )
             return
@@ -62,9 +114,7 @@ enum CLIInstaller {
                     atPath: defaultInstallPath,
                     withDestinationPath: scriptPath
                 )
-                presentSuccess(
-                    title: "Command Line Tool Installed",
-                    message: "The 'pine' command is now available.\n\nUsage: pine . or pine file.swift",
+                presentInstallSuccess(
                     projectManager: projectManager,
                     context: context
                 )
@@ -84,20 +134,19 @@ enum CLIInstaller {
         var error: NSDictionary?
         if let appleScript = NSAppleScript(source: script) {
             appleScript.executeAndReturnError(&error)
-            if let error {
-                let message = error[NSAppleScript.errorMessage] as? String ?? "Unknown error"
-                if !message.contains("User canceled") {
-                    showError(
-                        title: "Installation Failed",
-                        message: message,
-                        context: context
-                    )
-                }
-            } else {
-                presentSuccess(
-                    title: "Command Line Tool Installed",
-                    message: "The 'pine' command is now available.\n\nUsage: pine . or pine file.swift",
+            switch outcome(forScriptError: error) {
+            case .succeeded:
+                presentInstallSuccess(
                     projectManager: projectManager,
+                    context: context
+                )
+            case .cancelled:
+                // The user declined the authorization prompt — not a failure.
+                break
+            case .failed(let message):
+                showError(
+                    title: Strings.cliInstallFailedTitle,
+                    message: message,
                     context: context
                 )
             }
@@ -117,9 +166,7 @@ enum CLIInstaller {
         if FileManager.default.isDeletableFile(atPath: defaultInstallPath) {
             do {
                 try FileManager.default.removeItem(atPath: defaultInstallPath)
-                presentSuccess(
-                    title: "Command Line Tool Removed",
-                    message: "The 'pine' command has been removed from /usr/local/bin.",
+                presentUninstallSuccess(
                     projectManager: projectManager,
                     context: context
                 )
@@ -137,20 +184,19 @@ enum CLIInstaller {
         var error: NSDictionary?
         if let appleScript = NSAppleScript(source: script) {
             appleScript.executeAndReturnError(&error)
-            if let error {
-                let message = error[NSAppleScript.errorMessage] as? String ?? "Unknown error"
-                if !message.contains("User canceled") {
-                    showError(
-                        title: "Uninstall Failed",
-                        message: message,
-                        context: context
-                    )
-                }
-            } else {
-                presentSuccess(
-                    title: "Command Line Tool Removed",
-                    message: "The 'pine' command has been removed from /usr/local/bin.",
+            switch outcome(forScriptError: error) {
+            case .succeeded:
+                presentUninstallSuccess(
                     projectManager: projectManager,
+                    context: context
+                )
+            case .cancelled:
+                // The user declined the authorization prompt — not a failure.
+                break
+            case .failed(let message):
+                showError(
+                    title: Strings.cliUninstallFailedTitle,
+                    message: message,
                     context: context
                 )
             }
@@ -158,6 +204,32 @@ enum CLIInstaller {
     }
 
     // MARK: - Presentation
+
+    @MainActor
+    private static func presentInstallSuccess(
+        projectManager: ProjectManager?,
+        context: DialogPresentationContext
+    ) {
+        presentSuccess(
+            title: Strings.cliInstallSuccessTitle,
+            message: Strings.cliInstallSuccessMessage,
+            projectManager: projectManager,
+            context: context
+        )
+    }
+
+    @MainActor
+    private static func presentUninstallSuccess(
+        projectManager: ProjectManager?,
+        context: DialogPresentationContext
+    ) {
+        presentSuccess(
+            title: Strings.cliUninstallSuccessTitle,
+            message: Strings.cliUninstallSuccessMessage,
+            projectManager: projectManager,
+            context: context
+        )
+    }
 
     /// Reports success without taking focus or blocking any project window.
     /// Internal visibility keeps the no-sheet contract directly testable.

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -5007,6 +5007,486 @@
         }
       }
     },
+    "cli.error.unknown": {
+      "comment": "Fallback body when AppleScript reports an error without a message.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekannter Fehler"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown error"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error desconocido"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur inconnue"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明なエラー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알 수 없는 오류"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erro desconhecido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Неизвестная ошибка"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未知错误"
+          }
+        }
+      }
+    },
+    "cli.install.failedTitle": {
+      "comment": "Alert title when installing the pine command line tool fails.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installation fehlgeschlagen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installation Failed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error en la instalación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de l’installation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストールに失敗しました"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설치 실패"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha na instalação"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось установить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装失败"
+          }
+        }
+      }
+    },
+    "cli.install.missingScript": {
+      "comment": "Alert body when the bundled pine CLI script is missing from the app bundle.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das pine-Befehlszeilenskript wurde im App-Bundle nicht gefunden."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not find the pine CLI script in the app bundle."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró el script de la herramienta pine en el paquete de la app."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le script en ligne de commande pine est introuvable dans le paquet de l’app."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリバンドル内に pine コマンドラインスクリプトが見つかりませんでした。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앱 번들에서 pine 명령줄 스크립트를 찾을 수 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível encontrar o script de linha de comando pine no pacote do app."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось найти скрипт командной строки pine в пакете приложения."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在应用程序包中找不到 pine 命令行脚本。"
+          }
+        }
+      }
+    },
+    "cli.install.successMessage": {
+      "comment": "Confirmation body after the pine command line tool is installed.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Befehl „pine“ ist jetzt verfügbar.\n\nVerwendung: pine . oder pine file.swift"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The 'pine' command is now available.\n\nUsage: pine . or pine file.swift"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El comando «pine» ya está disponible.\n\nUso: pine . o pine file.swift"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La commande « pine » est maintenant disponible.\n\nUtilisation : pine . ou pine file.swift"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「pine」コマンドが使用できるようになりました。\n\n使い方: pine . または pine file.swift"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이제 ‘pine’ 명령을 사용할 수 있습니다.\n\n사용법: pine . 또는 pine file.swift"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O comando “pine” já está disponível.\n\nUso: pine . ou pine file.swift"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Команда «pine» теперь доступна.\n\nИспользование: pine . или pine file.swift"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“pine”命令现已可用。\n\n用法：pine . 或 pine file.swift"
+          }
+        }
+      }
+    },
+    "cli.install.successTitle": {
+      "comment": "Confirmation title after the pine command line tool is installed.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Befehlszeilenwerkzeug installiert"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command Line Tool Installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herramienta de línea de comandos instalada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outil en ligne de commande installé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コマンドラインツールをインストールしました"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "명령줄 도구 설치됨"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ferramenta de linha de comando instalada"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Инструмент командной строки установлен"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装命令行工具"
+          }
+        }
+      }
+    },
+    "cli.uninstall.failedTitle": {
+      "comment": "Alert title when removing the pine command line tool fails.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deinstallation fehlgeschlagen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uninstall Failed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al desinstalar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de la désinstallation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アンインストールに失敗しました"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제거 실패"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha na desinstalação"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось удалить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "卸载失败"
+          }
+        }
+      }
+    },
+    "cli.uninstall.successMessage": {
+      "comment": "Confirmation body after the pine command line tool is removed.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Befehl „pine“ wurde aus /usr/local/bin entfernt."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The 'pine' command has been removed from /usr/local/bin."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El comando «pine» se ha eliminado de /usr/local/bin."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La commande « pine » a été supprimée de /usr/local/bin."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「pine」コマンドを /usr/local/bin から削除しました。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "/usr/local/bin에서 ‘pine’ 명령을 제거했습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O comando “pine” foi removido de /usr/local/bin."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Команда «pine» удалена из /usr/local/bin."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已从 /usr/local/bin 中移除“pine”命令。"
+          }
+        }
+      }
+    },
+    "cli.uninstall.successTitle": {
+      "comment": "Confirmation title after the pine command line tool is removed.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Befehlszeilenwerkzeug entfernt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command Line Tool Removed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herramienta de línea de comandos eliminada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outil en ligne de commande supprimé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コマンドラインツールを削除しました"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "명령줄 도구 제거됨"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ferramenta de linha de comando removida"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Инструмент командной строки удалён"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已移除命令行工具"
+          }
+        }
+      }
+    },
     "conflict.externalModify.keep": {
       "comment": "Button: keep local unsaved changes instead of reloading from disk.",
       "extractionState": "manual",

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -2688,4 +2688,39 @@ enum Strings {
         )
         return String(format: format, locale: locale, kind, name, line)
     }
+
+    // MARK: - Command Line Tool (#1530)
+
+    static var cliInstallFailedTitle: String {
+        String(localized: "cli.install.failedTitle")
+    }
+
+    static var cliInstallMissingScript: String {
+        String(localized: "cli.install.missingScript")
+    }
+
+    static var cliInstallSuccessTitle: String {
+        String(localized: "cli.install.successTitle")
+    }
+
+    static var cliInstallSuccessMessage: String {
+        String(localized: "cli.install.successMessage")
+    }
+
+    static var cliUninstallFailedTitle: String {
+        String(localized: "cli.uninstall.failedTitle")
+    }
+
+    static var cliUninstallSuccessTitle: String {
+        String(localized: "cli.uninstall.successTitle")
+    }
+
+    static var cliUninstallSuccessMessage: String {
+        String(localized: "cli.uninstall.successMessage")
+    }
+
+    /// Fallback body when AppleScript reports an error with no message.
+    static var cliErrorUnknown: String {
+        String(localized: "cli.error.unknown")
+    }
 }

--- a/PineTests/CLIInstallerCancellationTests.swift
+++ b/PineTests/CLIInstallerCancellationTests.swift
@@ -1,0 +1,180 @@
+//
+//  CLIInstallerCancellationTests.swift
+//  PineTests
+//
+//  #1530 — the privileged-install path used to decide "the user cancelled" by
+//  substring-matching `NSAppleScript.errorMessage` against "User canceled".
+//  That message is localized by the system, so on eight of Pine's nine locales
+//  a normal cancellation was reported as "Installation Failed". Classification
+//  now runs off the AppleScript error *number*, which is locale-invariant.
+//
+
+import AppKit
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("CLI installer cancellation classification")
+struct CLIInstallerCancellationTests {
+    /// Localized renderings of `userCanceledErr` as macOS actually reports it.
+    /// `osascript -e 'error number -128'` on a Russian system prints
+    /// "Отменено пользователем." — none of these contain "User canceled".
+    private static let localizedCancellationMessages = [
+        "User canceled.",
+        "Отменено пользователем.",
+        "Der Benutzer hat abgebrochen.",
+        "El usuario ha cancelado.",
+        "L’utilisateur a annulé.",
+        "ユーザによって取り消されました。",
+        "사용자가 취소했습니다.",
+        "O usuário cancelou.",
+        "用户已取消。",
+    ]
+
+    private func scriptError(
+        number: Int?,
+        message: String?
+    ) -> NSDictionary {
+        let error = NSMutableDictionary()
+        if let number {
+            error[NSAppleScript.errorNumber] = NSNumber(value: number)
+        }
+        if let message {
+            error[NSAppleScript.errorMessage] = message
+        }
+        return error
+    }
+
+    // MARK: - Pure classification by error number
+
+    @Test("userCanceledErr is a cancellation")
+    func userCanceledErrIsCancellation() {
+        #expect(CLIInstaller.isUserCancellation(errorNumber: -128))
+        #expect(
+            CLIInstaller.isUserCancellation(
+                errorNumber: Int(userCanceledErr)
+            )
+        )
+    }
+
+    @Test("Related Apple Event cancellation codes count as cancellation")
+    func relatedCancellationCodes() {
+        #expect(
+            CLIInstaller.isUserCancellation(
+                errorNumber: Int(errAEWaitCanceled)
+            )
+        )
+        #expect(CLIInstaller.isUserCancellation(errorNumber: -1711))
+        #expect(
+            CLIInstaller.isUserCancellation(
+                errorNumber: Int(errAuthorizationCanceled)
+            )
+        )
+        #expect(CLIInstaller.isUserCancellation(errorNumber: -60006))
+    }
+
+    @Test("Genuine failure codes are not cancellations")
+    func failureCodesAreNotCancellations() {
+        let failureCodes = [
+            0,
+            1,
+            128,
+            255,
+            -1,
+            -60005,
+            Int(errAEEventNotHandled),
+            Int(errOSAScriptError),
+            -1743,
+            -10004,
+        ]
+        for code in failureCodes {
+            #expect(
+                !CLIInstaller.isUserCancellation(errorNumber: code),
+                "\(code) must not be treated as a user cancellation"
+            )
+        }
+    }
+
+    @Test("A missing error number is not a cancellation")
+    func missingErrorNumberIsNotCancellation() {
+        #expect(!CLIInstaller.isUserCancellation(errorNumber: nil))
+    }
+
+    // MARK: - Outcome mapping
+
+    @Test("No error dictionary means the script succeeded")
+    func nilErrorIsSuccess() {
+        #expect(CLIInstaller.outcome(forScriptError: nil) == .succeeded)
+    }
+
+    /// The regression guard: every localized spelling of the cancellation
+    /// message must classify as `.cancelled`. A text-matching implementation
+    /// passes only the English row.
+    @Test("Localized cancellation text still classifies as cancelled")
+    func localizedCancellationsAreCancelled() {
+        for message in Self.localizedCancellationMessages {
+            let error = scriptError(number: -128, message: message)
+            #expect(
+                CLIInstaller.outcome(forScriptError: error) == .cancelled,
+                "\(message) must classify as a cancellation"
+            )
+        }
+    }
+
+    @Test("Cancellation presents no alert")
+    func cancellationPresentsNoAlert() {
+        for message in Self.localizedCancellationMessages {
+            let error = scriptError(number: -128, message: message)
+            #expect(
+                CLIInstaller.outcome(
+                    forScriptError: error
+                ).presentsErrorAlert == false,
+                "\(message) must not raise an alert"
+            )
+        }
+        #expect(
+            CLIInstaller.outcome(forScriptError: nil).presentsErrorAlert
+                == false
+        )
+    }
+
+    @Test("An English failure message is reported verbatim")
+    func genuineFailureCarriesItsMessage() {
+        let error = scriptError(number: -10004, message: "A privilege violation occurred.")
+        #expect(
+            CLIInstaller.outcome(forScriptError: error)
+                == .failed(message: "A privilege violation occurred.")
+        )
+        #expect(CLIInstaller.outcome(forScriptError: error).presentsErrorAlert)
+    }
+
+    /// A failure whose localized text happens to mention cancellation must
+    /// still be a failure — the number, not the prose, decides.
+    @Test("Failure codes stay failures even when the text says canceled")
+    func misleadingTextDoesNotCancel() {
+        let error = scriptError(number: -10004, message: "User canceled.")
+        #expect(
+            CLIInstaller.outcome(forScriptError: error)
+                == .failed(message: "User canceled.")
+        )
+    }
+
+    @Test("A failure without a message falls back to the localized default")
+    func missingMessageUsesLocalizedFallback() {
+        let error = scriptError(number: 255, message: nil)
+        #expect(
+            CLIInstaller.outcome(forScriptError: error)
+                == .failed(message: Strings.cliErrorUnknown)
+        )
+    }
+
+    @Test("An error dictionary without a number is a failure, not a cancel")
+    func numberlessErrorIsFailure() {
+        let error = scriptError(number: nil, message: "Something broke.")
+        #expect(
+            CLIInstaller.outcome(forScriptError: error)
+                == .failed(message: "Something broke.")
+        )
+    }
+}


### PR DESCRIPTION
Fixes #1530.

`CLIInstaller` decided whether the user had cancelled the sudo prompt by substring-matching `NSAppleScript.errorMessage` against `"User canceled"`. That message is localized by the system, so the comparison only ever held in English — in the other eight locales Pine ships, pressing **Cancel** on the authorization dialog produced an **"Installation Failed"** alert. The user declined; the app reported a failure.

## The bug, measured

Not inferred — reproduced on the maintainer's machine, which runs a Russian system locale:

```
$ osascript -e 'error number -128'
0:17: execution error: Отменено пользователем. (-128)
```

Not one occurrence of `User canceled`. On this machine the old condition never matched, so **every** cancellation was reported as a failure. The same holds for de, es, fr, ja, ko, pt-BR and zh-Hans.

## The fix

Classification moves off the prose and onto the error *number*, which is locale-invariant. Two pure functions carry the whole decision, both reachable from tests without going near a real `NSAppleScript`:

- `CLIInstaller.isUserCancellation(errorNumber: Int?) -> Bool`
- `CLIInstaller.outcome(forScriptError: NSDictionary?) -> PrivilegedScriptOutcome` — `.succeeded` / `.cancelled` / `.failed(message:)`, where only `.failed` has `presentsErrorAlert == true`

Both install and uninstall paths now `switch` on that outcome. `.cancelled` presents **nothing at all** — no alert, no toast.

### Which error number, and how it was confirmed

`userCanceledErr` (**-128**) is what `do shell script … with administrator privileges` reports when the authorization dialog is dismissed. `errAEWaitCanceled` (-1711) and `errAuthorizationCanceled` (-60006) are accepted as the Apple Event and Authorization Services spellings of the same user action, so the classification never depends on which layer surfaced it.

Values were not taken from memory. They were extracted by compiling against `MacOSX.sdk` (Xcode-beta) and printing them: `-128`, `-1711`, `-60006`. All three resolve through `AppKit` + `Foundation`; no new imports were needed. The shape of the error dictionary was confirmed against a live `NSAppleScript`: `NSAppleScriptErrorNumber` → `NSNumber(-128)`, `NSAppleScriptErrorMessage` → the localized text.

## Localization

The eight user-facing English literals this file handed to alerts and toasts — fourteen occurrences, including the two `?? "Unknown error"` fallbacks — move to `Strings.swift` and `Localizable.xcstrings`, translated into all nine locales. Catalog entries were inserted as targeted text (`extractionState: "manual"`, with comments), never reserialized: the diff is exactly +480 lines with zero whitespace noise, and the `normalize-xcstrings.sh` pre-commit hook correctly left the semantic change staged.

New keys — all in **shared** files, so this diff wants to be merged in sequence with other in-flight branches:

| Key | en |
|---|---|
| `cli.error.unknown` | Unknown error |
| `cli.install.failedTitle` | Installation Failed |
| `cli.install.missingScript` | Could not find the pine CLI script in the app bundle. |
| `cli.install.successMessage` | The 'pine' command is now available.\n\nUsage: pine . or pine file.swift |
| `cli.install.successTitle` | Command Line Tool Installed |
| `cli.uninstall.failedTitle` | Uninstall Failed |
| `cli.uninstall.successMessage` | The 'pine' command has been removed from /usr/local/bin. |
| `cli.uninstall.successTitle` | Command Line Tool Removed |

**The eight non-English translations are mine, not a native speaker's.** Terminology was matched to the catalog's existing entries ("Befehlszeilenwerkzeug", "инструмент командной строки", "命令行工具", …), but they are worth a proofread before shipping. Flagging this explicitly rather than burying it in the table — the catalog has no state for "translated but unreviewed": all 706 entries are marked `translated`, and `LocalizationCatalogCompletenessTests` fails on an empty value, so there was no in-project way to mark them as provisional.

## One acceptance criterion was already satisfied

The issue asks for the App-menu items `"About Pine"` and `"Install/Uninstall Command Line Tool…"` to be localized. **They already are.** They are `LocalizedStringKey` literals, Xcode extracted them, and the catalog carries all three with full nine-locale translations — `"About Pine"` (line 211), `"Install Command Line Tool…"` (7355), `"Uninstall Command Line Tool…"` (21452), e.g. "Установить инструмент командной строки…". Migrating them to stable dot-keys was implemented and then deliberately reverted: it would orphan three fully-translated entries for no user-visible gain. That criterion is closed as already met, not skipped.

## Tests

`PineTests/CLIInstallerCancellationTests` — 11 tests over the classification seam: the error-number rule against genuine failure codes and a missing number, the nine localized spellings of the cancellation message, that a cancellation raises no alert, and that a failure code stays a failure even when its text happens to read "User canceled." — the number, not the prose, decides.

Written first, in their own commit, against an API that did not exist yet.

### Mutation verification

Baseline 11/11 green. Every mutation compiles and was run as its own single-class pass.

| # | Mutation | Result | Killed by |
|---|---|---|---|
| M1 | **revert to `message.contains("User canceled")`** | FAILED, 17 issues | localized-text classification (8 locales), no-alert-on-cancel (8), misleading-text-stays-failure |
| M2 | drop `-128` from the set | FAILED | userCanceledErr-is-cancellation, localized-text, no-alert |
| M3 | drop `-1711` and `-60006` | FAILED | related-cancellation-codes |
| M4 | `nil` number treated as cancellation | FAILED | missing-number-is-not-cancellation, numberless-dictionary-is-failure |
| M5 | `nil` dictionary → `.failed` instead of `.succeeded` | FAILED | nil-error-is-success, no-alert |
| M6 | hardcode `"Unknown error"` instead of `Strings.cliErrorUnknown` | FAILED | missing-message-uses-localized-fallback |
| M7 | `presentsErrorAlert` always `true` | FAILED | no-alert-on-cancel |

M6 is worth a second look: it fails only because the test bundle runs under the machine's Russian locale, where `Strings.cliErrorUnknown` resolves to "Неизвестная ошибка". So it proves the new catalog entry is genuinely wired up at runtime, not merely present in the file.

### Verification run

- `swiftlint --strict` — 0 violations, 0 serious across 805 files
- `PineTests/CLIInstallerCancellationTests` — 11/11
- `PineTests/CLIInstallerTests` — 5/5
- `PineTests/LocalizationCatalogCompletenessTests` — 4/4
- `PineTests/AccessibilityLocalizationMatrixTests` — 2/2

## Merge note

This branch touches the shared `Strings.swift` and `Localizable.xcstrings`, and is expected to land after the 2.6.0 tag, sequenced against the other in-flight diffs.
