### PR TITLE
fix(windows): an explicitly opened project outranks a remembered one

### DIFF
--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -119,7 +119,13 @@ private struct AppDelegateBridge: View {
     var body: some View {
         Color.clear.onAppear {
             appDelegate.openNamedWindow = { id in openWindow(id: id) }
-            appDelegate.openProjectWindow = { url in openWindow(value: url) }
+            appDelegate.openProjectWindow = { [registry] url in
+                // Every open that names a project funnels through here, so
+                // this is the one place the intent can be recorded before the
+                // scene reads its persisted "last active project" (#1543).
+                registry.noteExplicitProjectOpenRequest(url)
+                openWindow(value: url)
+            }
 
         }
     }
@@ -129,7 +135,16 @@ private struct AppDelegateBridge: View {
 
 /// Resolves a ProjectManager from the registry and injects it into ContentView.
 /// Also ensures AppDelegate is wired up even when Welcome window is never shown.
-private struct ProjectWindowView: View {
+///
+/// Deliberately **not** `private`. AppKit derives autosave names for the
+/// window's `NSSplitView` from `_typeName` of the scene's content type, and a
+/// `private` type mangles to `Pine.(unknown context at $<address>).ProjectWindowView`
+/// — an address that moves with ASLR on every launch. That made the autosave
+/// key unique per launch, so the sidebar width was never restored and the
+/// preference domain grew by one dead `NSSplitView Subview Frames …` key per
+/// run (#1543). Internal visibility gives the stable name `Pine.ProjectWindowView`.
+/// Covered by `WindowSceneAutosaveIdentityTests`.
+struct ProjectWindowView: View {
     let projectURL: URL
     let registry: ProjectRegistry
     let appDelegate: AppDelegate

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -1143,6 +1143,13 @@ final class ProjectRegistry: LSPSettingsObserver {
         weak var session: ProjectWindowSession?
     }
 
+    /// Projects the user named in an open request that has not yet been
+    /// claimed by the scene it opened. In-memory and per-run on purpose: this
+    /// is intent, not state, and it must never outlive the process that
+    /// recorded it.
+    @ObservationIgnored
+    private var explicitProjectOpenRequests: Set<URL> = []
+
     private static let recentProjectsKey = "recentProjectPaths"
     private static let recentProjectAgentIdentitiesKey =
         "recentProjectAgentTaskIdentities"
@@ -3345,6 +3352,33 @@ final class ProjectRegistry: LSPSettingsObserver {
 
     private func compactWindowSessions() {
         windowSessionRefs.removeAll { $0.session == nil }
+    }
+
+    // MARK: - Explicit open requests
+
+    /// Records that the user asked for `url` by name — Open Folder, Open
+    /// Recent, the Dock menu, a drop, or `PINE_OPEN_PROJECT` — immediately
+    /// before the window for it is opened.
+    ///
+    /// A window remembers which of its projects was last on screen, and a
+    /// scene reopening for the same URL cannot tell "macOS is restoring this
+    /// window" from "the user just picked this project". Without this record
+    /// the remembered project won every time, so a window that had once been
+    /// switched to project B answered every later request for project A with
+    /// B, forever (#1543).
+    func noteExplicitProjectOpenRequest(_ url: URL) {
+        explicitProjectOpenRequests.insert(
+            canonicalProjectURL(url).standardizedFileURL
+        )
+    }
+
+    /// Claims the pending request for `url`, if the user made one. Returns
+    /// true at most once per request: the scene that opens for a request
+    /// spends it, and a genuine restoration afterwards finds nothing.
+    func consumeExplicitProjectOpenRequest(for url: URL) -> Bool {
+        explicitProjectOpenRequests.remove(
+            canonicalProjectURL(url).standardizedFileURL
+        ) != nil
     }
 
     /// Repairs a retained manager when AppKit makes its SwiftUI project scene

--- a/Pine/ProjectWindowSession.swift
+++ b/Pine/ProjectWindowSession.swift
@@ -54,6 +54,11 @@ final class ProjectWindowSession {
     let id = UUID()
     let sceneProjectURL: URL
 
+    /// The project this scene was created for, before any persisted state had
+    /// a say. An explicit open request is matched against this — not against
+    /// ``sceneProjectURL``, which is the anchor of whatever window adopts it.
+    let requestedProjectURL: URL
+
     private(set) var projectURLs: [URL]
     private(set) var managedWorktrees: [URL: AgentManagedWorktree]
     private(set) var activeProjectURL: URL
@@ -66,6 +71,10 @@ final class ProjectWindowSession {
     @ObservationIgnored private var backgroundLeases: [URL: UUID] = [:]
     @ObservationIgnored private var pendingRestoredActiveURL: URL?
     @ObservationIgnored private var didRestore = false
+    /// Whether anything has moved this window off the project its scene was
+    /// created with. Distinguishes a fresh scene from one routing has already
+    /// placed, which decides whether a pending open request still applies.
+    @ObservationIgnored private var didTransition = false
     /// Whether the user closed the project this scene is keyed by. Persisted,
     /// because the reopening scene would otherwise hand that project straight
     /// back on the next launch.
@@ -78,6 +87,7 @@ final class ProjectWindowSession {
         toolResolver: ExternalToolResolver = .fromEnvironment()
     ) {
         let initial = initialProjectURL.standardizedFileURL
+        requestedProjectURL = initial
         self.defaults = defaults
         self.worktreeService = worktreeService
         self.toolResolver = toolResolver
@@ -245,14 +255,50 @@ final class ProjectWindowSession {
     ) async -> ProjectWindowRestorationResult {
         guard !didRestore else { return .alreadyRestored }
         didRestore = true
-        guard let target = pendingRestoredActiveURL else {
+        var pendingTarget = pendingRestoredActiveURL
+        pendingRestoredActiveURL = nil
+        // A named request outranks a remembered one. Restoring the project
+        // this window last showed is right when macOS is putting the window
+        // back, and wrong when the user just picked a project by name — those
+        // two arrive as the same scene, so the request has to say which it is
+        // (#1543).
+        //
+        // Spend the request either way, but only act on it while this window
+        // is still where its scene left it: routing (the Agent Inbox, a
+        // notification) can reach a scene before its restore task runs, and a
+        // request must not undo a placement the window has already made.
+        let hasExplicitRequest = registry.consumeExplicitProjectOpenRequest(
+            for: requestedProjectURL
+        )
+        if hasExplicitRequest, !didTransition {
+            readmitRequestedProject()
+            pendingTarget = requestedProjectURL
+        }
+        guard let target = pendingTarget else {
             return .unavailable
         }
-        pendingRestoredActiveURL = nil
         await activate(target, registry: registry, reportFailure: false)
-        return registry.projectManagerIfAdmitted(for: activeProjectURL) == nil
-            ? .unavailable
-            : .restored
+        guard registry.projectManagerIfAdmitted(for: activeProjectURL) != nil
+        else { return .unavailable }
+        // `activate` only persists when it actually switches, and the common
+        // case here is that it did not have to. Write the honoured request
+        // through anyway so the window stops remembering a project the user
+        // has moved off.
+        saveState()
+        return .restored
+    }
+
+    /// Puts the requested project back into this window's membership when the
+    /// user closed it out of the window earlier. Reopening a project by name
+    /// asks for it to be here again; without this the scene would restore with
+    /// the project absent from `projectURLs` and nothing to show.
+    private func readmitRequestedProject() {
+        guard managedWorktrees[requestedProjectURL] == nil,
+              !projectURLs.contains(requestedProjectURL) else { return }
+        projectURLs.insert(requestedProjectURL, at: 0)
+        if requestedProjectURL == sceneProjectURL {
+            didCloseAnchor = false
+        }
     }
 
     func openProject(
@@ -527,6 +573,7 @@ final class ProjectWindowSession {
         }
         _ = registry.reconcileKeyProjectPresentation(manager)
         activeProjectURL = target
+        didTransition = true
         saveState()
     }
 

--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -875,6 +875,9 @@ struct SidebarView: View {
     private func openNewProject() {
         Task { @MainActor in
             guard let url = await registry.openProjectViaPanel(for: projectManager) else { return }
+            // The picked folder is what the new window must show, whatever a
+            // window anchored there last had on screen (#1543).
+            registry.noteExplicitProjectOpenRequest(url)
             openWindow(value: url)
         }
     }

--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -513,6 +513,10 @@ struct WelcomeView: View {
         if let open = appDelegate?.openProjectWindow {
             open(url)
         } else {
+            // Same record the AppDelegate closure makes: without it the
+            // fallback path lets a window's remembered project override the
+            // one the user picked (#1543).
+            registry.noteExplicitProjectOpenRequest(url)
             openWindow(value: url)
         }
     }

--- a/PineTests/ProjectWindowSessionTests.swift
+++ b/PineTests/ProjectWindowSessionTests.swift
@@ -104,6 +104,225 @@ struct ProjectWindowSessionTests {
         )
     }
 
+    /// #1543: a window anchored at project A that the user last switched to
+    /// project B persists `activeURL = B`. Every later *explicit* open of A —
+    /// Open Folder, Open Recent, the Dock menu, `PINE_OPEN_PROJECT` — created
+    /// a scene keyed by A and then restored B over it, so the user got a
+    /// project they never asked for and the state never healed itself.
+    @Test("an explicit open shows the requested project, not the last active one")
+    func explicitOpenBeatsPersistedActiveProject() async throws {
+        let fixture = try ProjectWindowSessionFixture()
+        defer { fixture.cleanup() }
+        let firstRegistry = fixture.makeRegistry()
+        _ = try #require(
+            firstRegistry.projectManager(for: fixture.firstProject)
+        )
+        let session = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+        await session.openProject(
+            fixture.secondProject,
+            registry: firstRegistry
+        )
+        #expect(
+            session.activeProjectURL
+                == fixture.secondProject.standardizedFileURL
+        )
+        session.windowDidClose(registry: firstRegistry)
+
+        let registry = fixture.makeRegistry()
+        registry.noteExplicitProjectOpenRequest(fixture.firstProject)
+        let reopened = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+
+        #expect(
+            await reopened.restoreIfNeeded(registry: registry) == .restored
+        )
+        #expect(
+            reopened.activeProjectURL
+                == fixture.firstProject.standardizedFileURL
+        )
+        #expect(
+            registry.projectManagerIfAdmitted(for: fixture.firstProject) != nil
+        )
+        // The window keeps its membership: only the active project changed.
+        #expect(reopened.projectURLs == [
+            fixture.firstProject.standardizedFileURL,
+            fixture.secondProject.standardizedFileURL,
+        ])
+    }
+
+    /// The other half of #1543: with no explicit request in flight the scene
+    /// is genuine window restoration, and restoring the project the window
+    /// was last showing stays correct.
+    @Test("restoration with no explicit request still restores the active project")
+    func restorationWithoutRequestKeepsPersistedActiveProject() async throws {
+        let fixture = try ProjectWindowSessionFixture()
+        defer { fixture.cleanup() }
+        let firstRegistry = fixture.makeRegistry()
+        _ = try #require(
+            firstRegistry.projectManager(for: fixture.firstProject)
+        )
+        let session = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+        await session.openProject(
+            fixture.secondProject,
+            registry: firstRegistry
+        )
+        session.windowDidClose(registry: firstRegistry)
+
+        let registry = fixture.makeRegistry()
+        let restored = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+        _ = await restored.restoreIfNeeded(registry: registry)
+
+        #expect(
+            restored.activeProjectURL
+                == fixture.secondProject.standardizedFileURL
+        )
+    }
+
+    /// An explicit request is spent by the scene it opened. A second scene for
+    /// the same anchor — a real restoration — must not inherit it.
+    @Test("an explicit open request is consumed by exactly one scene")
+    func explicitOpenRequestIsConsumedOnce() async throws {
+        let fixture = try ProjectWindowSessionFixture()
+        defer { fixture.cleanup() }
+        let firstRegistry = fixture.makeRegistry()
+        _ = try #require(
+            firstRegistry.projectManager(for: fixture.firstProject)
+        )
+        let session = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+        await session.openProject(
+            fixture.secondProject,
+            registry: firstRegistry
+        )
+        session.windowDidClose(registry: firstRegistry)
+
+        let registry = fixture.makeRegistry()
+        registry.noteExplicitProjectOpenRequest(fixture.firstProject)
+        #expect(
+            registry.consumeExplicitProjectOpenRequest(
+                for: fixture.firstProject
+            )
+        )
+        #expect(
+            !registry.consumeExplicitProjectOpenRequest(
+                for: fixture.firstProject
+            )
+        )
+
+        let restored = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+        _ = await restored.restoreIfNeeded(registry: registry)
+
+        #expect(
+            restored.activeProjectURL
+                == fixture.secondProject.standardizedFileURL
+        )
+    }
+
+    /// Routing (Agent Inbox, a notification) can reach a scene before its
+    /// restore task runs. A request still pending from the open that created
+    /// the scene must not pull the window back off what routing placed.
+    @Test("routing that placed a window first is not undone by a pending request")
+    func routingBeforeRestoreOutranksPendingRequest() async throws {
+        let fixture = try ProjectWindowSessionFixture()
+        defer { fixture.cleanup() }
+        let firstRegistry = fixture.makeRegistry()
+        _ = try #require(
+            firstRegistry.projectManager(for: fixture.firstProject)
+        )
+        let session = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+        await session.openProject(
+            fixture.secondProject,
+            registry: firstRegistry
+        )
+        session.windowDidClose(registry: firstRegistry)
+
+        let registry = fixture.makeRegistry()
+        registry.noteExplicitProjectOpenRequest(fixture.firstProject)
+        let reopened = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+        await reopened.activate(fixture.secondProject, registry: registry)
+        #expect(
+            reopened.activeProjectURL
+                == fixture.secondProject.standardizedFileURL
+        )
+
+        _ = await reopened.restoreIfNeeded(registry: registry)
+
+        #expect(
+            reopened.activeProjectURL
+                == fixture.secondProject.standardizedFileURL
+        )
+    }
+
+    /// A project explicitly reopened after the user closed it out of its own
+    /// anchor window rejoins that window instead of arriving as a scene with
+    /// nothing to show.
+    @Test("an explicit open readmits a project closed out of its anchor window")
+    func explicitOpenReadmitsClosedAnchor() async throws {
+        let fixture = try ProjectWindowSessionFixture()
+        defer { fixture.cleanup() }
+        let firstRegistry = fixture.makeRegistry()
+        _ = try #require(
+            firstRegistry.projectManager(for: fixture.firstProject)
+        )
+        let session = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+        await session.openProject(
+            fixture.secondProject,
+            registry: firstRegistry
+        )
+        #expect(
+            await session.closeProject(
+                fixture.firstProject,
+                registry: firstRegistry
+            )
+        )
+        session.windowDidClose(registry: firstRegistry)
+
+        let registry = fixture.makeRegistry()
+        registry.noteExplicitProjectOpenRequest(fixture.firstProject)
+        let reopened = ProjectWindowSession(
+            initialProjectURL: fixture.firstProject,
+            defaults: fixture.defaults
+        )
+
+        #expect(
+            await reopened.restoreIfNeeded(registry: registry) == .restored
+        )
+        #expect(
+            reopened.activeProjectURL
+                == fixture.firstProject.standardizedFileURL
+        )
+        #expect(
+            reopened.projectURLs.contains(
+                fixture.firstProject.standardizedFileURL
+            )
+        )
+    }
+
     @Test("switching keeps each project alive and restores the active project")
     func switchingAndRestoration() async throws {
         let fixture = try ProjectWindowSessionFixture()

--- a/PineTests/WindowSceneAutosaveIdentityTests.swift
+++ b/PineTests/WindowSceneAutosaveIdentityTests.swift
@@ -1,0 +1,48 @@
+//
+//  WindowSceneAutosaveIdentityTests.swift
+//  PineTests
+//
+
+import Testing
+
+@testable import Pine
+
+/// #1543 (second defect): AppKit builds `NSSplitView` autosave keys out of
+/// `_typeName` of the SwiftUI scene's content type. A `private` (or otherwise
+/// file-scoped) type has no stable mangled name — the runtime prints
+/// `(unknown context at $<address>)`, and the address moves with ASLR — so the
+/// key was different on every launch. Two consequences on Fedor's machine:
+/// the sidebar width never survived a relaunch, and
+/// `io.github.batonogov.pine` had accumulated 746 dead
+/// `NSSplitView Subview Frames …` keys across 707 distinct launches.
+@Suite("Window Scene Autosave Identity")
+struct WindowSceneAutosaveIdentityTests {
+    @Test("the project scene's content type has a launch-stable name")
+    func projectSceneTypeNameIsStable() {
+        #expect(_typeName(ProjectWindowView.self) == "Pine.ProjectWindowView")
+    }
+
+    /// The autosave key embeds the scene content type inside the generic
+    /// `Optional<…>` `WindowGroup(for:)` wraps it in, which is the exact
+    /// substring that carried the address in the leaked keys. Asserting the
+    /// wrapped form too catches a regression that leaves the type itself
+    /// nameable but moves it under a file-scoped parent.
+    @Test("the wrapped scene type name matches the autosave key shape")
+    func wrappedSceneTypeNameIsStable() {
+        #expect(
+            _typeName(ProjectWindowView?.self)
+                == "Swift.Optional<Pine.ProjectWindowView>"
+        )
+    }
+
+    /// Proves the assertion above can fail: the exact mangling that caused the
+    /// leak is still detectable, so this suite is not asserting a tautology.
+    @Test("a file-scoped type still mangles to an address-bearing name")
+    func fileScopedTypeNameCarriesLaunchVaryingContext() {
+        let name = _typeName(FileScopedControlView.self)
+        #expect(name.contains("unknown context at"))
+        #expect(name != "PineTests.FileScopedControlView")
+    }
+}
+
+private struct FileScopedControlView {}


### PR DESCRIPTION
## Summary

- A project the user names — Open Folder, Open Recent, the Welcome list, the Dock menu, the sidebar's Open Folder, `PINE_OPEN_PROJECT` — now outranks the project a window remembers. Previously a multi-project window answered every request for its anchor project with whichever project it last displayed, and wrote that answer back, so the state never healed.
- The project window's scene content type is no longer `private`, so its `NSSplitView` autosave key stops embedding an ASLR-dependent memory address. The sidebar width is restored across launches again, and the preference domain stops growing by one dead key per launch.

## Related issue

Closes #1552
Closes #1553

