### PR TITLE
fix(ux): route menu items through the keybinding override system

### DIFF
--- a/Pine/Extensibility/UserKeybinding.swift
+++ b/Pine/Extensibility/UserKeybinding.swift
@@ -173,11 +173,57 @@ nonisolated enum UserCommand: String, Sendable, CaseIterable {
     }
 }
 
+/// The function keys a chord can name, and the characters AppKit reports for
+/// them.
+///
+/// `NSF1FunctionKey` … `NSF20FunctionKey` are contiguous private-use scalars
+/// starting at `U+F704`, which no keyboard layout can type and no
+/// configuration file can readably contain. So the chord grammar spells them
+/// `"f1"` … `"f20"` and this table is the single place the two spellings meet
+/// — used by `UserKeybindingRegistry.parse` and `keyToken` on the dispatch
+/// side and by `MenuKeyboardShortcut` on the menu side, so a function-key
+/// chord survives the whole round trip instead of being dropped by whichever
+/// layer forgot about it (#1539).
+nonisolated enum FunctionKeyToken {
+    private static let firstScalar: UInt32 = 0xF704
+    private static let count = 20
+
+    private static let charactersByToken: [String: Character] = {
+        var table: [String: Character] = [:]
+        for index in 0..<count {
+            guard let scalar = UnicodeScalar(firstScalar + UInt32(index)) else {
+                continue
+            }
+            table["f\(index + 1)"] = Character(scalar)
+        }
+        return table
+    }()
+
+    private static let tokensByCharacter: [Character: String] = {
+        var table: [Character: String] = [:]
+        for (token, character) in charactersByToken {
+            table[character] = token
+        }
+        return table
+    }()
+
+    /// `"f8"` → the `U+F70B` character AppKit and SwiftUI both use for F8.
+    static func character(for token: String) -> Character? {
+        charactersByToken[token]
+    }
+
+    /// The reverse: `U+F70B` → `"f8"`.
+    static func token(for character: Character) -> String? {
+        tokensByCharacter[character]
+    }
+}
+
 /// Parsed key chord: modifiers + a single character or special key.
 nonisolated struct ParsedKeyChord: Equatable, Hashable, Sendable {
     let modifiers: NSEvent.ModifierFlags
     /// Lowercased character (e.g. "f", "b"), or a special token ("return",
-    /// "up", "down", "left", "right", "tab", "delete", "esc", "space").
+    /// "up", "down", "left", "right", "tab", "delete", "esc", "space",
+    /// "f1" … "f20").
     let key: String
 
     static func == (lhs: ParsedKeyChord, rhs: ParsedKeyChord) -> Bool {
@@ -510,7 +556,7 @@ final class UserKeybindingRegistry {
             charactersIgnoringModifiers?
                 .lowercased()
                 .first
-                .map(String.init)
+                .map { FunctionKeyToken.token(for: $0) ?? String($0) }
         }
     }
 
@@ -531,7 +577,8 @@ final class UserKeybindingRegistry {
     ///
     /// Recognized modifier tokens (case-insensitive): `cmd`/`command`,
     /// `shift`, `alt`/`option`/`opt`, `ctrl`/`control`. The final token is
-    /// the key — a single character (lowercased) or a named special key.
+    /// the key — a single character (lowercased), a named special key, or a
+    /// function key `"f1"` … `"f20"`.
     nonisolated static func parse(_ chord: String) -> ParsedKeyChord? {
         let tokens = chord.split(separator: "+", omittingEmptySubsequences: false).map {
             $0.trimmingCharacters(in: .whitespaces).lowercased()
@@ -562,7 +609,10 @@ final class UserKeybindingRegistry {
         case "up", "down", "left", "right":
             return ParsedKeyChord(modifiers: flags, key: last)
         default:
-            // Single printable character.
+            // Function keys, then a single printable character.
+            if FunctionKeyToken.character(for: last) != nil {
+                return ParsedKeyChord(modifiers: flags, key: last)
+            }
             guard last.count == 1 else { return nil }
             return ParsedKeyChord(modifiers: flags, key: last)
         }

--- a/Pine/NativeMenuCommandState.swift
+++ b/Pine/NativeMenuCommandState.swift
@@ -196,6 +196,9 @@ nonisolated struct MenuKeyboardShortcut {
         case "left": return .leftArrow
         case "right": return .rightArrow
         default:
+            if let function = FunctionKeyToken.character(for: token) {
+                return KeyEquivalent(function)
+            }
             guard token.count == 1, let character = token.first else {
                 return nil
             }

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -350,7 +350,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuToggleComment, systemImage: MenuIcons.toggleComment)
             }
-            .keyboardShortcut("/", modifiers: .command)
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .toggleComment)
+            )
 
             Divider()
 
@@ -359,7 +361,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuFind, systemImage: MenuIcons.find)
             }
-            .keyboardShortcut("f", modifiers: .command)
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .findInFile)
+            )
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
 
             Button {
@@ -367,7 +371,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuFindAndReplace, systemImage: MenuIcons.findAndReplace)
             }
-            .keyboardShortcut("f", modifiers: [.command, .option])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .findAndReplace)
+            )
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
 
             Button {
@@ -375,7 +381,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuFindNext, systemImage: MenuIcons.nextChange)
             }
-            .keyboardShortcut("g", modifiers: .command)
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .findNext)
+            )
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
 
             Button {
@@ -383,7 +391,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuFindPrevious, systemImage: MenuIcons.previousChange)
             }
-            .keyboardShortcut("g", modifiers: [.command, .shift])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .findPrevious)
+            )
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
 
             Button {
@@ -391,7 +401,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuUseSelectionForFind, systemImage: MenuIcons.find)
             }
