### PR TITLE
fix(a11y): make PineAnimation consult Reduce Motion centrally

### DIFF
--- a/Pine/CommandOverlayView.swift
+++ b/Pine/CommandOverlayView.swift
@@ -20,10 +20,33 @@ struct CommandOverlayView<Content: View>: View {
     /// Optional cleanup invoked by every container-owned dismissal path
     /// (backdrop click and Escape) after the binding is cleared.
     var onDismiss: () -> Void = {}
+    /// Forces the motion preference. Production leaves this `nil` and reads the
+    /// environment; tests pin a branch with it, mirroring
+    /// `GlobalTabSwitcherOverlay`.
+    var reduceMotionOverride: Bool?
+    /// Reports the resolved presentation so hosted tests can verify that the
+    /// geometry component is really gone, rather than that a helper was called.
+    var observeMotion: (PineAnimation.OverlayPresentation) -> Void = { _ in }
     @ViewBuilder var content: () -> Content
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// The motion preference this overlay actually obeys.
+    var effectiveReduceMotion: Bool {
+        reduceMotionOverride ?? reduceMotion
+    }
+
+    /// Curve used by `dismiss()`. `nil` under Reduce Motion, so the overlay
+    /// disappears immediately instead of springing away.
+    var dismissalAnimation: Animation? {
+        PineAnimation.overlay(reduceMotion: effectiveReduceMotion)
+    }
+
     var body: some View {
-        ZStack {
+        let presentation = PineAnimation.OverlayPresentation.resolve(
+            reduceMotion: effectiveReduceMotion
+        )
+        return ZStack {
             // Translucent backdrop: dimmed to focus attention, captures clicks to dismiss.
             Color.primary.opacity(0.15)
                 .ignoresSafeArea()
@@ -40,10 +63,18 @@ struct CommandOverlayView<Content: View>: View {
                         .shadow(color: .black.opacity(0.2), radius: 24, y: 6)
                 }
                 .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                // Opacity-only under Reduce Motion: a cross-fade is the HIG
+                // replacement for a scale, and the scale is what moves.
+                .transition(PineAnimation.overlayTransition(presentation))
         }
-        .animation(PineAnimation.overlay, value: isPresented)
+        .animation(presentation.animation, value: isPresented)
         .accessibilityAddTraits(.isModal)
+        .onAppear {
+            observeMotion(presentation)
+        }
+        .onChange(of: presentation) { _, newPresentation in
+            observeMotion(newPresentation)
+        }
         .onExitCommand {
             dismiss()
         }
@@ -54,7 +85,7 @@ struct CommandOverlayView<Content: View>: View {
     /// focused content to this container.
     func dismiss() {
         guard isPresented else { return }
-        withAnimation(PineAnimation.overlay) {
+        withAnimation(dismissalAnimation) {
             isPresented = false
         }
         onDismiss()

--- a/Pine/GlobalTabSwitcherOverlay.swift
+++ b/Pine/GlobalTabSwitcherOverlay.swift
@@ -316,7 +316,10 @@ struct GlobalTabSwitcherOverlay: View {
         let usesAnimation = animated && !reduceMotion
         observeScroll(entries[selectedIndex].id, usesAnimation)
         if usesAnimation {
-            withAnimation(PineAnimation.quick) {
+            // Pass the resolved preference rather than reading the ambient one,
+            // so a hosted test that forces `reduceMotionOverride` gets the
+            // animation that override implies (#1534).
+            withAnimation(PineAnimation.quick(reduceMotion: reduceMotion)) {
                 proxy.scrollTo(selectedIndex, anchor: .center)
             }
         } else {

--- a/Pine/PineAnimation.swift
+++ b/Pine/PineAnimation.swift
@@ -3,31 +3,234 @@
 //  Pine
 //
 //  Standardized motion system for consistent animations across the app.
-//  Follows Apple HIG: subtle, purposeful motion that communicates hierarchy.
+//  Follows Apple HIG: subtle, purposeful motion that communicates hierarchy,
+//  and no motion at all when the system asks for less of it.
+//
+//  Issue #1534: this used to be a plain constant table. Honouring Reduce Motion
+//  was therefore optional at every call site, and most call sites skipped it —
+//  a per-site obligation that thirty-one sites can only ever fulfil thirty of.
+//  The Reduce Motion consultation now lives here, so `PineAnimation.quick`
+//  already means "quick, unless the user asked for less movement".
 //
 
+import AppKit
 import SwiftUI
+
+/// What an animation is capable of moving on screen.
+///
+/// The distinction is the whole Reduce Motion policy: geometry is what a
+/// vestibular disorder reacts to, a cross-fade is not. HIG asks for movement to
+/// be *replaced* by a cross-fade, not merely shortened.
+enum PineMotionIntent: Equatable, Sendable {
+    /// The animation can move, scale, spring, or scroll something.
+    case geometry
+    /// The animation only cross-fades opacity or colour; nothing moves.
+    case crossFade
+}
+
+/// The single ambient answer to "is Reduce Motion on right now".
+///
+/// SwiftUI views should prefer `@Environment(\.accessibilityReduceMotion)`,
+/// which is reactive and overridable per view — see `GlobalTabSwitcherOverlay`.
+/// This type exists for the code that has no environment to read: helper
+/// methods, notification observers, and the ambient `PineAnimation` accessors
+/// that keep the existing call sites correct without an edit each.
+///
+/// The system value is read live rather than cached. `PineAnimation` values are
+/// only read while SwiftUI evaluates a body in response to the state change
+/// being animated, so a live read is both cheap and always current — including
+/// when the user flips the setting while Pine is running.
+enum PineMotionPreference {
+    /// The live system reading.
+    ///
+    /// Kept as a named closure rather than inlined into `reduceMotion` so a
+    /// test can substitute it and prove that the returned value really does
+    /// track its source. An inlined `NSWorkspace` read is untestable on a
+    /// machine whose Reduce Motion happens to be off: every wrong answer and
+    /// the right answer are both `false`.
+    static let systemSource: () -> Bool = {
+        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+    }
+
+    /// Where `reduceMotion` currently gets its answer. Production never assigns
+    /// this; `withSource(_:perform:)` and `withOverride(_:perform:)` are the
+    /// only supported ways to change it and both always restore the previous
+    /// value. Main-actor isolated by the target's default isolation, like every
+    /// consumer of the preference.
+    private static var source: () -> Bool = systemSource
+
+    /// `true` when System Settings › Accessibility › Display › Reduce Motion
+    /// is enabled.
+    ///
+    /// Read on every access, never cached, so a user who flips the setting
+    /// while Pine is running gets the new behaviour at the next state change.
+    static var reduceMotion: Bool {
+        source()
+    }
+
+    /// Runs `body` with the preference forced to `value`, restoring the
+    /// previous source on every exit path including a thrown error.
+    @discardableResult
+    static func withOverride<Result>(
+        _ value: Bool,
+        perform body: () throws -> Result
+    ) rethrows -> Result {
+        try withSource({ value }, perform: body)
+    }
+
+    /// Runs `body` with the preference answered by `newSource`, restoring the
+    /// previous source on every exit path including a thrown error.
+    @discardableResult
+    static func withSource<Result>(
+        _ newSource: @escaping () -> Bool,
+        perform body: () throws -> Result
+    ) rethrows -> Result {
+        let previous = source
+        source = newSource
+        defer { source = previous }
+        return try body()
+    }
+}
 
 /// Centralized animation constants for Pine.
 /// Use these instead of ad-hoc animation values throughout the codebase.
 enum PineAnimation {
-    // MARK: - Quick Transitions (tab switch, sidebar toggle, state changes)
+
+    // MARK: - Base Curves
+
+    // The design tokens. These describe what Pine looks like when the user has
+    // not asked for less motion; nothing outside this file should read them
+    // directly except to state an expectation about them.
 
     /// Fast easeInOut for immediate UI responses (tab switch, sidebar toggle, indicators).
-    static let quick: Animation = .easeInOut(duration: 0.2)
-
-    // MARK: - Overlay Transitions (sheets, popovers, overlays)
+    static let quickCurve: Animation = .easeInOut(duration: 0.2)
 
     /// Spring animation for overlays (Quick Open, Go to Line, branch switcher).
-    static let overlay: Animation = .spring(response: 0.3, dampingFraction: 0.9)
-
-    // MARK: - Content Transitions (content appearing/disappearing)
+    static let overlayCurve: Animation = .spring(response: 0.3, dampingFraction: 0.9)
 
     /// Standard content transition for views that swap between states.
-    static let content: Animation = .easeInOut(duration: 0.25)
+    static let contentCurve: Animation = .easeInOut(duration: 0.25)
+
+    /// The only curve Pine plays while Reduce Motion is on: a short, plain
+    /// cross-fade. Never a spring — a spring overshoots, and overshoot is
+    /// movement.
+    static let reducedCrossFade: Animation = .easeInOut(duration: 0.15)
+
+    /// How far an overlay scales up from while it appears.
+    static let overlayScale: CGFloat = 0.96
+
+    // MARK: - Policy
+
+    /// Applies Pine's Reduce Motion policy to a base curve.
+    ///
+    /// - Geometry becomes `nil`: SwiftUI applies the new state immediately.
+    ///   A shorter or more damped spring is not an acceptable substitute —
+    ///   it is still movement.
+    /// - A cross-fade survives, de-sprung, because HIG asks for movement to be
+    ///   replaced by a cross-fade rather than by a hard cut.
+    static func resolve(
+        _ base: Animation,
+        intent: PineMotionIntent,
+        reduceMotion: Bool
+    ) -> Animation? {
+        guard reduceMotion else { return base }
+        switch intent {
+        case .geometry:
+            return nil
+        case .crossFade:
+            return reducedCrossFade
+        }
+    }
+
+    // MARK: - Explicit-preference accessors
+
+    // Preferred inside SwiftUI views, which can pass the environment value (or
+    // a test override) instead of the ambient system reading.
+
+    /// Quick transitions. Drives `scrollTo` and the sidebar column width, so it
+    /// is classified as geometry.
+    static func quick(reduceMotion: Bool) -> Animation? {
+        resolve(quickCurve, intent: .geometry, reduceMotion: reduceMotion)
+    }
+
+    /// Overlay presentation. A spring, therefore geometry by construction.
+    static func overlay(reduceMotion: Bool) -> Animation? {
+        resolve(overlayCurve, intent: .geometry, reduceMotion: reduceMotion)
+    }
+
+    /// Content swaps. Only ever drives opacity in Pine, so it stays as a
+    /// cross-fade under Reduce Motion.
+    static func content(reduceMotion: Bool) -> Animation? {
+        resolve(contentCurve, intent: .crossFade, reduceMotion: reduceMotion)
+    }
+
+    // MARK: - Ambient accessors
+
+    // These keep every existing `PineAnimation.quick` call site correct without
+    // asking it to remember the setting. `Animation?` is what both
+    // `withAnimation(_:_:)` and `.animation(_:value:)` accept, so `nil` means
+    // "apply now" at every one of them.
+
+    /// Fast easeInOut for immediate UI responses, or no animation at all while
+    /// Reduce Motion is on.
+    static var quick: Animation? {
+        quick(reduceMotion: PineMotionPreference.reduceMotion)
+    }
+
+    /// Spring animation for overlays, or no animation at all while Reduce
+    /// Motion is on.
+    static var overlay: Animation? {
+        overlay(reduceMotion: PineMotionPreference.reduceMotion)
+    }
+
+    /// Standard content transition, degraded to a plain cross-fade while
+    /// Reduce Motion is on.
+    static var content: Animation? {
+        content(reduceMotion: PineMotionPreference.reduceMotion)
+    }
 
     // MARK: - Standard Transitions
 
-    /// Opacity fade for appearing/disappearing content.
+    /// Opacity fade for appearing/disappearing content. Safe under Reduce
+    /// Motion at any time: nothing moves.
     static let fadeTransition: AnyTransition = .opacity
+
+    // MARK: - Overlay presentation
+
+    /// The resolved description of how a command overlay appears.
+    ///
+    /// Modelled as an `Equatable` value rather than an `AnyTransition` (which
+    /// cannot be compared) so a test can assert that the scale component is
+    /// actually gone, and so the production transition below is built from the
+    /// same decision the test inspects.
+    struct OverlayPresentation: Equatable, Sendable {
+        /// The cross-fade component. Always present — it is what replaces the
+        /// scale under Reduce Motion.
+        let usesOpacity: Bool
+        /// The scale the overlay grows from, or `nil` when geometry is barred.
+        let scale: CGFloat?
+        /// The curve driving the presentation, or `nil` for an instant swap.
+        let animation: Animation?
+
+        /// `true` when the presentation still moves something on screen.
+        var usesGeometry: Bool { scale != nil }
+
+        static func resolve(reduceMotion: Bool) -> Self {
+            Self(
+                usesOpacity: true,
+                scale: reduceMotion ? nil : PineAnimation.overlayScale,
+                animation: PineAnimation.overlay(reduceMotion: reduceMotion)
+            )
+        }
+    }
+
+    /// Builds the SwiftUI transition described by `presentation`.
+    static func overlayTransition(
+        _ presentation: OverlayPresentation
+    ) -> AnyTransition {
+        guard let scale = presentation.scale else {
+            return .opacity
+        }
+        return .opacity.combined(with: .scale(scale: scale))
+    }
 }

--- a/PineTests/CommandOverlayViewTests.swift
+++ b/PineTests/CommandOverlayViewTests.swift
@@ -56,6 +56,70 @@ struct CommandOverlayViewTests {
         #expect(cleanupCount == 1)
     }
 
+    // MARK: - CommandOverlayView Reduce Motion (#1534)
+
+    @MainActor
+    private final class MotionRecorder {
+        var presentations: [PineAnimation.OverlayPresentation] = []
+
+        func record(_ presentation: PineAnimation.OverlayPresentation) {
+            presentations.append(presentation)
+        }
+    }
+
+    @Test(
+        "Hosted overlay presents without geometry under Reduce Motion",
+        arguments: [false, true]
+    )
+    func overlayPresentationFollowsMotionPreference(
+        _ reduceMotion: Bool
+    ) throws {
+        let recorder = MotionRecorder()
+        let hosted = NSHostingView(
+            rootView: CommandOverlayView(
+                isPresented: .constant(true),
+                reduceMotionOverride: reduceMotion,
+                observeMotion: { recorder.record($0) },
+                content: { Text(verbatim: "content") }
+            )
+        )
+        hosted.frame = NSRect(x: 0, y: 0, width: 320, height: 200)
+        hosted.layoutSubtreeIfNeeded()
+        drainMainRunLoop()
+        hosted.layoutSubtreeIfNeeded()
+
+        let presentation = try #require(recorder.presentations.last)
+        #expect(presentation.usesGeometry == !reduceMotion)
+        #expect(presentation.scale == (reduceMotion ? nil : PineAnimation.overlayScale))
+        #expect(presentation.animation == (reduceMotion ? nil : PineAnimation.overlayCurve))
+        // The cross-fade replaces the scale rather than disappearing with it.
+        #expect(presentation.usesOpacity)
+        withExtendedLifetime(hosted) {}
+    }
+
+    @Test(
+        "Overlay dismissal animates only when motion is allowed",
+        arguments: [false, true]
+    )
+    func dismissalAnimationFollowsMotionPreference(_ reduceMotion: Bool) {
+        var isPresented = true
+        let overlay = CommandOverlayView(
+            isPresented: Binding(
+                get: { isPresented },
+                set: { isPresented = $0 }
+            ),
+            reduceMotionOverride: reduceMotion,
+            content: { Text(verbatim: "content") }
+        )
+
+        #expect(
+            overlay.dismissalAnimation
+                == (reduceMotion ? nil : PineAnimation.overlayCurve)
+        )
+        overlay.dismiss()
+        #expect(!isPresented)
+    }
+
     // MARK: - GoToLineView accessibility
 
     @Test("GoToLineView has invalid message accessibility identifier")

--- a/PineTests/PineAnimationReduceMotionTests.swift
+++ b/PineTests/PineAnimationReduceMotionTests.swift
@@ -1,0 +1,277 @@
+//
+//  PineAnimationReduceMotionTests.swift
+//  PineTests
+//
+//  Issue #1534: `PineAnimation` used to be a plain constant table, so honouring
+//  Reduce Motion was optional at every call site and most call sites skipped it.
+//  These tests pin the centralised policy: what the helper hands to SwiftUI must
+//  differ by motion preference, not merely be "available" to a caller who
+//  remembers to ask.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+@Suite("PineAnimation Reduce Motion policy", .serialized)
+@MainActor
+struct PineAnimationReduceMotionTests {
+
+    // MARK: - Policy: geometry
+
+    /// Every base curve the app ships. Declared as a property rather than as
+    /// `@Test(arguments:)` because the attribute expression is evaluated
+    /// outside the suite's main-actor isolation.
+    private var baseCurves: [Animation] {
+        [
+            PineAnimation.quickCurve,
+            PineAnimation.overlayCurve,
+            PineAnimation.contentCurve,
+        ]
+    }
+
+    @Test("Geometry motion resolves to no animation under Reduce Motion")
+    func geometryIsSuppressed() {
+        for curve in baseCurves {
+            #expect(
+                PineAnimation.resolve(
+                    curve,
+                    intent: .geometry,
+                    reduceMotion: true
+                ) == nil
+            )
+        }
+    }
+
+    @Test("A suppressed geometry animation is instant, not merely shorter")
+    func geometryIsInstantNotDamped() {
+        let resolved = PineAnimation.resolve(
+            PineAnimation.overlayCurve,
+            intent: .geometry,
+            reduceMotion: true
+        )
+        // `nil` is the only value SwiftUI treats as "apply the new state now".
+        // Any non-nil animation — however short or however damped — still plays
+        // the spring's overshoot, which is exactly what a vestibular disorder
+        // reacts to.
+        #expect(resolved == nil)
+        #expect(resolved != PineAnimation.reducedCrossFade)
+        #expect(resolved != PineAnimation.overlayCurve)
+    }
+
+    // MARK: - Policy: cross-fade
+
+    @Test("Cross-fades survive Reduce Motion as a plain curve")
+    func crossFadeSurvivesAsPlainCurve() {
+        let resolved = PineAnimation.resolve(
+            PineAnimation.contentCurve,
+            intent: .crossFade,
+            reduceMotion: true
+        )
+        // HIG: replace movement with a cross-fade rather than a hard cut.
+        #expect(resolved != nil)
+        #expect(resolved == PineAnimation.reducedCrossFade)
+        // ...but never with the spring, which overshoots.
+        #expect(resolved != PineAnimation.overlayCurve)
+    }
+
+    // MARK: - Policy: motion allowed
+
+    @Test("Reduce Motion off returns the base curve untouched")
+    func basePreservedWhenMotionAllowed() {
+        for curve in baseCurves {
+            #expect(
+                PineAnimation.resolve(
+                    curve,
+                    intent: .geometry,
+                    reduceMotion: false
+                ) == curve
+            )
+            #expect(
+                PineAnimation.resolve(
+                    curve,
+                    intent: .crossFade,
+                    reduceMotion: false
+                ) == curve
+            )
+        }
+    }
+
+    // MARK: - Explicit-preference accessors
+
+    @Test("Explicit accessors carry the same policy as resolve")
+    func explicitAccessorsMatchPolicy() {
+        #expect(PineAnimation.quick(reduceMotion: true) == nil)
+        #expect(PineAnimation.overlay(reduceMotion: true) == nil)
+        #expect(
+            PineAnimation.content(reduceMotion: true)
+                == PineAnimation.reducedCrossFade
+        )
+
+        #expect(
+            PineAnimation.quick(reduceMotion: false)
+                == PineAnimation.quickCurve
+        )
+        #expect(
+            PineAnimation.overlay(reduceMotion: false)
+                == PineAnimation.overlayCurve
+        )
+        #expect(
+            PineAnimation.content(reduceMotion: false)
+                == PineAnimation.contentCurve
+        )
+    }
+
+    // MARK: - Ambient accessors (the 31 existing call sites)
+
+    @Test("Ambient accessors go instant under Reduce Motion")
+    func ambientAccessorsRespectPreference() {
+        PineMotionPreference.withOverride(true) {
+            #expect(PineAnimation.quick == nil)
+            #expect(PineAnimation.overlay == nil)
+            #expect(PineAnimation.content == PineAnimation.reducedCrossFade)
+        }
+
+        PineMotionPreference.withOverride(false) {
+            #expect(PineAnimation.quick == PineAnimation.quickCurve)
+            #expect(PineAnimation.overlay == PineAnimation.overlayCurve)
+            #expect(PineAnimation.content == PineAnimation.contentCurve)
+        }
+    }
+
+    @Test("The ambient preference returns whatever its source says")
+    func ambientPreferenceTracksItsSource() {
+        // The value must come from the source, not from a hard-coded default.
+        // Asserting both directions is what makes this non-tautological on a
+        // machine whose own Reduce Motion is off.
+        PineMotionPreference.withSource({ true }, perform: {
+            #expect(PineMotionPreference.reduceMotion)
+        })
+        PineMotionPreference.withSource({ false }, perform: {
+            #expect(!PineMotionPreference.reduceMotion)
+        })
+    }
+
+    @Test("The preference is re-read on every access, never cached")
+    func ambientPreferenceIsNotCached() {
+        let counter = CallCounter()
+        PineMotionPreference.withSource({ counter.next() }, perform: {
+            // Someone who flips the setting mid-session must not have to
+            // relaunch Pine to be believed.
+            #expect(PineAnimation.quick == nil)
+            #expect(PineAnimation.quick == PineAnimation.quickCurve)
+            #expect(PineAnimation.quick == nil)
+        })
+        #expect(counter.count == 3)
+    }
+
+    @Test("The default source is the live system setting")
+    func defaultSourceIsTheSystem() {
+        // Deliberately weak: on a machine (or CI runner) with Reduce Motion
+        // off, every wrong answer is also `false`. Its only job is to catch a
+        // hard-coded default; the two tests above carry the real weight.
+        #expect(
+            PineMotionPreference.systemSource()
+                == NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+        )
+        #expect(
+            PineMotionPreference.reduceMotion
+                == NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+        )
+    }
+
+    /// Counts how often the motion source is consulted, and alternates its
+    /// answer so a cached read is visible as a wrong animation rather than
+    /// only as a wrong call count.
+    private final class CallCounter {
+        private(set) var count = 0
+
+        func next() -> Bool {
+            count += 1
+            return count.isMultiple(of: 2) == false
+        }
+    }
+
+    @Test("A scoped override never leaks past its body")
+    func overrideIsScoped() {
+        let ambient = PineMotionPreference.reduceMotion
+        PineMotionPreference.withOverride(!ambient) {
+            #expect(PineMotionPreference.reduceMotion == !ambient)
+            PineMotionPreference.withOverride(ambient) {
+                #expect(PineMotionPreference.reduceMotion == ambient)
+            }
+            #expect(PineMotionPreference.reduceMotion == !ambient)
+        }
+        #expect(PineMotionPreference.reduceMotion == ambient)
+    }
+
+    @Test("A throwing body still restores the previous override")
+    func overrideRestoredOnThrow() {
+        struct Boom: Error {}
+        let ambient = PineMotionPreference.reduceMotion
+        #expect(throws: Boom.self) {
+            try PineMotionPreference.withOverride(!ambient) {
+                throw Boom()
+            }
+        }
+        #expect(PineMotionPreference.reduceMotion == ambient)
+    }
+
+    // MARK: - Overlay presentation
+
+    @Test("Overlay presentation drops its scale component under Reduce Motion")
+    func overlayPresentationDropsScale() {
+        let reduced = PineAnimation.OverlayPresentation.resolve(
+            reduceMotion: true
+        )
+        #expect(reduced.scale == nil)
+        #expect(!reduced.usesGeometry)
+        // The cross-fade is what replaces the scale, so it must remain.
+        #expect(reduced.usesOpacity)
+        #expect(reduced.animation == nil)
+
+        let full = PineAnimation.OverlayPresentation.resolve(
+            reduceMotion: false
+        )
+        #expect(full.scale == PineAnimation.overlayScale)
+        #expect(full.usesGeometry)
+        #expect(full.usesOpacity)
+        #expect(full.animation == PineAnimation.overlayCurve)
+    }
+
+    @Test("The two overlay presentations are distinguishable")
+    func overlayPresentationsDiffer() {
+        #expect(
+            PineAnimation.OverlayPresentation.resolve(reduceMotion: true)
+                != PineAnimation.OverlayPresentation.resolve(
+                    reduceMotion: false
+                )
+        )
+    }
+
+    // MARK: - The `.center` sidebar policy must be untouched
+
+    @Test("Sidebar keyboard navigation is still unanimated and nearest-edge")
+    func sidebarKeyboardPolicyUnchanged() {
+        let request = SidebarScrollRequest.keyboardSelection(
+            URL(fileURLWithPath: "/tmp/a.swift")
+        )
+        #expect(request.alignment == .nearestEdge)
+        #expect(request.motion == .immediate)
+    }
+
+    @Test(
+        "Intentional reveal keeps .center and becomes immediate under Reduce Motion",
+        arguments: [false, true]
+    )
+    func sidebarRevealPolicyUnchanged(_ reduceMotion: Bool) {
+        let request = SidebarScrollRequest.intentionalReveal(
+            URL(fileURLWithPath: "/tmp/a.swift"),
+            reduceMotion: reduceMotion
+        )
+        #expect(request.alignment == .center)
+        #expect(request.motion == (reduceMotion ? .immediate : .animated))
+    }
+}