-            .keyboardShortcut("e", modifiers: .command)
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .useSelectionForFind)
+            )
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
 
             Divider()
@@ -401,7 +413,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuFindInProject, systemImage: MenuIcons.findInProject)
             }
-            .keyboardShortcut("f", modifiers: [.command, .shift])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .findInProject)
+            )
 
             Divider()
 
@@ -413,7 +427,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuGoToLine, systemImage: MenuIcons.goToLine)
             }
-            .keyboardShortcut("l", modifiers: .command)
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .goToLine)
+            )
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
 
             Divider()
@@ -426,7 +442,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuNextChange, systemImage: MenuIcons.nextChange)
             }
-            .keyboardShortcut(.downArrow, modifiers: [.control, .option])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .nextChange)
+            )
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
 
             Button {
@@ -437,7 +455,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuPreviousChange, systemImage: MenuIcons.previousChange)
             }
-            .keyboardShortcut(.upArrow, modifiers: [.control, .option])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .previousChange)
+            )
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
 
             Button {
@@ -448,7 +468,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuAcceptChange, systemImage: MenuIcons.acceptChange)
             }
-            .keyboardShortcut(.return, modifiers: [.control, .option])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .acceptChange)
+            )
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
 
             Button {
@@ -459,7 +481,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuRevertChange, systemImage: MenuIcons.revertChange)
             }
-            .keyboardShortcut(.delete, modifiers: [.control, .option])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .revertChange)
+            )
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
 
             Button {
@@ -492,7 +516,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuFoldCode, systemImage: MenuIcons.foldCode)
             }
-            .keyboardShortcut(.leftArrow, modifiers: [.command, .option])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .foldCode)
+            )
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
 
             Button {
@@ -503,7 +529,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuUnfoldCode, systemImage: MenuIcons.unfoldCode)
             }
-            .keyboardShortcut(.rightArrow, modifiers: [.command, .option])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .unfoldCode)
+            )
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
 
             Button {
@@ -514,7 +542,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuFoldAll, systemImage: MenuIcons.foldAll)
             }
-            .keyboardShortcut(.leftArrow, modifiers: [.command, .option, .shift])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .foldAll)
+            )
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
 
             Button {
@@ -525,7 +555,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuUnfoldAll, systemImage: MenuIcons.unfoldAll)
             }
-            .keyboardShortcut(.rightArrow, modifiers: [.command, .option, .shift])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .unfoldAll)
+            )
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
         }
 
@@ -539,21 +571,27 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuIncreaseFontSize, systemImage: MenuIcons.increaseFontSize)
             }
-            .keyboardShortcut("+", modifiers: .command)
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .increaseFontSize)
+            )
 
             Button {
                 FontSizeSettings.shared.decrease()
             } label: {
                 Label(Strings.menuDecreaseFontSize, systemImage: MenuIcons.decreaseFontSize)
             }
-            .keyboardShortcut("-", modifiers: .command)
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .decreaseFontSize)
+            )
 
             Button {
                 FontSizeSettings.shared.reset()
             } label: {
                 Label(Strings.menuResetFontSize, systemImage: MenuIcons.resetFontSize)
             }
-            .keyboardShortcut("0", modifiers: .command)
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .resetFontSize)
+            )
 
             Divider()
 
@@ -566,7 +604,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.toggleTerminal, systemImage: MenuIcons.toggleTerminal)
             }
-            .keyboardShortcut("`", modifiers: .command)
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .toggleTerminal)
+            )
 
             Button {
                 guard let pm = focusedProject else { return }
@@ -574,24 +614,32 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuTogglePreview, systemImage: MenuIcons.togglePreview)
             }
-            .keyboardShortcut("p", modifiers: [.command, .shift])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .togglePreview)
+            )
 
             Divider()
 
             Toggle(isOn: $minimapVisible) {
                 Label(Strings.menuToggleMinimap, systemImage: MenuIcons.toggleMinimap)
             }
-            .keyboardShortcut("m", modifiers: [.command, .shift])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .toggleMinimap)
+            )
 
             Toggle(isOn: $blameVisible) {
                 Label(Strings.menuToggleBlame, systemImage: MenuIcons.toggleBlame)
             }
-            .keyboardShortcut("b", modifiers: [.command, .control])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .toggleBlame)
+            )
 
             Toggle(isOn: $wordWrapEnabled) {
                 Label(Strings.menuToggleWordWrap, systemImage: MenuIcons.toggleWordWrap)
             }
-            .keyboardShortcut("z", modifiers: .option)
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .toggleWordWrap)
+            )
 
             Divider()
 
@@ -604,7 +652,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuProblems, systemImage: MenuIcons.problems)
             }
-            .keyboardShortcut("x", modifiers: [.command, .shift])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .showProblems)
+            )
             .disabled(focusedProject == nil)
 
             Button {
@@ -619,7 +669,9 @@ struct PineAppMenuCommands: Commands {
                     systemImage: MenuIcons.nextDiagnostic
                 )
             }
-            .keyboardShortcut(KeyEquivalent("\u{F70B}"), modifiers: [])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .nextDiagnostic)
+            )
             .disabled(focusedProject == nil)
 
             Button {
@@ -634,9 +686,8 @@ struct PineAppMenuCommands: Commands {
                     systemImage: MenuIcons.previousDiagnostic
                 )
             }
-            .keyboardShortcut(
-                KeyEquivalent("\u{F70B}"),
-                modifiers: .shift
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .previousDiagnostic)
             )
             .disabled(focusedProject == nil)
 
@@ -690,7 +741,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuRevealFileInFinder, systemImage: MenuIcons.revealFileInFinder)
             }
-            .keyboardShortcut("r", modifiers: [.command, .shift])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .revealFileInFinder)
+            )
             .disabled(
                 focusedProject?.paneManager.activeTabManager?
                     .activeTab?
@@ -746,7 +799,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuSwitchBranch, systemImage: MenuIcons.switchBranch)
             }
-            .keyboardShortcut("b", modifiers: [.command, .shift])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .showBranchSwitcher)
+            )
             .disabled(focusedProject?.workspace.gitProvider.isGitRepository != true)
         }
 
@@ -791,7 +846,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuNewTerminalTab, systemImage: MenuIcons.newTerminalTab)
             }
-            .keyboardShortcut("t", modifiers: .command)
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .newTerminalTab)
+            )
 
             Divider()
 
@@ -809,7 +866,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuSendToTerminal, systemImage: MenuIcons.sendToTerminal)
             }
-            .keyboardShortcut(.return, modifiers: [.command, .shift])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .sendToTerminal)
+            )
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
 
             Divider()
@@ -826,7 +885,9 @@ struct PineAppMenuCommands: Commands {
             } label: {
                 Label(Strings.menuToggleTerminalZoom, systemImage: MenuIcons.maximizeTerminal)
             }
-            .keyboardShortcut(.return, modifiers: [.command, .option])
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .toggleTerminalZoom)
+            )
             .disabled(focusedProject?.hasTerminalPanes != true)
 
             Divider()