--- a/PineTests/PineAnimationTests.swift
+++ b/PineTests/PineAnimationTests.swift
@@ -4,6 +4,9 @@
 //
 //  Tests for PineAnimation motion system constants.
 //
+//  The Reduce Motion policy these constants are resolved through lives in
+//  `PineAnimationReduceMotionTests` (#1534).
+//
 
 import Foundation
 import SwiftUI
@@ -15,24 +18,31 @@ import Testing
 @MainActor
 struct PineAnimationTests {
 
-    // MARK: - Constants existence and values
+    // MARK: - Base curves
 
-    @Test("Quick animation is defined")
-    func quickAnimationExists() {
-        let animation = PineAnimation.quick
-        #expect(type(of: animation) == Animation.self)
+    // These are the design tokens: what Pine plays when the user has not asked
+    // for less motion. They are distinct from each other, so a call site that
+    // picks the wrong one is observable.
+
+    @Test("The base curves are three distinct animations")
+    func baseCurvesAreDistinct() {
+        let curves = [
+            PineAnimation.quickCurve,
+            PineAnimation.overlayCurve,
+            PineAnimation.contentCurve,
+            PineAnimation.reducedCrossFade,
+        ]
+        #expect(Set(curves).count == curves.count)
     }
 
-    @Test("Overlay animation is defined")
-    func overlayAnimationExists() {
-        let animation = PineAnimation.overlay
-        #expect(type(of: animation) == Animation.self)
-    }
-
-    @Test("Content animation is defined")
-    func contentAnimationExists() {
-        let animation = PineAnimation.content
-        #expect(type(of: animation) == Animation.self)
+    @Test("The overlay curve is the only spring")
+    func overlayCurveIsTheSpring() {
+        // A spring overshoots, which is why the Reduce Motion policy may never
+        // fall back to this curve.
+        #expect(PineAnimation.overlayCurve == .spring(response: 0.3, dampingFraction: 0.9))
+        #expect(PineAnimation.quickCurve == .easeInOut(duration: 0.2))
+        #expect(PineAnimation.contentCurve == .easeInOut(duration: 0.25))
+        #expect(PineAnimation.reducedCrossFade == .easeInOut(duration: 0.15))
     }
 
     @Test("Fade transition is defined")


### PR DESCRIPTION
# fix(a11y): make `PineAnimation` consult Reduce Motion centrally

Closes the root-cause item of #1534. **Merge after the 2.6.0 tag** — this is post-release polish, not a 2.6.0 blocker.

Base: `origin/main` @ `e30b26c3eb3f0474f950a7011bae5f7286ae5c2a`. Branch: `fix/reduce-motion-central`, one commit, not pushed.

## The problem

`PineAnimation` was a table of `let` constants. Nothing in it knew about `accessibilityReduceMotion`, so honouring the setting was optional at every call site — and most call sites declined. Thirty sites remembering is thirty-one sites forgetting.

## Counts — method first, because the method is where the numbers went wrong

The issue's numbers were revised twice and are still slightly off. Every command below is run against `main`.

### `PineAnimation.` usages

```
$ git grep -c 'PineAnimation\.' main -- 'Pine/*.swift' | awk -F: '{s+=$3} END {print s}'
32                       # matching LINES, in 15 files

$ git grep -oh 'PineAnimation\.' main -- 'Pine/*.swift' | wc -l
33                       # actual OCCURRENCES
```

Two corrections to the issue:

1. **32 vs 33 is lines vs occurrences.** `grep -c` counts matching *lines*. `Pine/ToastView.swift:45` carries two occurrences on one line (`reduceMotion ? PineAnimation.content : PineAnimation.overlay`), so 32 lines contain 33 occurrences. The issue's "32 occurrences" is really 32 lines.

2. **The 32nd line is not "the definition itself".** It is the filename in the header comment:

   ```
   $ git grep -n 'PineAnimation\.' main -- 'Pine/PineAnimation.swift'
   main:Pine/PineAnimation.swift:2://  PineAnimation.swift
   ```

   `PineAnimation\.` matches the `.` before `swift`. The actual definition, `enum PineAnimation {`, never matches the pattern at all — so filtering "the file that defines it" removes a false positive, not a real one.

**Corrected baseline: 31 call-site lines / 32 call-site occurrences across 14 consumer files.**

### Broader animation surface

```
$ grep -rho 'withAnimation\|\.animation(\|\.transition(' Pine --include='*.swift' | wc -l
43
$ grep -rl  'withAnimation\|\.animation(\|\.transition(' Pine --include='*.swift' | wc -l
19
```

Both confirmed as the issue states. Note the 19 files are a superset of the 14: five files animate without going through `PineAnimation` at all (the agent badge pulse in `TerminalBarView` is one, and it already gates itself correctly).

### How many consumers actually gate themselves

The issue measures this per **file**, via `comm` against any mention of `reduceMotion`:

```
$ comm -23 <(grep -rl 'PineAnimation\.' Pine --include='*.swift' | grep -v 'PineAnimation.swift' | sort) \
           <(grep -rl 'reduceMotion\|ReduceMotion' Pine --include='*.swift' | sort) | wc -l
9                        # 9 of 14 consumer files never mention Reduce Motion
```

That reproduces, but it **flatters the code**, because a file can mention `reduceMotion` once and still animate ungated everywhere else. Measuring per **call site** — a site counts as gated when it, or one of the four lines above it, names the preference:

```
$ python3 gate_audit.py main        # full script inlined at the bottom of this PR
main: 6 gated / 25 ungated / 31 call sites
```

The five "Reduce Motion aware" files hide three ungated sites of their own:

| file:line | site | issue's file-level verdict | real verdict |
|---|---|---|---|
| `Pine/ToastView.swift:31` | `withAnimation(PineAnimation.quick)` on dismiss | aware | **ungated** |
| `Pine/EditorTabBar.swift:521` | `.animation(PineAnimation.quick, value: isActive)` | aware | **ungated** |
| `Pine/EditorTabBar.swift:522` | `.animation(PineAnimation.quick, value: isHovering)` | aware | **ungated** |

**So the honest number is 25 of 31 call sites ungated, not 9 of 14 files.**

## The fix

Point checks in thirty places guarantee the thirty-first is forgotten, so the consultation moved into the helper:

- `PineMotionPreference` — one ambient answer to "is Reduce Motion on", read live from `NSWorkspace.shared.accessibilityDisplayShouldReduceMotion` on every access (never cached, so flipping the setting mid-session takes effect at the next state change). The reader is a swappable closure so tests can prove the value *tracks its source*.
- `PineAnimation.resolve(_:intent:reduceMotion:)` — the whole policy, in one pure function:
  - `.geometry` → `nil`. Not a shorter spring, not a more damped one: `nil` is the only value SwiftUI treats as "apply now".
  - `.crossFade` → `reducedCrossFade` (a plain 0.15s `easeInOut`). HIG asks for movement to be *replaced* by a cross-fade, not cut.
- `PineAnimation.quick` / `.overlay` / `.content` are now computed `Animation?` accessors that run that policy. **All 31 existing call sites become Reduce-Motion-aware with no edit**, because `Animation?` is exactly what both `withAnimation(_:_:)` and `.animation(_:value:)` accept, and `nil` means "instant" at every one of them.
- `quick(reduceMotion:)` / `overlay(reduceMotion:)` / `content(reduceMotion:)` — the same policy for views that already hold the environment value, which is the more correct source (reactive, and overridable per-view).
- `CommandOverlayView` additionally drops the **transition's** scale component: `.opacity.combined(with: .scale(0.96))` → `.opacity`, resolved through an `Equatable` `OverlayPresentation` value so it can be asserted (an `AnyTransition` cannot be compared). It now reads `@Environment(\.accessibilityReduceMotion)` and takes a `reduceMotionOverride`, mirroring `GlobalTabSwitcherOverlay` exactly.
- `GlobalTabSwitcherOverlay` — one line: `withAnimation(PineAnimation.quick(reduceMotion:))` instead of the ambient accessor, so a hosted test forcing `reduceMotionOverride: false` on a machine with Reduce Motion on gets the animation that override implies. The reference implementation stays the reference implementation; no second way was invented.

Deliberately **not** changed: the three inline `reduceMotion ? … :` ternaries in `ContentView`, `EditorTabBar` and `ToastView` are now redundant but strictly better than the ambient read — they use the reactive environment value. Left alone.

## Constraints checked

- **`.center` scroll policy (AGENTS.md).** `SidebarView.performSidebarScroll` uses a bare `withAnimation { }`, not `PineAnimation`, so it is untouched by this diff. `SidebarScrollRequest.keyboardSelection` still yields `(.nearestEdge, .immediate)` and `intentionalReveal` still yields `(.center, .immediate)` under Reduce Motion — both pinned by new tests in this PR so a future refactor of the helper cannot silently move them.
- **Routine list navigation stays unanimated.** Unchanged: `keyboardSelection` was already `.immediate`, and the new policy can only remove animation, never add it.
- **Intentional reveal is immediate, not "less animated".** `resolve(_:intent: .geometry, reduceMotion: true)` returns `nil`; mutation **M8** below proves a "very short spring" substitution reds the suite.
- **Zero behavioural change with Reduce Motion off.** Every accessor returns its exact previous constant. That is why no snapshot baseline moved.

## TDD and mutation verification

Tests were written first (`PineTests/PineAnimationReduceMotionTests.swift` — 15 tests, and 2 new parameterised tests in `CommandOverlayViewTests`), then the implementation. Each mutation was applied to the production source, the three suites re-run, and the mutation reverted.

| # | Mutation | Result | Killed by |
|---|---|---|---|
| M1 | `.geometry` branch returns `base` instead of `nil` | **KILLED** | `Geometry motion resolves to no animation…`, both hosted overlay tests |
| M2 | `resolve()` drops the `guard reduceMotion` — no consultation at all | **KILLED** | 4 tests across 2 suites |
| M3 | `reduceMotion` returns a hard-coded `false` instead of `source()` | **KILLED** | `The ambient preference returns whatever its source says` + 2 more |
| M4 | `OverlayPresentation` always keeps its scale | **KILLED** | `Overlay presentation drops its scale component…`, hosted overlay test |
| M5 | `CommandOverlayView.effectiveReduceMotion` returns `false` | **KILLED** | both hosted overlay tests |
| M6 | `.crossFade` branch returns `base` — the spring survives | **KILLED** | 3 tests |
| M7 | `overlayTransition` ignores the resolved decision, always scales | **SURVIVED** | — see below |
| M8 | `.geometry` returns `.spring(response: 0.05, dampingFraction: 1.0)` — "less animated", not instant | **KILLED** | `Geometry motion resolves to no animation…`, `A suppressed geometry animation is instant, not merely shorter` |
| M9 | the preference is cached once at launch instead of read live | **SURVIVED** | — see below |

**Does the suite test behaviour or the presence of a call?** M8 is the answer: it leaves the Reduce Motion consultation fully in place and only changes *what* it returns to a barely-perceptible spring. A test that merely asserted "the helper consults the preference" would stay green. Three tests go red. Likewise M3 leaves `withOverride` working and only changes the value that reaches the accessors.

**Two honest survivors:**

- **M7** — `AnyTransition` is opaque; SwiftUI exposes no way to inspect a built transition, so nothing can assert the output of `overlayTransition(_:)`. The *decision it consumes* is fully pinned (M4 dies). Blast radius if M7 ever regressed for real: the transition would carry a scale component that never plays, because the accompanying animation is `nil` under Reduce Motion and SwiftUI applies the end state instantly. Closing this properly needs a UI-level assertion — see the CI finding below, which is where it belongs.
- **M9** — proving "not cached across a *system-setting* change" requires actually flipping the system setting mid-process, which is a UI-test concern, not a unit-test one. `withSource` legitimately replaces the source, so a unit test cannot see behind it. Mitigation is structural: `source` is initialised to the `systemSource` **closure**, not to `systemSource()`, so caching would have to be an explicit act.

My own first attempt at the M3 test was itself tautological — it asserted `PineMotionPreference.reduceMotion == NSWorkspace.shared.accessibilityDisplayShouldReduceMotion`, which passes trivially on any machine with Reduce Motion off, exactly the shape of the CI hole below. M3 survived, the seam was rebuilt around an injectable source, and M3 now dies. The weak assertion is kept as `The default source is the live system setting` and is **labelled in the test as deliberately weak**.

## Separate finding: the CI `de-pt-dark-reduce-motion` leg asserts nothing about Pine

Reported separately because it is worth more than the fix.

`.github/workflows/ci.yml:791` does `defaults write com.apple.universalaccess reduceMotion -bool "$PINE_A11Y_REDUCE_MOTION"`, and `PINE_A11Y_REDUCE_MOTION` reaches the test as `configuration.reduceMotion`. That value is then used in exactly one place in the entire 869-line suite:

```
$ grep -n -i 'reduce' PineUITests/AccessibilityLocalizationSmokeTests.swift
21:            NSWorkspace.shared.accessibilityDisplayShouldReduceMotion,
22:            configuration.reduceMotion,
23:            "The runner must apply the requested Reduce Motion state"
739:    let reduceMotion: Bool
755:            reduceMotion: bool(environment["PINE_A11Y_REDUCE_MOTION"]),
```

Lines 20-24 are a `setUpWithError` assertion that the **test runner's own process** sees the setting the workflow just wrote. It verifies the `defaults write` step, not the app. No test in the file branches on `configuration.reduceMotion`, and no assertion anywhere compares behaviour between a Reduce Motion leg and a non-Reduce Motion leg.

Consequence: `de-pt-dark-reduce-motion` runs **byte-identical assertions** to `en-es-fr-light`. The matrix has run Reduce Motion in CI since it was added and has never been capable of catching a Reduce Motion regression — including the 25 ungated call sites this PR fixes. It is the same shape as the `ru-…-double-length` leg forcing English: the leg is configured, the configuration is verified, the behaviour is not.

This is a hole in the harness, not in this diff, so I have not widened its scope here. The concrete follow-up, which would also kill mutations M7 and M9, is a UI test that opens a command overlay and asserts the overlay reaches its final frame within one frame under Reduce Motion while taking measurably longer without it — a real geometry assertion, gated on `configuration.reduceMotion`. Happy to file it as its own issue.

## #1541 (agent badge) — unaffected, neither better nor worse

The pulsing badge lives in `Pine/TerminalBarView.swift:69-105`. It uses a raw `.easeInOut(duration: 0.8).repeatForever(autoreverses: true)`, **not** `PineAnimation`, and it already gates itself through `Self.shouldPulse(isActive:reduceMotion:)`. It is the only `repeatForever` in the codebase:

```
$ grep -rn 'repeatForever' Pine --include='*.swift'
Pine/TerminalBarView.swift:85:                                .repeatForever(autoreverses: true)
```

This diff does not touch it. The three-states-collapse-into-one-dot problem in #1541 is exactly as bad after this PR as before it — not worse. Fixing it needs a non-motion channel (glyph or label), which is #1541's job.

## Also worth knowing: checklist item 2 of #1534 is stale

The issue says `Pine/CommandOverlayView.swift:43` "affects Quick Open, Command Palette, Go to Line and Symbol Navigator". It no longer does:

```
$ grep -rn 'CommandOverlayView' Pine --include='*.swift'
Pine/CommandOverlayView.swift:2://  CommandOverlayView.swift
Pine/CommandOverlayView.swift:18:struct CommandOverlayView<Content: View>: View {
Pine/CommandOverlayWindow.swift:10://    PR #986 migrated the navigation flows to `CommandOverlayView` (a SwiftUI
Pine/Agent/AgentAttentionOverlay.swift:14:/// `CommandOverlayView`. Rows are sorted blocked → active → done; clicking a
```

Two comments and its own declaration. `CommandOverlayContainer` routes all four flows through `CommandOverlayWindow` (an `NSPanel`), which shows without any animation at all. `CommandOverlayView` is live only in `CommandOverlayViewTests` and `NavigationOverlaySnapshotTests`. It is still shipped code, so it is fixed here and its dead-in-production status is worth a follow-up decision (delete, or re-adopt), but no user currently sees the spring the issue describes.

The other listed sites — `AgentAttentionOverlay.swift:131` (`.center` scroll) and `GitAndNotificationObserver.swift:234` (sidebar column width) — are live, and both are fixed by the central change with no per-site edit.

## Verification

```
$ sw_vers
ProductName:    macOS
ProductVersion: 27.0
BuildVersion:   26A5421a

$ xcodebuild -version
Xcode 27.0
Build version 27A5237l

$ xcrun --sdk macosx --show-sdk-version        -> 27.0
$ xcrun --sdk macosx --show-sdk-build-version  -> 26A5406c

DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
-derivedDataPath /private/tmp/dd-1534
```

- `xcodebuild build` — **BUILD SUCCEEDED**
- `swiftlint --strict` — **0 violations, 0 serious in 805 files**
- `git diff --check` — clean
- Targeted suites, one class per run:
  - `PineTests/PineAnimationReduceMotionTests` — 15 tests, passed
  - `PineTests/PineAnimationTests` — 3 tests, passed
  - `PineTests/CommandOverlayViewTests` — 10 tests, passed
  - `PineTests/GlobalTabSwitcherOverlayHostedTests` — 5 tests, passed
  - `PineTests/SidebarTreeNavigationTests` — 23 tests, passed
  - `PineTests/NavigationOverlaySnapshotTests` / `GoToLineViewSnapshotTests` / `BranchSwitcherSnapshotTests` / `GlobalTabSwitcherOverlaySnapshotTests` — 8 tests, passed, **no baseline moved**
- No `sleep` / `Task.yield()` used as a wait anywhere in the new tests; hosted tests use the existing `drainMainRunLoop()` helper.

Full `-only-testing:PineTests` on this machine reports 39 issues, all in process/PTY/LSP/window-lifecycle suites hitting 60s time limits under parallel load. Each was re-run in isolation and passes (`AgentAdapterRegistryTests` 49/49, `WindowLifecycleTests` 58/58). This is the macOS 27 beta contention AGENTS.md warns about, not this diff — CI is the signal.

## Acceptance criteria (#1534)

- [x] `PineAnimation` exposes a Reduce-Motion-aware API and the ungated call sites adopt it — all 31, via the accessors.
- [x] No geometry-changing transition plays with Reduce Motion on — animation resolves to `nil`; `CommandOverlayView`'s scale component is removed from the transition too.
- [ ] Indefinitely repeating indicators — **out of scope, tracked as #1541.** The only one is the agent badge; it already gates itself and this diff does not regress it.
- [x] Tests pin the Reduce Motion branch the way `GlobalTabSwitcherOverlay` does — same `reduceMotionOverride` + observer-closure pattern.

---

<details>
<summary>The call-site gating audit script used above</summary>

```python
import re, subprocess, sys
ref = sys.argv[1] if len(sys.argv) > 1 else "main"
files = subprocess.run(["git", "grep", "-l", r"PineAnimation\.", ref, "--", "Pine/*.swift"],
                       capture_output=True, text=True).stdout.split()
gated = ungated = 0
for entry in sorted(files):
    path = entry.split(":", 1)[1]
    if path.endswith("/PineAnimation.swift"):
        continue
    lines = subprocess.run(["git", "show", f"{ref}:{path}"], capture_output=True, text=True).stdout.splitlines()
    for i, line in enumerate(lines):
        if "PineAnimation." not in line:
            continue
        # A site counts as gated when it, or one of the four lines above it,
        # names the Reduce Motion preference.
        window = lines[max(0, i - 4): i + 1]
        if any(re.search(r"reduceMotion|usesAnimation", w) for w in window):
            gated += 1
            print(f"  GATED   {path}:{i+1}: {line.strip()}")
        else:
            ungated += 1
            print(f"  ungated {path}:{i+1}: {line.strip()}")
print(f"\n{ref}: {gated} gated / {ungated} ungated / {gated + ungated} call sites")
```

</details>