--- a/PineTests/MenuHardcodedShortcutGuardTests.swift
+++ b/PineTests/MenuHardcodedShortcutGuardTests.swift
@@ -1,0 +1,342 @@
+//
+//  MenuHardcodedShortcutGuardTests.swift
+//  PineTests
+//
+//  The guard half of #1539. Converting 32 menu items to
+//  `effectiveKeyboardShortcut` fixes the 32; it does nothing about the 33rd,
+//  which is a single line someone adds six months from now. So the invariant
+//  is stated over the source itself: a menu item may spell a key equivalent
+//  out only when no `UserCommand` claims it.
+//
+
+import AppKit
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("No menu item hardcodes a rebindable chord")
+struct MenuHardcodedShortcutGuardTests {
+    /// The menu items allowed to spell a key equivalent out in source.
+    ///
+    /// None of them is a `UserCommand`, so there is no override to honour and
+    /// nothing for `effectiveKeyboardShortcut` to read. Every other item in
+    /// the menu takes its chord from `keybindings.effectiveChord(for:)`.
+    ///
+    /// Adding a name here is a claim that the item has no `UserCommand` case.
+    /// ``exemptChordsAreNotRebindable`` checks that claim against the chord,
+    /// so an exemption written for a rebindable command still fails.
+    static let exemptItems: Set<String> = [
+        // Control-Tab MRU switching; handled by a local event monitor, with
+        // the menu equivalents kept only as the Accessibility fallback.
+        "tabSwitchNext",
+        "tabSwitchPrevious",
+        // Move Tab — pane and tab arrangement, not a registered command.
+        "tabMoveLeading",
+        "tabMoveTrailing",
+        "tabMoveToPreviousPane",
+        "tabMoveToNextPane",
+        // Recover Terminal Display — a renderer escape hatch (#1472).
+        "menuRecoverTerminalDisplay",
+    ]
+
+    @Test("only the exempt menu items spell a key equivalent out in source")
+    func hardcodedShortcutsAreConfinedToExemptItems() throws {
+        let sites = try MenuCommandSource.hardcodedShortcuts()
+
+        #expect(Set(sites.map(\.item)) == Self.exemptItems)
+    }
+
+    /// The semantic half: whatever the allowlist says, a hardcoded chord that
+    /// a `UserCommand` also claims is the #1539 bug by definition — the user
+    /// can rebind that command, and the menu will keep advertising this.
+    @Test("no hardcoded chord belongs to a rebindable command")
+    func exemptChordsAreNotRebindable() throws {
+        let rebindable = Set(UserCommand.allCases.compactMap(\.defaultChord))
+
+        for site in try MenuCommandSource.hardcodedShortcuts() {
+            let chord = try #require(
+                MenuCommandSource.chord(from: site.argument),
+                """
+                \(site.item) at line \(site.line) spells out a key \
+                equivalent this guard cannot read: \(site.argument). Route \
+                it through effectiveKeyboardShortcut, or teach \
+                MenuCommandSource.chord(from:) the new spelling — an \
+                unreadable hardcode is not an exempt one.
+                """
+            )
+            #expect(
+                !rebindable.contains(chord),
+                """
+                \(site.item) at line \(site.line) hardcodes \
+                \(chord.displayText), which is a UserCommand's built-in \
+                chord. Use .effectiveKeyboardShortcut(...) so a user rebind \
+                replaces it instead of running alongside it (#1539).
+                """
+            )
+        }
+    }
+
+    /// Every exemption has to correspond to a site that actually exists, so a
+    /// removed menu item leaves a stale name behind rather than a silent hole
+    /// the next hardcode can slip through.
+    @Test("no exemption outlives the menu item it was written for")
+    func exemptionsAreAllInUse() throws {
+        let sites = Set(try MenuCommandSource.hardcodedShortcuts().map(\.item))
+
+        #expect(Self.exemptItems.subtracting(sites).isEmpty)
+    }
+
+    /// The other way to leave the conversion half-done: drop the hardcoded
+    /// chord without putting `effectiveChord(for:)` in its place, or paste the
+    /// replacement from the item above and leave the neighbouring command's
+    /// name in it. Neither shows up in the counts — one item quietly loses its
+    /// key equivalent and another quietly grows a second one.
+    @Test("each command with a built-in chord is read by exactly one item")
+    func rebindableCommandsAreWiredOnceEach() throws {
+        let wired = try MenuCommandSource.overriddenCommands()
+        let rebindable = Set(
+            UserCommand.allCases
+                .filter { $0.defaultChord != nil }
+                .map(\.rawValue)
+        )
+
+        #expect(
+            Set(wired).count == wired.count,
+            """
+            Two menu items read the same command's chord: \
+            \(wired.filter { name in wired.filter { $0 == name }.count > 1 })
+            """
+        )
+        #expect(
+            rebindable.subtracting(wired).isEmpty,
+            """
+            \(rebindable.subtracting(wired).sorted()) own a built-in chord \
+            that no menu item reads, so the menu advertises nothing for them.
+            """
+        )
+    }
+}
+
+/// Reads `Pine/PineAppMenuCommands.swift` the way the guards above need it.
+///
+/// A source scan, not a runtime one, because `Commands` bodies are opaque:
+/// SwiftUI offers no way to ask a built menu what key equivalent an item
+/// carries, and the defect being guarded is a spelling in the source anyway.
+///
+/// Fails closed at every step — a moved file, an unreadable file, or a file
+/// whose contents no longer look like the menu definitions is an error, never
+/// an empty result. A guard that scans nothing must not pass (#1508).
+enum MenuCommandSource {
+    /// One `.keyboardShortcut(…)` call spelled out in the menu source.
+    struct HardcodedShortcut {
+        /// The `Strings.<key>` the enclosing item labels itself with — the
+        /// closest thing the source has to an identity for a menu item.
+        let item: String
+        /// Source text between the call's parentheses, newlines collapsed.
+        let argument: String
+        let line: Int
+    }
+
+    struct SourceNotRecognizedError: Error, CustomStringConvertible {
+        let url: URL
+        let reason: String
+
+        var description: String {
+            """
+            \(url.path) does not look like Pine's menu definitions \
+            (\(reason)). This guard cannot pass on a file it failed to \
+            read — check whether the menu moved.
+            """
+        }
+    }
+
+    static let relativePath = "Pine/PineAppMenuCommands.swift"
+
+    /// The literal a hardcoded call passes as its key, mapped to the token the
+    /// chord grammar uses for the same key.
+    private static let keyTokensBySpelling: [String: String] = [
+        ".return": "return",
+        ".tab": "tab",
+        ".delete": "delete",
+        ".escape": "esc",
+        ".space": "space",
+        ".upArrow": "up",
+        ".downArrow": "down",
+        ".leftArrow": "left",
+        ".rightArrow": "right",
+        "\\t": "tab",
+        "\\r": "return",
+        "\\n": "return",
+    ]
+
+    static func source() throws -> String {
+        let url = try ProductionSourceScan.repositoryRoot()
+            .appendingPathComponent(relativePath)
+        let text = try String(contentsOf: url, encoding: .utf8)
+        guard text.contains("struct PineAppMenuCommands") else {
+            throw SourceNotRecognizedError(
+                url: url,
+                reason: "no PineAppMenuCommands declaration"
+            )
+        }
+        guard text.contains(".effectiveKeyboardShortcut(") else {
+            throw SourceNotRecognizedError(
+                url: url,
+                reason: "no effectiveKeyboardShortcut call"
+            )
+        }
+        return text
+    }
+
+    /// Every `.keyboardShortcut(…)` call in the menu source, with the menu
+    /// item each one belongs to.
+    ///
+    /// `.effectiveKeyboardShortcut(` does not match: the capital `K` in the
+    /// composed name is not the `.k` this searches for.
+    static func hardcodedShortcuts() throws -> [HardcodedShortcut] {
+        let text = try source()
+        var results: [HardcodedShortcut] = []
+        var searchStart = text.startIndex
+
+        while let call = text.range(
+            of: ".keyboardShortcut(",
+            range: searchStart..<text.endIndex
+        ) {
+            var depth = 1
+            var index = call.upperBound
+            var argument = ""
+            while index < text.endIndex {
+                let character = text[index]
+                if character == "(" {
+                    depth += 1
+                } else if character == ")" {
+                    depth -= 1
+                    if depth == 0 { break }
+                }
+                argument.append(character)
+                index = text.index(after: index)
+            }
+            results.append(
+                HardcodedShortcut(
+                    item: itemLabel(before: call.lowerBound, in: text) ?? "",
+                    argument: collapse(argument),
+                    line: text[..<call.lowerBound].filter { $0 == "\n" }
+                        .count + 1
+                )
+            )
+            searchStart = index
+        }
+        return results
+    }
+
+    /// The commands the menu reads a chord for, in source order, one entry per
+    /// `effectiveChord(for: .command)` call — repeats included, because a
+    /// repeat is the defect ``rebindableCommandsAreWiredOnceEach`` looks for.
+    static func overriddenCommands() throws -> [String] {
+        let text = try source()
+        let marker = "effectiveChord(for: ."
+        var results: [String] = []
+        var searchStart = text.startIndex
+
+        while let call = text.range(
+            of: marker,
+            range: searchStart..<text.endIndex
+        ) {
+            let name = text[call.upperBound...].prefix {
+                $0.isLetter || $0.isNumber
+            }
+            if !name.isEmpty { results.append(String(name)) }
+            searchStart = call.upperBound
+        }
+        return results
+    }
+
+    /// Turns a hardcoded call's argument text into the chord it installs, so
+    /// the guard can compare it with `UserCommand.defaultChord` rather than
+    /// trusting an allowlist alone.
+    ///
+    /// Returns `nil` for a spelling it does not recognize; the caller treats
+    /// that as a failure, so an unreadable hardcode is never a passing one.
+    static func chord(from argument: String) -> ParsedKeyChord? {
+        let parts = argument.components(separatedBy: "modifiers:")
+        let keyText = parts[0]
+            .trimmingCharacters(in: CharacterSet(charactersIn: " ,"))
+        guard let key = keyToken(from: keyText) else { return nil }
+
+        var modifiers: NSEvent.ModifierFlags = []
+        if parts.count > 1 {
+            let modifierText = parts[1]
+            if modifierText.contains(".command") { modifiers.insert(.command) }
+            if modifierText.contains(".control") { modifiers.insert(.control) }
+            if modifierText.contains(".option") { modifiers.insert(.option) }
+            if modifierText.contains(".shift") { modifiers.insert(.shift) }
+        }
+        return ParsedKeyChord(modifiers: modifiers, key: key)
+    }
+
+    // MARK: - Private
+
+    private static func keyToken(from text: String) -> String? {
+        var spelling = text
+        // `KeyEquivalent("x")` and a bare `"x"` name the same key.
+        if spelling.hasPrefix("KeyEquivalent(") {
+            spelling = String(spelling.dropFirst("KeyEquivalent(".count))
+            guard spelling.hasSuffix(")") else { return nil }
+            spelling = String(spelling.dropLast())
+        }
+        if let token = keyTokensBySpelling[spelling] { return token }
+        guard spelling.hasPrefix("\""), spelling.hasSuffix("\""),
+              spelling.count >= 2 else {
+            return nil
+        }
+        let literal = String(spelling.dropFirst().dropLast())
+        if let token = keyTokensBySpelling[literal] { return token }
+        if let scalar = unicodeEscape(literal) {
+            return UserKeybindingRegistry.keyToken(
+                keyCode: 0,
+                charactersIgnoringModifiers: String(scalar)
+            )
+        }
+        guard literal.count == 1 else { return nil }
+        return literal.lowercased()
+    }
+
+    /// Decodes a `\u{F70B}` escape as written in Swift source.
+    private static func unicodeEscape(_ literal: String) -> Character? {
+        guard literal.hasPrefix("\\u{"), literal.hasSuffix("}") else {
+            return nil
+        }
+        let digits = literal.dropFirst("\\u{".count).dropLast()
+        guard let value = UInt32(digits, radix: 16),
+              let scalar = UnicodeScalar(value) else {
+            return nil
+        }
+        return Character(scalar)
+    }
+
+    private static func itemLabel(
+        before index: String.Index,
+        in text: String
+    ) -> String? {
+        guard let marker = text.range(
+            of: "Strings.",
+            options: .backwards,
+            range: text.startIndex..<index
+        ) else {
+            return nil
+        }
+        let name = text[marker.upperBound...].prefix {
+            $0.isLetter || $0.isNumber || $0 == "_"
+        }
+        return name.isEmpty ? nil : String(name)
+    }
+
+    private static func collapse(_ argument: String) -> String {
+        argument
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/PineTests/MenuShortcutOverrideTests.swift
+++ b/PineTests/MenuShortcutOverrideTests.swift
@@ -1,0 +1,259 @@
+//
+//  MenuShortcutOverrideTests.swift
+//  PineTests
+//
+//  Issue #1539: menu items that spell their key equivalent out in source
+//  ignore the user's keybinding override, so a rebound command answers to
+//  both chords and the menu advertises the wrong one.
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+@Suite("Menu key equivalents come from the override system")
+@MainActor
+struct MenuShortcutOverrideTests {
+    /// A key equivalent as a menu item advertises it.
+    ///
+    /// `KeyEquivalent` is not `Equatable`, so comparisons go through
+    /// `character`; the type exists to keep the table below readable.
+    struct AdvertisedShortcut {
+        let key: KeyEquivalent
+        let modifiers: EventModifiers
+
+        init(_ key: KeyEquivalent, _ modifiers: EventModifiers = []) {
+            self.key = key
+            self.modifiers = modifiers
+        }
+    }
+
+    /// The key equivalent every rebindable menu item advertised *before*
+    /// #1539, transcribed from the `.keyboardShortcut(…)` literals the menu
+    /// used to carry.
+    ///
+    /// Writing them out a second time is the point. Routing an item through
+    /// `effectiveKeyboardShortcut` has to preserve what the menu shows, and
+    /// the one way that can fail silently is a built-in chord the menu layer
+    /// cannot render: `MenuKeyboardShortcut` returns `nil`, the item loses
+    /// its key equivalent, and nothing else in the app notices. This table is
+    /// the independent record of what each item is supposed to show.
+    static var advertisedShortcuts: [UserCommand: AdvertisedShortcut] {
+        [
+            // File
+            .newFile: AdvertisedShortcut("n", .command),
+            .openFile: AdvertisedShortcut("o", .command),
+            .openFolder: AdvertisedShortcut("o", [.command, .shift]),
+            .quickOpen: AdvertisedShortcut("p", .command),
+            .commandPalette: AdvertisedShortcut("p", [.command, .option]),
+            .symbolNavigator: AdvertisedShortcut("r", .command),
+            .closeTab: AdvertisedShortcut("w", .command),
+            .closeProject: AdvertisedShortcut("w", [.command, .control]),
+            .closeWindow: AdvertisedShortcut("w", [.command, .shift]),
+            .save: AdvertisedShortcut("s", .command),
+            .saveAll: AdvertisedShortcut("s", [.command, .option]),
+            .saveAs: AdvertisedShortcut("s", [.command, .shift]),
+            .duplicate: AdvertisedShortcut("d", [.command, .shift]),
+            // Edit
+            .toggleComment: AdvertisedShortcut("/", .command),
+            .findInFile: AdvertisedShortcut("f", .command),
+            .findAndReplace: AdvertisedShortcut("f", [.command, .option]),
+            .findNext: AdvertisedShortcut("g", .command),
+            .findPrevious: AdvertisedShortcut("g", [.command, .shift]),
+            .useSelectionForFind: AdvertisedShortcut("e", .command),
+            .findInProject: AdvertisedShortcut("f", [.command, .shift]),
+            .goToLine: AdvertisedShortcut("l", .command),
+            .nextChange: AdvertisedShortcut(.downArrow, [.control, .option]),
+            .previousChange: AdvertisedShortcut(.upArrow, [.control, .option]),
+            .acceptChange: AdvertisedShortcut(.return, [.control, .option]),
+            .revertChange: AdvertisedShortcut(.delete, [.control, .option]),
+            .foldCode: AdvertisedShortcut(.leftArrow, [.command, .option]),
+            .unfoldCode: AdvertisedShortcut(.rightArrow, [.command, .option]),
+            .foldAll: AdvertisedShortcut(
+                .leftArrow, [.command, .option, .shift]
+            ),
+            .unfoldAll: AdvertisedShortcut(
+                .rightArrow, [.command, .option, .shift]
+            ),
+            // View
+            .increaseFontSize: AdvertisedShortcut("+", .command),
+            .decreaseFontSize: AdvertisedShortcut("-", .command),
+            .resetFontSize: AdvertisedShortcut("0", .command),
+            .toggleTerminal: AdvertisedShortcut("`", .command),
+            .togglePreview: AdvertisedShortcut("p", [.command, .shift]),
+            .toggleMinimap: AdvertisedShortcut("m", [.command, .shift]),
+            .toggleBlame: AdvertisedShortcut("b", [.command, .control]),
+            .toggleWordWrap: AdvertisedShortcut("z", .option),
+            .showProblems: AdvertisedShortcut("x", [.command, .shift]),
+            .nextDiagnostic: AdvertisedShortcut(KeyEquivalent("\u{F70B}")),
+            .previousDiagnostic: AdvertisedShortcut(
+                KeyEquivalent("\u{F70B}"), .shift
+            ),
+            .revealFileInFinder: AdvertisedShortcut("r", [.command, .shift]),
+            .showAgentInbox: AdvertisedShortcut("i", [.command, .shift]),
+            // Git
+            .showBranchSwitcher: AdvertisedShortcut("b", [.command, .shift]),
+            // Terminal
+            .newTerminalTab: AdvertisedShortcut("t", .command),
+            .sendToTerminal: AdvertisedShortcut(.return, [.command, .shift]),
+            .toggleTerminalZoom: AdvertisedShortcut(
+                .return, [.command, .option]
+            ),
+        ]
+    }
+
+    // MARK: - The chord the menu shows
+
+    /// With no user configuration loaded, every rebindable command must come
+    /// out of the override layer showing exactly the chord it always showed.
+    ///
+    /// This is the half of #1539 that a purely mechanical edit gets wrong:
+    /// `.keyboardShortcut(KeyEquivalent("\u{F70B}"))` renders F8 whether or
+    /// not the chord grammar can name that key, while
+    /// `effectiveKeyboardShortcut(keybindings.effectiveChord(for:))` renders
+    /// nothing at all when it cannot.
+    @Test("built-in chords survive the trip through the override layer")
+    func builtInChordsRenderThroughTheOverrideLayer() throws {
+        let keybindings = UserKeybindingRegistry()
+
+        for (command, expected) in Self.advertisedShortcuts {
+            let shortcut = try #require(
+                MenuKeyboardShortcut(keybindings.effectiveChord(for: command)),
+                "\(command.rawValue) renders no menu key equivalent"
+            )
+            #expect(
+                shortcut.key.character == expected.key.character,
+                "\(command.rawValue) key equivalent"
+            )
+            #expect(
+                shortcut.modifiers == expected.modifiers,
+                "\(command.rawValue) modifiers"
+            )
+        }
+    }
+
+    /// Ties the table to the command list, so a new rebindable command cannot
+    /// be added with a built-in chord and no record of what its menu item is
+    /// supposed to show.
+    @Test("the table covers exactly the commands that own a built-in chord")
+    func tableCoversEveryCommandWithABuiltInChord() {
+        let withBuiltInChords = Set(
+            UserCommand.allCases.filter { $0.defaultChord != nil }
+        )
+
+        #expect(Set(Self.advertisedShortcuts.keys) == withBuiltInChords)
+    }
+
+    // MARK: - The chord the menu shows after a rebind
+
+    /// The user-visible symptom in #1539: a rebound command answers to both
+    /// chords. The override has to *replace* the built-in one — in the menu
+    /// and in dispatch.
+    @Test("a rebind replaces the advertised chord instead of adding to it")
+    func rebindReplacesTheAdvertisedChord() async throws {
+        let keybindings = try await Self.registry(
+            loading: #"[{"command": "findInFile", "key": "cmd+k"}]"#
+        )
+
+        let shortcut = try #require(
+            MenuKeyboardShortcut(keybindings.effectiveChord(for: .findInFile))
+        )
+        #expect(shortcut.key.character == "k")
+        #expect(shortcut.modifiers == .command)
+        #expect(
+            keybindings.suppressesBuiltInShortcut(
+                for: try #require(Self.keyDown("f", modifiers: .command))
+            )
+        )
+    }
+
+    /// The same replacement, for the two commands whose built-in chord is a
+    /// function key. Before #1539 the chord grammar could not name F8 at all,
+    /// so rebinding Next Diagnostic left F8 live underneath the new chord.
+    @Test("rebinding a function-key command retires the function key")
+    func rebindRetiresAFunctionKeyChord() async throws {
+        let keybindings = try await Self.registry(
+            loading: #"[{"command": "nextDiagnostic", "key": "cmd+j"}]"#
+        )
+
+        let shortcut = try #require(
+            MenuKeyboardShortcut(
+                keybindings.effectiveChord(for: .nextDiagnostic)
+            )
+        )
+        #expect(shortcut.key.character == "j")
+        #expect(
+            keybindings.suppressesBuiltInShortcut(
+                for: try #require(
+                    Self.keyDown("\u{F70B}", modifiers: [], keyCode: 100)
+                )
+            )
+        )
+    }
+
+    /// `f1` … `f20` have to round-trip through the chord grammar, otherwise
+    /// `defaultChord` is `nil` for the two diagnostic commands and neither
+    /// the menu nor the palette can advertise anything for them.
+    @Test("the chord grammar names function keys")
+    func chordGrammarNamesFunctionKeys() throws {
+        let parsed = try #require(UserKeybindingRegistry.parse("f8"))
+        #expect(parsed.key == "f8")
+        #expect(parsed.modifiers.isEmpty)
+        #expect(parsed.displayText == "F8")
+        #expect(UserCommand.nextDiagnostic.defaultChord == parsed)
+        #expect(
+            UserCommand.previousDiagnostic.defaultChord
+                == UserKeybindingRegistry.parse("shift+f8")
+        )
+        #expect(
+            UserKeybindingRegistry.keyToken(
+                keyCode: 100,
+                charactersIgnoringModifiers: "\u{F70B}"
+            ) == "f8"
+        )
+        #expect(UserKeybindingRegistry.parse("f21") == nil)
+        #expect(UserKeybindingRegistry.parse("ff") == nil)
+    }
+
+    // MARK: - Helpers
+
+    private static func registry(
+        loading json: String
+    ) async throws -> UserKeybindingRegistry {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-menu-chord-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("keybindings.json")
+        try Data(json.utf8).write(to: file)
+
+        let keybindings = UserKeybindingRegistry()
+        #expect(await keybindings.load(from: file).outcome == .loaded)
+        return keybindings
+    }
+
+    private static func keyDown(
+        _ characters: String,
+        modifiers: NSEvent.ModifierFlags,
+        keyCode: UInt16 = 0
+    ) -> NSEvent? {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: keyCode
+        )
+    }
+}


### PR DESCRIPTION
# fix(menu): route every rebindable menu item through the override system

Closes #1539.

That issue is an umbrella with four sections. This PR does the first — "user
keybinding overrides are ignored by most menu items". The other three —
non-standard key equivalents, menu placement, menu naming — are carried forward
to #1564 rather than left behind a closed issue; see
**Not done**.

## The defect

`NativeMenuCommandState.effectiveKeyboardShortcut` exists so a menu item shows
the chord that is actually in effect, and shows *nothing* when the built-in
chord has been rebound or shadowed. 14 items used it. 32 items instead spelled
their chord out as a `.keyboardShortcut(...)` literal while the command behind
them was registered in `UserCommand` and advertised as rebindable. After a
rebind of, say, `findInFile`, both ⌘F and the new chord fired, and the menu kept
presenting ⌘F as authoritative.

## Counting method

The two call shapes are distinguishable by grep alone: `.effectiveKeyboardShortcut(`
does not match `.keyboardShortcut(`, because the composed name capitalises the `K`.

```console
$ git show origin/main:Pine/PineAppMenuCommands.swift | grep -c 'effectiveKeyboardShortcut('
14
$ git show origin/main:Pine/PineAppMenuCommands.swift | grep -c '\.keyboardShortcut('
39
```

Splitting the 39 into "belongs to a `UserCommand`" and "does not" is the part a
grep cannot do, so it is done by the chord rather than by reading: a hardcoded
site is rebindable exactly when its chord equals some `UserCommand.defaultChord`.
`MenuHardcodedShortcutGuardTests.exemptChordsAreNotRebindable` performs that
comparison, and against `origin/main` it reports **30** violations, not 32.

The two missing ones are not a miscount in the issue — they are a second defect.
`nextDiagnostic` and `previousDiagnostic` are bound to F8 and ⇧F8, and
`UserKeybindingRegistry.parse` had no spelling for a function key, so
`"f8"` failed to parse and `defaultChord` was `nil` for both. They were
rebindable commands whose built-in chord the override system could not see at
all — which is also why the issue's own audit found "44 distinct default
chords" for what is really 46 commands.

After the change:

```console
$ grep -c 'effectiveChord(for: \.' Pine/PineAppMenuCommands.swift
46
$ grep -c '\.keyboardShortcut(' Pine/PineAppMenuCommands.swift
7
```

14 + 32 = 46, 39 − 32 = 7. The surviving 7 are the tab-switch pair, the four
Move Tab items, and Recover Terminal Display — none is a `UserCommand`. That
membership is asserted by the guard, not by this description.

## Changes

**`Pine/PineAppMenuCommands.swift`** — 32 items converted from
`.keyboardShortcut(<literal>)` to
`.effectiveKeyboardShortcut(keybindings.effectiveChord(for: .command))`. No
default chord changes; every item still advertises what it advertised before.

**`Pine/Extensibility/UserKeybinding.swift`** — a new `FunctionKeyToken` table
maps `"f1"` … `"f20"` to the contiguous private-use scalars AppKit uses
(`NSF1FunctionKey` = `U+F704`, so F8 = `U+F70B`, the literal the menu used to
carry). `parse` accepts those tokens, and `keyToken` reports them for incoming
events, so a rebind of a function-key command suppresses the old function key
instead of leaving it live underneath the new chord. `displayText` already
rendered `"f8"` as `F8`, so the palette and the Settings list pick it up for
free — where they previously showed no shortcut for the two diagnostic
commands.

**`Pine/NativeMenuCommandState.swift`** — `MenuKeyboardShortcut` reads the same
table, which is what keeps the conversion of those two items from silently
deleting their key equivalent.

No new user-facing strings; `Strings.swift` and `Localizable.xcstrings` are
untouched.

## Tests

`PineTests/MenuShortcutOverrideTests.swift` — behaviour.

- A table of all 46 chords, transcribed from the `.keyboardShortcut(...)`
  literals the menu carried *before* this change, checked through
  `MenuKeyboardShortcut(keybindings.effectiveChord(for:))`. This is what makes
  the conversion provably lossless: the one way it fails quietly is a chord the
  menu layer cannot render.
- The table's key set is pinned to `{c | c.defaultChord != nil}`, so a new
  rebindable command cannot arrive without a record of what its item shows.
- A rebind replaces rather than supplements — for an ordinary chord and for a
  function-key chord.

`PineTests/MenuHardcodedShortcutGuardTests.swift` — the invariant, read off the
source, because SwiftUI offers no way to ask a built `Commands` body what key
equivalent an item carries.

- Every `.keyboardShortcut(` site must be one of 7 named exempt items.
- No hardcoded chord may equal a `UserCommand.defaultChord`.
- No exemption may outlive its menu item.
- Every command with a built-in chord is read by exactly one item — which
  catches both a dropped conversion and a copy-pasted neighbour's command name.

The scan fails closed throughout (missing file, unrecognised file, unreadable
chord spelling), following `ProductionSourceScan` and #1508.

## Mutation verification

Each row is a defect introduced into a green tree; the suites were re-run and
the mutation reverted.

| # | Mutation | Result |
|---|---|---|
| 1 | The 33rd hardcode: revert Toggle Comment to `.keyboardShortcut("/", modifiers: .command)` | **RED** — exempt-items, not-rebindable, and wired-once all fail |
| 2 | 33rd hardcode with a chord no command claims: `.keyboardShortcut("y", modifiers: [.command, .control])` added to Toggle Comment | **RED** — exempt-items only. Shows the allowlist is load-bearing where the chord comparison is blind |
| 3 | Hardcode the guard cannot read: `.keyboardShortcut(KeyEquivalent(Character("y")), …)` | **RED** — `#require` on the parsed chord fails. An unreadable hardcode is not an exempt one |
| 4 | `MenuKeyboardShortcut` loses its function-key branch | **RED** — the 46-chord table only. This is the F8 hole, and nothing else catches it |
| 5 | `parse` loses its function-key branch | **RED** — grammar, table coverage, the 46-chord table, and function-key suppression |
| 6 | `keyToken` loses its function-key branch (menu still renders F8) | **RED** — function-key suppression and the grammar test. The menu-side tests stay green, so the dispatch-side assertion is doing its own work |
| 7 | Mis-wire an item: Find Next reads `effectiveChord(for: .findPrevious)` | **RED** — wired-once, both halves |
| 8 | Delete Toggle Terminal Zoom's shortcut modifier outright | **RED** — wired-once ("owns a built-in chord that no menu item reads") |
| 9 | Point the scan at a moved `PineAppMenuCommands.swift` | **RED** — all four guards throw. The scan cannot pass on nothing |

Mutation 4 is the one worth reading twice: it is the exact failure a mechanical
conversion of the 32 items would have shipped, and only the transcribed table
catches it.

## Verification

```
swiftlint --strict                              # 0 violations, 806 files
PineTests/MenuShortcutOverrideTests             # 5 tests
PineTests/MenuHardcodedShortcutGuardTests       # 4 tests
PineTests/NativeFileWindowMenuTests             # 20 tests
PineTests/DestructiveShortcutPolicyTests        # 20 tests
PineTests/LocalizationCatalogCompletenessTests  # 4 tests
PineTests/ProductionSourceScanTests             # 11 tests
PineTests/UserKeybindingDispatcherTests         # 10 tests
PineTests/UserCommandInvocationRouterTests      # 6 tests
PineTests/CommandPaletteModelTests              # 9 tests
PineTests/PineAppMenuCommandsTests              # 4 tests
PineTests/SettingsLocalizationTests             # 5 tests
PineTests/HelpBookTests                         # 6 tests
```

All green. Xcode-beta toolchain, `platform=macOS`.

## Not done

Deliberately out of scope. All three are tracked in #1564
with per-item file:line references renumbered against this diff — #1539's line
numbers are stale below `PineAppMenuCommands.swift:350`, which this PR moved by
roughly +50 lines.

- **Non-standard key equivalents** (⌥Z for Word Wrap, bare F8/⇧F8, ⌘+ without a
  ⌘= alias, ⌘\` colliding with the system shortcut). Every one of these is a
  change to a *default chord*, and each needs its own decision plus a help-book
  and palette pass. Now cheaper than before: F8 is finally expressible in the
  chord grammar, and `⌘=` would be a hidden duplicate item, not a parser change.
  Estimate: ~half a day, mostly deciding the replacements.
- **Menu placement** (Close Window → File, Reveal in Finder → File, Move Tab →
  Window, Agent panels → Window). Four `CommandGroup` relocations; the risk is
  in `CommandGroup(after:)` anchors and the Xcode-26 ten-child limit noted in
  `PineCommandCollection`, not in the moves themselves. Needs a visual check of
  every menu afterwards. Estimate: ~half a day.
- **Menu naming** (missing ellipses, "Toggle X" on checkmarked items, help-book
  wording drift, the LSP ⌘R collision). This one touches `Strings.swift` and all
  nine locales in `Localizable.xcstrings`, so it should be its own PR rather
  than a rider on either of the above. Estimate: ~a day including translations.
