### PR TITLE
fix(agent): reach New Agent and project switching from the menu bar and palette

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -626,7 +626,7 @@ jobs:
               -only-testing:PineUITests/UserTaskExecutionUITests
               -only-testing:PineUITests/UnsavedChangesUITests
               -only-testing:PineUITests/ReleaseArtifactSmokeTests
-          # Shard 6 — Search & Panes (34 tests)
+          # Shard 6 — Search & Panes (35 tests)
           - shard-name: "Search & Panes"
             test-classes: >-
               -only-testing:PineUITests/CloseProjectMenuTests
@@ -636,6 +636,7 @@ jobs:
               -only-testing:PineUITests/FontSizeTests
               -only-testing:PineUITests/AgentActivityFilterUITests
               -only-testing:PineUITests/MinimapTests
+              -only-testing:PineUITests/AgentMenuBarCommandsUITests
           # Shard 7 — Security & Layout (35 tests)
           - shard-name: "Security & Layout"
             test-classes: >-

--- a/Pine/CommandOverlayContainer.swift
+++ b/Pine/CommandOverlayContainer.swift
@@ -19,6 +19,12 @@ struct CommandOverlayContainer: ViewModifier {
 
     let router: CommandOverlayRouter
     let projectManager: ProjectManager
+    /// The window session behind this project scene. Optional because the
+    /// modifier is also reachable from hosted tests and previews, where no
+    /// session is installed; a missing one simply reports that this window can
+    /// neither start an agent nor switch project (#1525).
+    @Environment(ProjectWindowSession.self) private var windowSession:
+        ProjectWindowSession?
 
     func body(content: Content) -> some View {
         content
@@ -139,7 +145,11 @@ struct CommandOverlayContainer: ViewModifier {
                     tasks: ExtensibilityManager.shared.tasks.tasks,
                     keybindings: ExtensibilityManager.shared.keybindings,
                     context: UserCommandInvocationRouter.context(
-                        for: projectManager
+                        for: projectManager,
+                        windowAvailability: ProjectWindowCommandAvailability(
+                            session: windowSession,
+                            projectManager: projectManager
+                        )
                     )
                 ),
                 onAnnounce: router.announcementSink(for: .commandPalette),
@@ -147,7 +157,11 @@ struct CommandOverlayContainer: ViewModifier {
                     CommandPaletteInvocationRouter.invoke(
                         item,
                         projectManager: projectManager,
-                        overlayRouter: router
+                        overlayRouter: router,
+                        windowAvailability: ProjectWindowCommandAvailability(
+                            session: windowSession,
+                            projectManager: projectManager
+                        )
                     )
                 }
             )
@@ -329,6 +343,7 @@ enum CommandPaletteInvocationRouter {
         _ item: CommandPaletteItem,
         projectManager: ProjectManager,
         overlayRouter: CommandOverlayRouter,
+        windowAvailability: ProjectWindowCommandAvailability = .none,
         notificationCenter: NotificationCenter = .default
     ) {
         switch item.id {
@@ -343,6 +358,7 @@ enum CommandPaletteInvocationRouter {
                 UserCommandInvocationRouter.dispatch(
                     command,
                     projectManager: projectManager,
+                    windowAvailability: windowAvailability,
                     notificationCenter: notificationCenter
                 )
             }

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -354,6 +354,11 @@ struct ContentView: View {
             ) else { return }
             handleToggleWordWrap()
         }
+        .modifier(ProjectWindowCommandObserver(
+            projectManager: projectManager,
+            session: projectWindowSession,
+            registry: registry
+        ))
         .onReceive(NotificationCenter.default.publisher(for: .revealInSidebar)) { notification in
             handleRevealInSidebar(notification)
         }

--- a/Pine/Extensibility/CommandPaletteModel.swift
+++ b/Pine/Extensibility/CommandPaletteModel.swift
@@ -37,13 +37,18 @@ nonisolated enum CommandPaletteCategory: String, Sendable, CaseIterable {
     }
 }
 
-nonisolated enum CommandAvailabilityRequirement: Sendable {
+nonisolated enum CommandAvailabilityRequirement: Sendable, Equatable {
     case always
     case project
     case activeFile
     case activeFileAndTerminal
     case gitRepository
     case terminal
+    /// A git project in a window whose session can still start an agent
+    /// (#1525): an agent CLI on `PATH`, and no launch already in flight.
+    case agentWorktree
+    /// A window holding more than one project or agent worktree (#1525).
+    case projectSwitching
 }
 
 nonisolated struct CommandPaletteContext: Sendable, Equatable {
@@ -51,6 +56,27 @@ nonisolated struct CommandPaletteContext: Sendable, Equatable {
     let hasActiveFile: Bool
     let isGitRepository: Bool
     let hasTerminal: Bool
+    /// Window-scoped facts (#1525). Defaulted so the many call sites that
+    /// only describe the focused project keep compiling and keep meaning
+    /// "no window session, therefore nothing on offer".
+    let canLaunchAgent: Bool
+    let canSwitchProjectInWindow: Bool
+
+    init(
+        hasProject: Bool,
+        hasActiveFile: Bool,
+        isGitRepository: Bool,
+        hasTerminal: Bool,
+        canLaunchAgent: Bool = false,
+        canSwitchProjectInWindow: Bool = false
+    ) {
+        self.hasProject = hasProject
+        self.hasActiveFile = hasActiveFile
+        self.isGitRepository = isGitRepository
+        self.hasTerminal = hasTerminal
+        self.canLaunchAgent = canLaunchAgent
+        self.canSwitchProjectInWindow = canSwitchProjectInWindow
+    }
 
     static let unavailable = CommandPaletteContext(
         hasProject: false,
@@ -73,6 +99,10 @@ nonisolated struct CommandPaletteContext: Sendable, Equatable {
             isGitRepository
         case .terminal:
             hasTerminal
+        case .agentWorktree:
+            canLaunchAgent
+        case .projectSwitching:
+            canSwitchProjectInWindow
         }
     }
 }
@@ -227,6 +257,10 @@ enum CommandPaletteCatalog {
             Strings.commandPaletteRequiresGitRepository
         case .terminal:
             Strings.commandPaletteRequiresTerminal
+        case .agentWorktree:
+            Strings.commandPaletteRequiresAgentWorktree
+        case .projectSwitching:
+            Strings.commandPaletteRequiresProjectSwitching
         }
     }
 

--- a/Pine/Extensibility/UserCommand+Palette.swift
+++ b/Pine/Extensibility/UserCommand+Palette.swift
@@ -110,6 +110,12 @@ nonisolated extension UserCommand {
             String(localized: "menu.agentHistory")
         case .showAgentInbox:
             String(localized: "menu.agentInbox")
+        case .newAgent:
+            String(localized: "projectSwitcher.newAgent")
+        case .nextProjectInWindow:
+            String(localized: "menu.nextProjectInWindow")
+        case .previousProjectInWindow:
+            String(localized: "menu.previousProjectInWindow")
         case .toggleTerminal:
             String(localized: "terminal.toggle")
         case .newTerminalTab:
@@ -154,8 +160,10 @@ nonisolated extension UserCommand {
              .toggleWordWrap, .toggleMinimap, .toggleBlame, .togglePreview,
              .revealFileInFinder, .revealProjectInFinder,
              .showAgentActivity, .showAgentHistory, .showAgentInbox,
-             .showProblems:
+             .showProblems, .newAgent:
             .view
+        case .nextProjectInWindow, .previousProjectInWindow:
+            .file
         case .nextDiagnostic, .previousDiagnostic:
             .edit
         case .showBranchSwitcher:
@@ -262,6 +270,12 @@ nonisolated extension UserCommand {
             MenuIcons.agentHistory
         case .showAgentInbox:
             MenuIcons.agentInbox
+        case .newAgent:
+            MenuIcons.projectSwitcherNewAgent
+        case .nextProjectInWindow:
+            MenuIcons.nextProjectInWindow
+        case .previousProjectInWindow:
+            MenuIcons.previousProjectInWindow
         case .toggleTerminal:
             MenuIcons.toggleTerminal
         case .newTerminalTab:
@@ -303,6 +317,10 @@ nonisolated extension UserCommand {
              .revealProjectInFinder, .showAgentActivity, .showAgentHistory,
              .showProblems, .nextDiagnostic, .previousDiagnostic:
             .project
+        case .newAgent:
+            .agentWorktree
+        case .nextProjectInWindow, .previousProjectInWindow:
+            .projectSwitching
         case .showBranchSwitcher:
             .gitRepository
         case .findInTerminal, .toggleTerminalZoom:
@@ -402,6 +420,16 @@ nonisolated extension UserCommand {
             value = nil
         case .showAgentInbox:
             value = "cmd+shift+i"
+        case .newAgent:
+            // "A" for agent, beside the Agent Inbox's cmd+shift+i. Free in
+            // Pine and not claimed by a standard macOS menu equivalent.
+            value = "cmd+shift+a"
+        case .nextProjectInWindow, .previousProjectInWindow:
+            // Which project to switch *to* is not expressible as a chord, and
+            // every remaining free chord is meaningful to someone. The menu
+            // bar and the palette carry the discovery; a user who wants a
+            // chord binds one in `keybindings.json`.
+            value = nil
         case .toggleTerminal:
             value = "cmd+`"
         case .newTerminalTab:

--- a/Pine/Extensibility/UserCommandInvocationRouter.swift
+++ b/Pine/Extensibility/UserCommandInvocationRouter.swift
@@ -15,9 +15,13 @@ enum UserCommandInvocationRouter {
     static func dispatch(
         _ command: UserCommand,
         projectManager: ProjectManager?,
+        windowAvailability: ProjectWindowCommandAvailability = .none,
         notificationCenter: NotificationCenter = .default
     ) {
-        let context = context(for: projectManager)
+        let context = context(
+            for: projectManager,
+            windowAvailability: windowAvailability
+        )
         guard context.satisfies(command.availabilityRequirement) else {
             return
         }
@@ -92,6 +96,24 @@ enum UserCommandInvocationRouter {
             notificationCenter.post(
                 name: .showAgentInbox,
                 object: nil
+            )
+
+        case .newAgent:
+            // No identifier: the palette and user keybindings mean the
+            // preferred (last-used) agent. Only a menu item names one.
+            ProjectAgentLaunchSelection.post(
+                identifier: nil,
+                projectManager: projectManager,
+                notificationCenter: notificationCenter
+            )
+
+        case .nextProjectInWindow, .previousProjectInWindow:
+            let direction: ProjectWindowSwitchOrder.Direction =
+                command == .nextProjectInWindow ? .next : .previous
+            notificationCenter.post(
+                name: .switchProjectInWindow,
+                object: projectManager,
+                userInfo: ["direction": direction.rawValue]
             )
 
         case .goToLine, .symbolNavigator, .quickOpen, .commandPalette:
@@ -249,7 +271,8 @@ enum UserCommandInvocationRouter {
     }
 
     static func context(
-        for projectManager: ProjectManager?
+        for projectManager: ProjectManager?,
+        windowAvailability: ProjectWindowCommandAvailability = .none
     ) -> CommandPaletteContext {
         guard let projectManager else {
             return .unavailable
@@ -261,7 +284,9 @@ enum UserCommandInvocationRouter {
             hasProject: projectManager.workspace.rootURL != nil,
             hasActiveFile: nativeState.activeEditorTabID != nil,
             isGitRepository: projectManager.workspace.gitProvider.isGitRepository,
-            hasTerminal: projectManager.hasTerminalPanes
+            hasTerminal: projectManager.hasTerminalPanes,
+            canLaunchAgent: windowAvailability.canLaunchAgent,
+            canSwitchProjectInWindow: windowAvailability.canSwitchProject
         )
     }
 

--- a/Pine/Extensibility/UserKeybinding.swift
+++ b/Pine/Extensibility/UserKeybinding.swift
@@ -87,6 +87,10 @@ nonisolated enum UserCommand: String, Sendable, CaseIterable {
     case showAgentActivity
     case showAgentHistory
     case showAgentInbox
+    // Agent worktrees (#1525) — reachable without the toolbar
+    case newAgent
+    case nextProjectInWindow
+    case previousProjectInWindow
     case toggleTerminal
     case newTerminalTab
     case findInTerminal
@@ -147,6 +151,9 @@ nonisolated enum UserCommand: String, Sendable, CaseIterable {
         case .showAgentActivity: "showAgentActivity"
         case .showAgentHistory: "showAgentHistory"
         case .showAgentInbox: "showAgentInbox"
+        case .newAgent: "newAgent"
+        case .nextProjectInWindow, .previousProjectInWindow:
+            "switchProjectInWindow"
         case .toggleTerminal: "user.toggleTerminal"
         case .newTerminalTab: "user.newTerminalTab"
         case .findInTerminal: "findInTerminal"

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -8970,6 +8970,66 @@
         }
       }
     },
+    "menu.nextProjectInWindow": {
+      "comment": "Menu command that activates the next project or agent worktree open in the current window.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nächstes Projekt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next Project"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proyecto siguiente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Projet suivant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次のプロジェクト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음 프로젝트"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Próximo projeto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Следующий проект"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下一个项目"
+          }
+        }
+      }
+    },
     "menu.openFolder": {
       "comment": "Menu command: open a folder picker dialog (⌘⇧O).",
       "extractionState": "manual",
@@ -9086,6 +9146,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "跳转到上一处更改"
+          }
+        }
+      }
+    },
+    "menu.previousProjectInWindow": {
+      "comment": "Menu command that activates the previous project or agent worktree open in the current window.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorheriges Projekt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous Project"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proyecto anterior"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Projet précédent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前のプロジェクト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전 프로젝트"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Projeto anterior"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предыдущий проект"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上一个项目"
           }
         }
       }
@@ -9986,6 +10106,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "切换分支…"
+          }
+        }
+      }
+    },
+    "menu.switchProjectInWindow": {
+      "comment": "Menu-bar submenu listing the projects and agent worktrees open in the current window.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Projekt wechseln"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch Project"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar de proyecto"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changer de projet"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロジェクトを切り替え"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로젝트 전환"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alternar projeto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переключить проект"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换项目"
           }
         }
       }
@@ -25504,6 +25684,66 @@
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "需要活动文件。" } }
       }
     },
+    "commandPalette.unavailable.agentWorktree": {
+      "comment": "Command palette explanation for a disabled command that requires a Git repository and an installed agent.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erfordert ein Git-Repository und einen installierten Agenten."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requires a Git repository and an installed agent."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requiere un repositorio Git y un agente instalado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nécessite un dépôt Git et un agent installé."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Git リポジトリとインストール済みのエージェントが必要です。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Git 저장소와 설치된 에이전트가 필요합니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requer um repositório Git e um agente instalado."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Требуется репозиторий Git и установленный агент."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要 Git 仓库和已安装的智能体。"
+          }
+        }
+      }
+    },
     "commandPalette.unavailable.gitRepository": {
       "comment": "Command palette explanation for a disabled command that requires a Git repository.",
       "extractionState": "manual",
@@ -25517,6 +25757,66 @@
         "pt-BR": { "stringUnit": { "state": "translated", "value": "Requer um repositório Git." } },
         "ru": { "stringUnit": { "state": "translated", "value": "Требуется репозиторий Git." } },
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "需要 Git 仓库。" } }
+      }
+    },
+    "commandPalette.unavailable.projectSwitching": {
+      "comment": "Command palette explanation for a disabled command that requires a second project or agent worktree in the same window.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erfordert ein weiteres Projekt oder Worktree in diesem Fenster."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requires another project or worktree in this window."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requiere otro proyecto o árbol de trabajo en esta ventana."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nécessite un autre projet ou arbre de travail dans cette fenêtre."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このウインドウに別のプロジェクトまたはワークツリーが必要です。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 윈도우에 다른 프로젝트나 워크트리가 필요합니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requer outro projeto ou worktree nesta janela."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Требуется другой проект или рабочее дерево в этом окне."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要此窗口中的另一个项目或工作树。"
+          }
+        }
       }
     },
     "commandPalette.unavailable.terminal": {

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -118,4 +118,8 @@ nonisolated enum MenuIcons {
     static let projectSwitcherOpenFolder = "folder.badge.plus"
     static let projectSwitcherActive = "checkmark"
     static let projectSwitcherProject = "folder"
+    /// Menu-bar route to the switcher rows (#1525).
+    static let switchProjectInWindow = "rectangle.stack"
+    static let nextProjectInWindow = "chevron.forward"
+    static let previousProjectInWindow = "chevron.backward"
 }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -43,6 +43,12 @@ struct PineApp: App {
                 },
                 showAgentInbox: { [weak appDelegate] in
                     appDelegate?.showAgentInbox()
+                },
+                windowSession: { [weak appDelegate] in
+                    appDelegate?.registry.keyWindowSession()
+                },
+                projectRegistry: { [weak appDelegate] in
+                    appDelegate?.registry
                 }
             )
         }
@@ -1609,7 +1615,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 dispatchUserCommand: { command in
                     UserCommandInvocationRouter.dispatch(
                         command,
-                        projectManager: self?.activeProjectManager()
+                        projectManager: self?.activeProjectManager(),
+                        windowAvailability: ProjectWindowCommandAvailability(
+                            session: self?.registry.keyWindowSession(),
+                            projectManager: self?.activeProjectManager()
+                        )
                     )
                 },
                 dispatchBuiltIn: { [weak self] event in

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -40,6 +40,16 @@ struct PineAppMenuCommands: Commands {
     /// observation of `ProjectRegistry.recentProjects` in the menu body.
     let recentProjects: () -> [URL]
     let showAgentInbox: () -> Void
+    /// The window session behind the focused project scene (#1525). Starting
+    /// an agent in a worktree, and moving between the projects one window
+    /// holds, are session-scoped commands that used to exist only inside the
+    /// toolbar's switcher menu; the menu bar needs the same session to offer
+    /// them. `nil` while no project window is key.
+    let windowSession: () -> ProjectWindowSession?
+    /// Reads the app-scoped registry for the switcher rows, which resolve each
+    /// worktree's agent task to a status glyph. Same rationale as
+    /// `recentProjects`: a closure keeps Commands off the AppDelegate.
+    let projectRegistry: () -> ProjectRegistry?
     @FocusedValue(\.projectManager) private var focusedProject: ProjectManager?
     @AppStorage("minimapVisible") private var minimapVisible = true
     @AppStorage(BlameConstants.storageKey) private var blameVisible = true
@@ -49,6 +59,16 @@ struct PineAppMenuCommands: Commands {
     }
     private var nativeState: NativeMenuCommandState {
         NativeMenuCommandState(projectManager: focusedProject)
+    }
+    /// What the focused window can do with its projects and agents (#1525).
+    private var windowAvailability: ProjectWindowCommandAvailability {
+        ProjectWindowCommandAvailability(
+            session: windowSession(),
+            projectManager: focusedProject
+        )
+    }
+    private var agentLaunchOptions: [ProjectAgentLaunchOption] {
+        windowSession()?.availableAgentOptions ?? []
     }
 
     var body: some Commands {
@@ -339,6 +359,68 @@ struct PineAppMenuCommands: Commands {
                 (focusedProject?.paneManager
                     .validGlobalTabSwitchOrder().count ?? 0) < 2
             )
+
+            Divider()
+
+            // The window's projects and agent worktrees, listed where macOS
+            // keeps "what this window is showing" (#1525).
+            Menu {
+                if let session = windowSession(),
+                   let registry = projectRegistry() {
+                    ProjectSwitcherRows(
+                        session: session,
+                        registry: registry,
+                        carriesIdentifiers: false,
+                        onSelect: { url in
+                            NotificationCenter.default.post(
+                                name: .switchProjectInWindow,
+                                object: focusedProject,
+                                userInfo: ["url": url]
+                            )
+                        }
+                    )
+                }
+            } label: {
+                Label(
+                    Strings.menuSwitchProjectInWindow,
+                    systemImage: MenuIcons.switchProjectInWindow
+                )
+            }
+            .disabled(!windowAvailability.canSwitchProject)
+
+            Button {
+                UserCommandInvocationRouter.dispatch(
+                    .nextProjectInWindow,
+                    projectManager: focusedProject,
+                    windowAvailability: windowAvailability
+                )
+            } label: {
+                Label(
+                    Strings.menuNextProjectInWindow,
+                    systemImage: MenuIcons.nextProjectInWindow
+                )
+            }
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .nextProjectInWindow)
+            )
+            .disabled(!windowAvailability.canSwitchProject)
+
+            Button {
+                UserCommandInvocationRouter.dispatch(
+                    .previousProjectInWindow,
+                    projectManager: focusedProject,
+                    windowAvailability: windowAvailability
+                )
+            } label: {
+                Label(
+                    Strings.menuPreviousProjectInWindow,
+                    systemImage: MenuIcons.previousProjectInWindow
+                )
+            }
+            .effectiveKeyboardShortcut(
+                keybindings.effectiveChord(for: .previousProjectInWindow)
+            )
+            .disabled(!windowAvailability.canSwitchProject)
         }
 
         // MARK: - Edit menu
@@ -707,6 +789,42 @@ struct PineAppMenuCommands: Commands {
             .disabled(focusedProject?.workspace.rootURL == nil)
 
             Divider()
+
+            // The switcher's New Agent submenu, in the menu bar where it
+            // belongs (#1525). Hiding the toolbar used to delete the feature
+            // outright: a toolbar is a convenience layer over commands that
+            // live in the menu bar, never their only route.
+            Menu {
+                let options = agentLaunchOptions
+                if options.isEmpty {
+                    Text(Strings.projectSwitcherNoAgents)
+                } else {
+                    ForEach(options) { option in
+                        Button(option.displayName) {
+                            ProjectAgentLaunchSelection.post(
+                                identifier: option.id,
+                                projectManager: focusedProject
+                            )
+                        }
+                        // The preferred (last-used) agent carries the
+                        // command's chord, because that is exactly what the
+                        // palette and a user keybinding launch. Attaching it
+                        // to the submenu's own item instead would give the
+                        // chord nothing to fire.
+                        .effectiveKeyboardShortcut(
+                            option.id == options.first?.id
+                                ? keybindings.effectiveChord(for: .newAgent)
+                                : nil
+                        )
+                    }
+                }
+            } label: {
+                Label(
+                    Strings.projectSwitcherNewAgent,
+                    systemImage: MenuIcons.projectSwitcherNewAgent
+                )
+            }
+            .disabled(!windowAvailability.canLaunchAgent)
 
             Button {
                 showAgentInbox()

--- a/Pine/PineAppNotifications.swift
+++ b/Pine/PineAppNotifications.swift
@@ -93,6 +93,20 @@ extension Notification.Name {
     /// Shows the persistent agent-history timeline sheet.
     static let showAgentHistory = Notification.Name("showAgentHistory")
 
+    // MARK: - Agent worktrees (#1525)
+    /// Starts an agent in a fresh worktree off the target window's active
+    /// repository.
+    /// userInfo: ["agentIdentifier": String] — absent means the preferred
+    /// (last-used) agent.
+    static let newAgent = Notification.Name("newAgent")
+
+    /// Changes which project or agent worktree the target window shows.
+    /// userInfo: ["url": URL] for a named row, or ["direction": "next" |
+    /// "previous"] to step through the switcher order.
+    static let switchProjectInWindow = Notification.Name(
+        "switchProjectInWindow"
+    )
+
     // MARK: - Agent handoff (#933)
     /// Posted after the user changes the read-only editor-context permission.
     static let agentHandoffSettingsChanged = Notification.Name(

--- a/Pine/ProjectSwitcherView.swift
+++ b/Pine/ProjectSwitcherView.swift
@@ -22,19 +22,16 @@ struct ProjectSwitcherView: View {
 
     var body: some View {
         Menu {
-            let groups = session.groups
-            ForEach(Array(groups.enumerated()), id: \.element.id) { index, group in
-                if ProjectSwitcherMenuLayout.needsDivider(
-                    before: index,
-                    in: groups
-                ) {
-                    Divider()
+            ProjectSwitcherRows(
+                session: session,
+                registry: registry,
+                carriesIdentifiers: true,
+                onSelect: { url in
+                    Task { @MainActor in
+                        await session.activate(url, registry: registry)
+                    }
                 }
-                projectButton(group.projectURL)
-                ForEach(group.worktrees, id: \.worktreeRoot) { worktree in
-                    worktreeButton(worktree)
-                }
-            }
+            )
 
             Divider()
 
@@ -130,13 +127,48 @@ struct ProjectSwitcherView: View {
         .accessibilityLabel(Text(session.activeDisplayName))
         .accessibilityIdentifier(AccessibilityID.projectSwitcher)
     }
+}
+
+/// The switcher's rows: every project this window holds, the agent worktrees
+/// hanging off each, and the dividers that group them.
+///
+/// Shared by the toolbar control and the menu bar's Switch Project submenu
+/// (#1525). The toolbar is a convenience layer over commands that exist in the
+/// menu bar, never their only home — and one row renderer is what keeps the
+/// two from disagreeing about what this window is showing.
+struct ProjectSwitcherRows: View {
+    let session: ProjectWindowSession
+    let registry: ProjectRegistry
+    /// Whether these rows carry the switcher's accessibility identifiers.
+    ///
+    /// The toolbar control owns them. The menu bar draws the same rows and
+    /// must not stamp a second copy with the same identifiers: every XCUITest
+    /// and VoiceOver lookup would then match two elements and reach whichever
+    /// came first. Menu-bar rows are found by title, as every other menu-bar
+    /// item is.
+    let carriesIdentifiers: Bool
+    let onSelect: (URL) -> Void
+
+    var body: some View {
+        let groups = session.groups
+        ForEach(Array(groups.enumerated()), id: \.element.id) { index, group in
+            if ProjectSwitcherMenuLayout.needsDivider(
+                before: index,
+                in: groups
+            ) {
+                Divider()
+            }
+            projectButton(group.projectURL)
+            ForEach(group.worktrees, id: \.worktreeRoot) { worktree in
+                worktreeButton(worktree)
+            }
+        }
+    }
 
     @ViewBuilder
     private func projectButton(_ url: URL) -> some View {
-        Button {
-            Task { @MainActor in
-                await session.activate(url, registry: registry)
-            }
+        let button = Button {
+            onSelect(url)
         } label: {
             Label {
                 Text(session.displayName(for: url))
@@ -147,13 +179,21 @@ struct ProjectSwitcherView: View {
             }
         }
         .disabled(session.isLaunchingAgent)
-        // Identified by the disambiguated name, not the folder name: two roots
-        // called `infra` would otherwise answer to the same identifier, and
-        // both VoiceOver and XCUITest would only ever reach the first one.
-        // With no collision the two strings are identical, so this is stable.
-        .accessibilityIdentifier(
-            AccessibilityID.projectSwitcherProject(session.displayName(for: url))
-        )
+
+        if carriesIdentifiers {
+            // Identified by the disambiguated name, not the folder name: two
+            // roots called `infra` would otherwise answer to the same
+            // identifier, and both VoiceOver and XCUITest would only ever
+            // reach the first one. With no collision the two strings are
+            // identical, so this is stable.
+            button.accessibilityIdentifier(
+                AccessibilityID.projectSwitcherProject(
+                    session.displayName(for: url)
+                )
+            )
+        } else {
+            button
+        }
     }
 
     @ViewBuilder
@@ -164,13 +204,8 @@ struct ProjectSwitcherView: View {
             task: task,
             isActive: session.activeProjectURL == worktree.worktreeRoot
         )
-        Button {
-            Task { @MainActor in
-                await session.activate(
-                    worktree.worktreeRoot,
-                    registry: registry
-                )
-            }
+        let button = Button {
+            onSelect(worktree.worktreeRoot)
         } label: {
             Label {
                 Text(presentation.title)
@@ -179,9 +214,14 @@ struct ProjectSwitcherView: View {
             }
         }
         .disabled(session.isLaunchingAgent)
-        .accessibilityIdentifier(
-            AccessibilityID.projectSwitcherWorktree(worktree.taskID)
-        )
+
+        if carriesIdentifiers {
+            button.accessibilityIdentifier(
+                AccessibilityID.projectSwitcherWorktree(worktree.taskID)
+            )
+        } else {
+            button
+        }
     }
 }
 

--- a/Pine/ProjectWindowCommandAvailability.swift
+++ b/Pine/ProjectWindowCommandAvailability.swift
@@ -1,0 +1,113 @@
+//
+//  ProjectWindowCommandAvailability.swift
+//  Pine
+//
+//  Issue #1525: starting an agent in a worktree, and moving between the
+//  projects a window holds, used to exist only inside the toolbar's
+//  project-switcher menu — hiding the toolbar deleted both features.
+//
+//  Both are now ordinary registered commands, which means three surfaces
+//  (menu bar, Command Palette, user keybindings) have to agree on when they
+//  are offered. That agreement lives here as a plain value: the window
+//  session is a `@MainActor` observable object, and threading it through the
+//  invocation router would make the router's gate untestable.
+//
+
+import Foundation
+
+/// What the focused window can currently do with its projects and agents.
+nonisolated struct ProjectWindowCommandAvailability: Sendable, Equatable {
+    /// Agent worktrees are cut with `git worktree add`; a plain folder has
+    /// nothing to branch from.
+    let isGitRepository: Bool
+    /// Whether any first-party agent CLI resolved on `PATH`.
+    let hasAgentOptions: Bool
+    /// A launch already in flight. `ProjectWindowSession` refuses a second
+    /// one, and every switcher row is disabled while it runs.
+    let isLaunchingAgent: Bool
+    /// Projects plus agent worktrees in this window.
+    let switchableTargetCount: Int
+
+    /// No window, or no window session — the Welcome window, a scene whose
+    /// project was closed. Nothing on offer.
+    static let none = ProjectWindowCommandAvailability(
+        isGitRepository: false,
+        hasAgentOptions: false,
+        isLaunchingAgent: false,
+        switchableTargetCount: 0
+    )
+
+    var canLaunchAgent: Bool {
+        isGitRepository && hasAgentOptions && !isLaunchingAgent
+    }
+
+    /// One row is not a choice: wrapping would re-activate the row already on
+    /// screen, so a single-project window offers no switching.
+    var canSwitchProject: Bool {
+        !isLaunchingAgent && switchableTargetCount > 1
+    }
+}
+
+@MainActor
+extension ProjectWindowCommandAvailability {
+    /// Reads the live facts off the focused window.
+    ///
+    /// The repository question is asked of the focused project rather than the
+    /// session's `activeRepositoryURL`: an agent worktree is itself a git
+    /// checkout, so the answer is the same, and this way the menu never has to
+    /// touch the filesystem to decide whether to dim an item.
+    init(
+        session: ProjectWindowSession?,
+        projectManager: ProjectManager?
+    ) {
+        guard let session, let projectManager else {
+            self = .none
+            return
+        }
+        self.init(
+            isGitRepository: projectManager.workspace.gitProvider
+                .isGitRepository,
+            hasAgentOptions: !session.availableAgentOptions.isEmpty,
+            isLaunchingAgent: session.isLaunchingAgent,
+            switchableTargetCount: session.switchTargets.count
+        )
+    }
+}
+
+/// Resolves which agent a New Agent request means, and carries that request
+/// from a menu item to the window that owns the session.
+nonisolated enum ProjectAgentLaunchSelection {
+    /// `userInfo` key naming one agent. Absent means "the preferred one".
+    static let identifierKey = "agentIdentifier"
+
+    /// The agent a request names, or the preferred one when it names nothing.
+    ///
+    /// A named agent that is no longer in the catalog resolves to `nil` rather
+    /// than falling back: the catalog can shrink between a menu opening and
+    /// the click landing, and launching a different agent than the one clicked
+    /// is worse than launching none.
+    static func option(
+        identifier: String?,
+        in options: [ProjectAgentLaunchOption]
+    ) -> ProjectAgentLaunchOption? {
+        guard let identifier else { return options.first }
+        return options.first { $0.id == identifier }
+    }
+
+    /// Posts a New Agent request at the window owning `projectManager`.
+    ///
+    /// Menu items name their agent; the palette and user keybindings do not,
+    /// and mean the preferred one.
+    @MainActor
+    static func post(
+        identifier: String?,
+        projectManager: ProjectManager?,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        notificationCenter.post(
+            name: .newAgent,
+            object: projectManager,
+            userInfo: identifier.map { [identifierKey: $0] }
+        )
+    }
+}

--- a/Pine/ProjectWindowCommandObserver.swift
+++ b/Pine/ProjectWindowCommandObserver.swift
@@ -1,0 +1,110 @@
+//
+//  ProjectWindowCommandObserver.swift
+//  Pine
+//
+//  Issue #1525: New Agent and project switching are now ordinary registered
+//  commands, posted from the menu bar, the Command Palette and user
+//  keybindings. They act on the window session, which only a project scene
+//  owns — so the scene is where the requests land.
+//
+
+import SwiftUI
+
+/// Applies window-scoped agent and project-switching commands to this scene.
+struct ProjectWindowCommandObserver: ViewModifier {
+    @Environment(\.controlActiveState) private var controlActiveState
+    let projectManager: ProjectManager
+    let session: ProjectWindowSession
+    let registry: ProjectRegistry
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(
+                NotificationCenter.default.publisher(for: .newAgent)
+            ) { notification in
+                guard isForThisWindow(notification) else { return }
+                let identifier = notification.userInfo?[
+                    ProjectAgentLaunchSelection.identifierKey
+                ] as? String
+                // A menu click arrives while AppKit is still tracking the
+                // menu, and launching mutates the session (active project,
+                // a new terminal) synchronously inside its first hop. Let
+                // menu tracking unwind first, exactly as Open Folder and
+                // Close Project do.
+                NativeCommandDelivery.deferToNextMainRunLoop {
+                    launchAgent(identifier: identifier)
+                }
+            }
+            .onReceive(
+                NotificationCenter.default
+                    .publisher(for: .switchProjectInWindow)
+            ) { notification in
+                guard isForThisWindow(notification) else { return }
+                guard let target = target(of: notification) else { return }
+                NativeCommandDelivery.deferToNextMainRunLoop {
+                    Task { @MainActor in
+                        await session.activate(target, registry: registry)
+                    }
+                }
+            }
+    }
+
+    private func isForThisWindow(_ notification: Notification) -> Bool {
+        ContentView.shouldHandleTargetedCommand(
+            notificationObject: notification.object,
+            currentProject: projectManager,
+            isKeyWindow: controlActiveState == .key
+        )
+    }
+
+    private func launchAgent(identifier: String?) {
+        // Resolved against the live catalog rather than the one the menu was
+        // built from: an agent uninstalled in between must not silently
+        // launch a different one in its place.
+        guard let option = ProjectAgentLaunchSelection.option(
+            identifier: identifier,
+            in: session.availableAgentOptions
+        ) else {
+            return
+        }
+        Task { @MainActor in
+            await session.launchAgent(option, registry: registry)
+        }
+    }
+
+    /// A named row, or the row one step away in the switcher's order.
+    private func target(of notification: Notification) -> URL? {
+        switch ProjectWindowSwitchRequest.parse(notification.userInfo) {
+        case .row(let url):
+            url
+        case .step(let direction):
+            session.neighbourTarget(direction)
+        case nil:
+            nil
+        }
+    }
+}
+
+/// What a `switchProjectInWindow` notification is asking for.
+///
+/// Menu rows name a URL; Next/Previous Project name a direction. Anything
+/// else — a missing payload, a direction Pine does not define — is not a
+/// request at all: acting on a half-understood payload would move the window
+/// somewhere the user never pointed at.
+nonisolated enum ProjectWindowSwitchRequest: Equatable {
+    case row(URL)
+    case step(ProjectWindowSwitchOrder.Direction)
+
+    static func parse(_ userInfo: [AnyHashable: Any]?) -> Self? {
+        if let url = userInfo?["url"] as? URL {
+            return .row(url)
+        }
+        guard let raw = userInfo?["direction"] as? String,
+              let direction = ProjectWindowSwitchOrder.Direction(
+                  rawValue: raw
+              ) else {
+            return nil
+        }
+        return .step(direction)
+    }
+}

--- a/Pine/ProjectWindowSession.swift
+++ b/Pine/ProjectWindowSession.swift
@@ -31,6 +31,48 @@ nonisolated struct ProjectWindowGroup: Identifiable, Equatable, Sendable {
     var id: URL { projectURL }
 }
 
+/// The switcher's rows as a flat, walkable list (#1525).
+///
+/// The toolbar menu is not the only way to move between the projects and
+/// agent worktrees a window holds — the menu bar offers the same rows, and
+/// Next/Previous Project step through them. Keeping the order in one pure
+/// place is what stops the two surfaces from disagreeing about which row
+/// comes after which.
+nonisolated enum ProjectWindowSwitchOrder {
+    enum Direction: String, Sendable, Equatable {
+        case next
+        case previous
+    }
+
+    /// Reading order of the switcher: every project immediately followed by
+    /// the agent worktrees hanging off it.
+    static func targets(in groups: [ProjectWindowGroup]) -> [URL] {
+        groups.flatMap { group in
+            [group.projectURL.standardizedFileURL]
+                + group.worktrees.map(\.worktreeRoot.standardizedFileURL)
+        }
+    }
+
+    /// The row `direction` away from `active`, wrapping at either end.
+    ///
+    /// `nil` when there is nowhere to go — a window showing a single row, or
+    /// an origin this window no longer holds. Both cases must not guess: a
+    /// guess would switch the window somewhere the user never pointed at.
+    static func neighbour(
+        of active: URL,
+        in targets: [URL],
+        direction: Direction
+    ) -> URL? {
+        guard targets.count > 1,
+              let index = targets.firstIndex(of: active.standardizedFileURL)
+        else {
+            return nil
+        }
+        let offset = direction == .next ? 1 : targets.count - 1
+        return targets[(index + offset) % targets.count]
+    }
+}
+
 enum ProjectWindowRestorationResult: Equatable {
     case restored
     case unavailable
@@ -238,6 +280,24 @@ final class ProjectWindowSession {
             return lhs.displayName.localizedStandardCompare(rhs.displayName)
                 == .orderedAscending
         }
+    }
+
+    /// Every project and agent worktree this window holds, in switcher order.
+    var switchTargets: [URL] {
+        ProjectWindowSwitchOrder.targets(in: groups)
+    }
+
+    /// The row a Next/Previous Project command should activate, or `nil` when
+    /// this window has nowhere to step to.
+    func neighbourTarget(
+        _ direction: ProjectWindowSwitchOrder.Direction
+    ) -> URL? {
+        guard !isLaunchingAgent else { return nil }
+        return ProjectWindowSwitchOrder.neighbour(
+            of: activeProjectURL,
+            in: switchTargets,
+            direction: direction
+        )
     }
 
     func restoreIfNeeded(

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -774,6 +774,15 @@ enum Strings {
     static let projectSwitcherNoAgents: LocalizedStringKey =
         "projectSwitcher.noAgents"
 
+    /// Menu-bar route to the switcher rows (#1525). The toolbar is a
+    /// convenience layer over these commands, never their only home.
+    static let menuSwitchProjectInWindow: LocalizedStringKey =
+        "menu.switchProjectInWindow"
+    static let menuNextProjectInWindow: LocalizedStringKey =
+        "menu.nextProjectInWindow"
+    static let menuPreviousProjectInWindow: LocalizedStringKey =
+        "menu.previousProjectInWindow"
+
     /// Names the project being closed, so the menu item is unambiguous in a
     /// window holding several.
     static func projectSwitcherCloseProjectTitle(
@@ -1574,6 +1583,12 @@ enum Strings {
     }
     static var commandPaletteRequiresTerminal: String {
         String(localized: "commandPalette.unavailable.terminal")
+    }
+    static var commandPaletteRequiresAgentWorktree: String {
+        String(localized: "commandPalette.unavailable.agentWorktree")
+    }
+    static var commandPaletteRequiresProjectSwitching: String {
+        String(localized: "commandPalette.unavailable.projectSwitching")
     }
     static var commandPaletteNeedsFileAndTerminal: String {
         String(localized: "commandPalette.unavailable.activeFileAndTerminal")

--- a/PineTests/AgentLaunchCommandTests.swift
+++ b/PineTests/AgentLaunchCommandTests.swift
@@ -1,0 +1,453 @@
+//
+//  AgentLaunchCommandTests.swift
+//  PineTests
+//
+//  Issue #1525: launching an agent in a worktree, and switching the window's
+//  active project, existed only inside the toolbar's project-switcher menu.
+//  Hiding the toolbar removed both. These tests pin the headless halves of
+//  the menu-bar / Command Palette / keybinding route that replaces it.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Agent launch and project switching commands")
+@MainActor
+struct AgentLaunchCommandTests {
+
+    // MARK: - Availability
+
+    private func availability(
+        git: Bool = true,
+        agents: Bool = true,
+        launching: Bool = false,
+        targets: Int = 2
+    ) -> ProjectWindowCommandAvailability {
+        ProjectWindowCommandAvailability(
+            isGitRepository: git,
+            hasAgentOptions: agents,
+            isLaunchingAgent: launching,
+            switchableTargetCount: targets
+        )
+    }
+
+    /// Every clause has to hold. A worktree cannot be cut from a non-repository,
+    /// there is nothing to run without an installed agent CLI, and a second
+    /// launch while one is in flight is what `ProjectWindowSession.launchAgent`
+    /// already refuses — the menu must not offer what the session will drop.
+    @Test("agent launch needs a repository, an agent, and an idle session")
+    func agentLaunchAvailabilityIsConjunctive() {
+        #expect(availability().canLaunchAgent)
+        #expect(!availability(git: false).canLaunchAgent)
+        #expect(!availability(agents: false).canLaunchAgent)
+        #expect(!availability(launching: true).canLaunchAgent)
+    }
+
+    @Test("switching needs a second row and an idle session")
+    func projectSwitchAvailability() {
+        #expect(availability(targets: 2).canSwitchProject)
+        #expect(!availability(targets: 1).canSwitchProject)
+        #expect(!availability(targets: 0).canSwitchProject)
+        #expect(!availability(launching: true, targets: 2).canSwitchProject)
+    }
+
+    @Test("an absent window session offers neither command")
+    func absentSessionOffersNothing() {
+        #expect(!ProjectWindowCommandAvailability.none.canLaunchAgent)
+        #expect(!ProjectWindowCommandAvailability.none.canSwitchProject)
+    }
+
+    // MARK: - Agent selection
+
+    private func option(_ id: String) -> ProjectAgentLaunchOption {
+        ProjectAgentLaunchOption(
+            id: id,
+            displayName: id.capitalized,
+            command: id
+        )
+    }
+
+    /// `availableAgentOptions` sorts the last-used agent first, so an
+    /// unqualified request — a keybinding, the palette — means "the one I
+    /// used last".
+    @Test("an unqualified request launches the preferred agent")
+    func unqualifiedRequestUsesPreferredOption() {
+        let options = [option("codex"), option("claudeCode")]
+
+        #expect(
+            ProjectAgentLaunchSelection.option(
+                identifier: nil,
+                in: options
+            )?.id == "codex"
+        )
+    }
+
+    @Test("a named request launches exactly that agent")
+    func namedRequestSelectsThatOption() {
+        let options = [option("codex"), option("claudeCode")]
+
+        #expect(
+            ProjectAgentLaunchSelection.option(
+                identifier: "claudeCode",
+                in: options
+            )?.id == "claudeCode"
+        )
+    }
+
+    /// The catalog can shrink between a menu opening and the click landing —
+    /// a CLI uninstalled, PATH changed. Falling back to "whatever is first"
+    /// would silently start a different agent than the one clicked.
+    @Test("a named request for a vanished agent launches nothing")
+    func unknownIdentifierSelectsNothing() {
+        #expect(
+            ProjectAgentLaunchSelection.option(
+                identifier: "claudeCode",
+                in: [option("codex")]
+            ) == nil
+        )
+    }
+
+    @Test("an empty catalog launches nothing")
+    func emptyCatalogSelectsNothing() {
+        #expect(
+            ProjectAgentLaunchSelection.option(identifier: nil, in: []) == nil
+        )
+    }
+
+    // MARK: - Switch request payloads
+
+    @Test("a named row wins over any direction in the same payload")
+    func namedRowIsPreferred() {
+        let url = URL(fileURLWithPath: "/a", isDirectory: true)
+
+        #expect(
+            ProjectWindowSwitchRequest.parse([
+                "url": url,
+                "direction": "next",
+            ]) == .row(url)
+        )
+    }
+
+    @Test("a direction payload becomes a step")
+    func directionBecomesStep() {
+        #expect(
+            ProjectWindowSwitchRequest.parse(["direction": "previous"])
+                == .step(.previous)
+        )
+    }
+
+    /// A payload Pine does not understand is not a request. Defaulting to a
+    /// direction would move the window on a malformed notification.
+    @Test("an unusable payload is not a request")
+    func unusablePayloadIsIgnored() {
+        #expect(ProjectWindowSwitchRequest.parse(nil) == nil)
+        #expect(ProjectWindowSwitchRequest.parse([:]) == nil)
+        #expect(ProjectWindowSwitchRequest.parse(["direction": "up"]) == nil)
+        #expect(ProjectWindowSwitchRequest.parse(["url": "/a"]) == nil)
+    }
+
+    // MARK: - Command metadata
+
+    @Test("the new commands are registered for the palette and keybindings")
+    func newCommandsAreRegistered() {
+        let all = Set(UserCommand.allCases)
+
+        #expect(all.contains(.newAgent))
+        #expect(all.contains(.nextProjectInWindow))
+        #expect(all.contains(.previousProjectInWindow))
+    }
+
+    @Test("the new commands carry palette metadata")
+    func newCommandsHaveMetadata() {
+        for command in [
+            UserCommand.newAgent,
+            .nextProjectInWindow,
+            .previousProjectInWindow,
+        ] {
+            #expect(!command.localizedTitle.isEmpty)
+            #expect(!command.iconName.isEmpty)
+            #expect(!command.notificationKey.isEmpty)
+        }
+        #expect(UserCommand.newAgent.availabilityRequirement == .agentWorktree)
+        #expect(
+            UserCommand.nextProjectInWindow.availabilityRequirement
+                == .projectSwitching
+        )
+        #expect(
+            UserCommand.previousProjectInWindow.availabilityRequirement
+                == .projectSwitching
+        )
+    }
+
+    /// A rebindable command whose built-in chord collides with another
+    /// command's is a shadowed command: `effectiveChord(for:)` hands the chord
+    /// to whichever entry claims it and the loser silently loses its shortcut.
+    @Test("no two built-in commands claim the same default chord")
+    func defaultChordsAreUnique() {
+        var owners: [ParsedKeyChord: UserCommand] = [:]
+
+        for command in UserCommand.allCases {
+            guard let chord = command.defaultChord else { continue }
+            #expect(
+                owners[chord] == nil,
+                """
+                \(command) claims the chord already held by \
+                \(String(describing: owners[chord]))
+                """
+            )
+            owners[chord] = command
+        }
+    }
+
+    @Test("New Agent takes the free Shift-Command-A chord")
+    func newAgentChord() throws {
+        let chord = try #require(UserCommand.newAgent.defaultChord)
+
+        #expect(chord == UserKeybindingRegistry.parse("cmd+shift+a"))
+    }
+
+    /// Which project a chord should switch *to* is not expressible as a key
+    /// equivalent, and every free chord left is meaningful to someone. The
+    /// menu-bar submenu and the palette are the discovery surface; a user who
+    /// wants a chord binds one in `keybindings.json`.
+    @Test("project switching ships without a built-in chord")
+    func projectSwitchingHasNoDefaultChord() {
+        #expect(UserCommand.nextProjectInWindow.defaultChord == nil)
+        #expect(UserCommand.previousProjectInWindow.defaultChord == nil)
+    }
+
+    @Test("the New Agent chord is documented in the README")
+    func newAgentChordIsDocumented() throws {
+        let readme = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("README.md")
+        let content = try String(contentsOf: readme, encoding: .utf8)
+
+        #expect(
+            content.contains("| `Cmd+Shift+A` | New agent in a worktree |")
+        )
+    }
+
+    // MARK: - Palette surfacing
+
+    @Test("the palette lists the new commands and explains their absence")
+    func paletteListsNewCommands() throws {
+        let items = CommandPaletteCatalog.makeItems(
+            tasks: [],
+            keybindings: UserKeybindingRegistry(),
+            context: .unavailable
+        )
+
+        for command in [
+            UserCommand.newAgent,
+            .nextProjectInWindow,
+            .previousProjectInWindow,
+        ] {
+            let item = try #require(
+                items.first { $0.id == .builtIn(command) },
+                "\(command) must be reachable from the Command Palette"
+            )
+            #expect(!item.isEnabled)
+            #expect(item.unavailabilityReason?.isEmpty == false)
+        }
+    }
+
+    @Test("a qualifying window enables the new palette entries")
+    func paletteEnablesNewCommandsInAQualifyingWindow() throws {
+        let context = CommandPaletteContext(
+            hasProject: true,
+            hasActiveFile: false,
+            isGitRepository: true,
+            hasTerminal: false,
+            canLaunchAgent: true,
+            canSwitchProjectInWindow: true
+        )
+        let items = CommandPaletteCatalog.makeItems(
+            tasks: [],
+            keybindings: UserKeybindingRegistry(),
+            context: context
+        )
+
+        for command in [
+            UserCommand.newAgent,
+            .nextProjectInWindow,
+            .previousProjectInWindow,
+        ] {
+            let item = try #require(items.first { $0.id == .builtIn(command) })
+            #expect(item.isEnabled)
+        }
+    }
+
+    // MARK: - Dispatch
+
+    @Test("New Agent dispatch targets its own window")
+    func newAgentDispatchTargetsProject() {
+        let projectManager = ProjectManager()
+        let identifier = ObjectIdentifier(projectManager)
+        let center = NotificationCenter()
+        let probe = CommandProbe()
+        let token = center.addObserver(
+            forName: .newAgent,
+            object: nil,
+            queue: nil
+        ) { notification in
+            let target = (notification.object as AnyObject?).map(
+                ObjectIdentifier.init
+            )
+            probe.record("newAgent:\(target == identifier)")
+        }
+        defer { center.removeObserver(token) }
+
+        UserCommandInvocationRouter.dispatch(
+            .newAgent,
+            projectManager: projectManager,
+            windowAvailability: availability(),
+            notificationCenter: center
+        )
+
+        #expect(probe.values == ["newAgent:true"])
+    }
+
+    /// The router is the single gate every surface passes through (#1117).
+    /// A palette row or a user chord fired against a window that cannot host
+    /// an agent has to stop here, not at the menu item's `disabled` modifier.
+    @Test("New Agent dispatch stops when the window cannot host an agent")
+    func newAgentDispatchRespectsAvailability() {
+        let projectManager = ProjectManager()
+        let center = NotificationCenter()
+        let probe = CommandProbe()
+        let token = center.addObserver(
+            forName: .newAgent,
+            object: nil,
+            queue: nil
+        ) { _ in
+            probe.record("newAgent")
+        }
+        defer { center.removeObserver(token) }
+
+        for blocked in [
+            availability(git: false),
+            availability(agents: false),
+            availability(launching: true),
+            ProjectWindowCommandAvailability.none,
+        ] {
+            UserCommandInvocationRouter.dispatch(
+                .newAgent,
+                projectManager: projectManager,
+                windowAvailability: blocked,
+                notificationCenter: center
+            )
+        }
+
+        #expect(probe.values.isEmpty)
+    }
+
+    @Test("project switching dispatch carries its direction")
+    func projectSwitchDispatchCarriesDirection() {
+        let projectManager = ProjectManager()
+        let center = NotificationCenter()
+        let probe = CommandProbe()
+        let token = center.addObserver(
+            forName: .switchProjectInWindow,
+            object: nil,
+            queue: nil
+        ) { notification in
+            probe.record(
+                notification.userInfo?["direction"] as? String ?? "missing"
+            )
+        }
+        defer { center.removeObserver(token) }
+
+        UserCommandInvocationRouter.dispatch(
+            .nextProjectInWindow,
+            projectManager: projectManager,
+            windowAvailability: availability(),
+            notificationCenter: center
+        )
+        UserCommandInvocationRouter.dispatch(
+            .previousProjectInWindow,
+            projectManager: projectManager,
+            windowAvailability: availability(),
+            notificationCenter: center
+        )
+
+        #expect(probe.values == ["next", "previous"])
+    }
+
+    @Test("project switching dispatch stops in a single-project window")
+    func projectSwitchDispatchRespectsAvailability() {
+        let projectManager = ProjectManager()
+        let center = NotificationCenter()
+        let probe = CommandProbe()
+        let token = center.addObserver(
+            forName: .switchProjectInWindow,
+            object: nil,
+            queue: nil
+        ) { _ in
+            probe.record("switch")
+        }
+        defer { center.removeObserver(token) }
+
+        UserCommandInvocationRouter.dispatch(
+            .nextProjectInWindow,
+            projectManager: projectManager,
+            windowAvailability: availability(targets: 1),
+            notificationCenter: center
+        )
+
+        #expect(probe.values.isEmpty)
+    }
+
+    /// Menu items name one agent each, and that name has to survive the trip
+    /// through the notification — otherwise every submenu row would launch
+    /// the preferred agent.
+    @Test("a menu-chosen agent identifier survives dispatch")
+    func newAgentRequestCarriesChosenIdentifier() {
+        let projectManager = ProjectManager()
+        let center = NotificationCenter()
+        let probe = CommandProbe()
+        let token = center.addObserver(
+            forName: .newAgent,
+            object: nil,
+            queue: nil
+        ) { notification in
+            probe.record(
+                notification.userInfo?[
+                    ProjectAgentLaunchSelection.identifierKey
+                ] as? String ?? "preferred"
+            )
+        }
+        defer { center.removeObserver(token) }
+
+        ProjectAgentLaunchSelection.post(
+            identifier: "claudeCode",
+            projectManager: projectManager,
+            notificationCenter: center
+        )
+        ProjectAgentLaunchSelection.post(
+            identifier: nil,
+            projectManager: projectManager,
+            notificationCenter: center
+        )
+
+        #expect(probe.values == ["claudeCode", "preferred"])
+    }
+}
+
+nonisolated private final class CommandProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String] = []
+
+    var values: [String] {
+        lock.withLock { storage }
+    }
+
+    func record(_ value: String) {
+        lock.withLock {
+            storage.append(value)
+        }
+    }
+}

--- a/PineTests/MenuIconTests.swift
+++ b/PineTests/MenuIconTests.swift
@@ -73,6 +73,9 @@ struct MenuIconTests {
         (MenuIcons.projectSwitcherOpenFolder, "Open Folder (switcher menu)"),
         (MenuIcons.projectSwitcherActive, "Active project checkmark"),
         (MenuIcons.projectSwitcherProject, "Inactive project"),
+        (MenuIcons.switchProjectInWindow, "Switch Project (menu bar)"),
+        (MenuIcons.nextProjectInWindow, "Next Project"),
+        (MenuIcons.previousProjectInWindow, "Previous Project"),
     ])
     func projectSwitcherIconExists(_ symbol: String, _ element: String) {
         #expect(

--- a/PineTests/PineAppMenuCommandsTests.swift
+++ b/PineTests/PineAppMenuCommandsTests.swift
@@ -30,7 +30,9 @@ struct PineAppMenuCommandsTests {
             toggleQuickTerminal: {},
             recoverQuickTerminalDisplay: {},
             recentProjects: { [] },
-            showAgentInbox: {}
+            showAgentInbox: {},
+            windowSession: { nil },
+            projectRegistry: { nil }
         )
         // `body` is `some Commands` — we can't introspect it, but forcing
         // evaluation verifies the view-builder closure compiles and runs

--- a/PineTests/ProjectWindowSwitchOrderTests.swift
+++ b/PineTests/ProjectWindowSwitchOrderTests.swift
@@ -1,0 +1,173 @@
+//
+//  ProjectWindowSwitchOrderTests.swift
+//  PineTests
+//
+//  Issue #1525: switching the window's active project/worktree has to be
+//  reachable from the menu bar, which means the switcher's visual order needs
+//  a headless, testable form the Next/Previous commands can walk.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Project Window Switch Order")
+struct ProjectWindowSwitchOrderTests {
+    private func group(
+        _ path: String,
+        worktrees: Int = 0
+    ) -> ProjectWindowGroup {
+        let root = URL(fileURLWithPath: path, isDirectory: true)
+        let proof = RecentAgentTaskRepositoryProof(
+            commonDirectoryDevice: 1,
+            commonDirectoryInode: 2,
+            commonDirectoryGeneration: 3,
+            commonDirectoryBirthSeconds: 4,
+            commonDirectoryBirthNanoseconds: 5
+        )
+        return ProjectWindowGroup(
+            projectURL: root,
+            worktrees: (0..<worktrees).map { index in
+                AgentManagedWorktree(
+                    taskID: UUID(),
+                    repositoryRoot: root,
+                    managedRoot: root.appendingPathComponent("managed"),
+                    worktreeRoot: root
+                        .appendingPathComponent("managed/\(index)"),
+                    branchName: "pine/agent/codex/\(index)",
+                    baseCommit: String(repeating: "a", count: 40),
+                    repositoryProof: proof
+                )
+            }
+        )
+    }
+
+    private func url(_ path: String) -> URL {
+        URL(fileURLWithPath: path, isDirectory: true)
+    }
+
+    /// Worktree roots are built by `appendingPathComponent`, which produces a
+    /// URL without the directory marker — and a URL with a trailing slash is
+    /// not equal to one without.
+    private func worktreeURL(_ project: String, _ index: Int) -> URL {
+        url(project).appendingPathComponent("managed/\(index)")
+    }
+
+    @Test("targets flatten each project ahead of its own worktrees")
+    func targetsMatchTheSwitcherReadingOrder() {
+        let groups = [group("/a", worktrees: 2), group("/b")]
+
+        #expect(
+            ProjectWindowSwitchOrder.targets(in: groups) == [
+                url("/a"),
+                worktreeURL("/a", 0),
+                worktreeURL("/a", 1),
+                url("/b"),
+            ]
+        )
+    }
+
+    @Test("next steps to the following row and wraps at the end")
+    func nextWalksForwardAndWraps() {
+        let targets = ProjectWindowSwitchOrder.targets(
+            in: [group("/a", worktrees: 1), group("/b")]
+        )
+
+        #expect(
+            ProjectWindowSwitchOrder.neighbour(
+                of: url("/a"),
+                in: targets,
+                direction: .next
+            ) == worktreeURL("/a", 0)
+        )
+        #expect(
+            ProjectWindowSwitchOrder.neighbour(
+                of: url("/b"),
+                in: targets,
+                direction: .next
+            ) == url("/a")
+        )
+    }
+
+    @Test("previous steps to the preceding row and wraps at the start")
+    func previousWalksBackwardAndWraps() {
+        let targets = ProjectWindowSwitchOrder.targets(
+            in: [group("/a", worktrees: 1), group("/b")]
+        )
+
+        #expect(
+            ProjectWindowSwitchOrder.neighbour(
+                of: worktreeURL("/a", 0),
+                in: targets,
+                direction: .previous
+            ) == url("/a")
+        )
+        #expect(
+            ProjectWindowSwitchOrder.neighbour(
+                of: url("/a"),
+                in: targets,
+                direction: .previous
+            ) == url("/b")
+        )
+    }
+
+    /// A window showing one project has nowhere to go. Wrapping would
+    /// "switch" to the row already on screen, and the menu item that reports
+    /// itself enabled would do nothing when clicked.
+    @Test("a lone target has no neighbour in either direction")
+    func singleTargetHasNoNeighbour() {
+        let targets = ProjectWindowSwitchOrder.targets(in: [group("/a")])
+
+        #expect(
+            ProjectWindowSwitchOrder.neighbour(
+                of: url("/a"),
+                in: targets,
+                direction: .next
+            ) == nil
+        )
+        #expect(
+            ProjectWindowSwitchOrder.neighbour(
+                of: url("/a"),
+                in: targets,
+                direction: .previous
+            ) == nil
+        )
+    }
+
+    /// The active URL can disappear between a menu opening and the command
+    /// firing — a worktree closed from another surface, say. Guessing a
+    /// starting row would switch the window somewhere the user never asked
+    /// for, so an unknown origin yields nothing.
+    @Test("an origin outside the window yields no neighbour")
+    func unknownOriginYieldsNothing() {
+        let targets = ProjectWindowSwitchOrder.targets(
+            in: [group("/a"), group("/b")]
+        )
+
+        #expect(
+            ProjectWindowSwitchOrder.neighbour(
+                of: url("/elsewhere"),
+                in: targets,
+                direction: .next
+            ) == nil
+        )
+    }
+
+    /// The session stores standardized paths; a caller handing back a URL with
+    /// a trailing slash or a `.` segment still means the same row.
+    @Test("a non-standardized origin still finds its row")
+    func nonStandardizedOriginIsMatched() {
+        let targets = ProjectWindowSwitchOrder.targets(
+            in: [group("/a"), group("/b")]
+        )
+
+        #expect(
+            ProjectWindowSwitchOrder.neighbour(
+                of: URL(fileURLWithPath: "/a/./", isDirectory: true),
+                in: targets,
+                direction: .next
+            ) == url("/b")
+        )
+    }
+}

--- a/PineUITests/AgentMenuBarCommandsUITests.swift
+++ b/PineUITests/AgentMenuBarCommandsUITests.swift
@@ -1,0 +1,60 @@
+//
+//  AgentMenuBarCommandsUITests.swift
+//  PineUITests
+//
+//  Issue #1525: starting an agent in a worktree, and moving between the
+//  projects a window holds, lived at exactly one place in the UI — a submenu
+//  inside the toolbar's project switcher. No menu-bar item, no Command
+//  Palette entry, no shortcut. This test fails if either ever leaves the
+//  menu bar again.
+//
+
+import XCTest
+
+final class AgentMenuBarCommandsUITests: PineUITestCase {
+    private var projectURL: URL!
+
+    /// Titles that must be reachable from the menu bar, per menu.
+    private static let viewMenuTitles = ["New Agent…"]
+    private static let windowMenuTitles = [
+        "Switch Project",
+        "Next Project",
+        "Previous Project",
+    ]
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        projectURL = try createTempProject()
+    }
+
+    override func tearDownWithError() throws {
+        if let url = projectURL { cleanupProject(url) }
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Helpers
+
+    /// Existence, not enablement: a CI runner with no agent CLI on `PATH` and
+    /// a project that is not a git repository dims both commands, and the
+    /// point of this test is that they are *there* to be dimmed.
+    private func assertMenuItems(_ titles: [String], in menu: String) {
+        clickMenuBarItem(menu)
+        for title in titles {
+            let item = app.menuItems[title].firstMatch
+            XCTAssertTrue(
+                waitForExistence(item, timeout: 3),
+                "\(menu) ▸ \(title) should be reachable from the menu bar"
+            )
+        }
+        app.typeKey(.escape, modifierFlags: [])
+    }
+
+    // MARK: - Tests
+
+    func testAgentAndProjectCommandsExistInTheMenuBar() throws {
+        launchWithProject(projectURL)
+
+        assertMenuItems(Self.viewMenuTitles, in: "View")
+        assertMenuItems(Self.windowMenuTitles, in: "Window")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ release disk image without publishing a release.
 | `Cmd+R` | Go to Symbol |
 | `Cmd+/` | Toggle comment |
 | `Cmd+Shift+B` | Switch branch |
+| `Cmd+Shift+A` | New agent in a worktree |
 | `Cmd+Shift+M` | Toggle minimap |
 | `Cmd+Shift+P` | Markdown preview |
 | `Ctrl+Option+Down` / `Up` | Next / Previous change |


### PR DESCRIPTION
# fix(agent): give New Agent and project switching a menu-bar home

Closes #1525. Part of the #1494 native-conventions audit; unblocks #1488.

## The problem

Launching an agent in a worktree — the headline 2.6 capability — existed at
exactly one place in the UI: a submenu inside the toolbar's project switcher.
No menu-bar item, no Command Palette entry, no shortcut, nothing rebindable.
Switching the projects and agent worktrees a window holds was in the same
position. A toolbar is a convenience layer over commands that live in the menu
bar; it was the only route to both.

## What changed

Three new `UserCommand` cases, so all three extensibility surfaces (menu bar,
Command Palette, `keybindings.json`) get them at once:

| Command | Menu | Shortcut |
| --- | --- | --- |
| `newAgent` | View ▸ New Agent… (agent picker submenu) | `⇧⌘A` |
| `nextProjectInWindow` | Window ▸ Next Project | — |
| `previousProjectInWindow` | Window ▸ Previous Project | — |

Plus **Window ▸ Switch Project**, a submenu of the window's projects and agent
worktrees — the same rows the toolbar draws, from the same renderer.

- **View menu.** New Agent sits at the head of the existing agent block
  (Inbox / Activity / History), mirroring the toolbar's submenu. The chord
  rides on the preferred (last-used) agent's item, which is exactly what the
  palette and a user keybinding launch — a key equivalent on the submenu's own
  item would have nothing to fire.
- **Window menu.** macOS keeps "what this window is showing" here, next to the
  tab-switching items already in that group.
- **Shortcut.** `⇧⌘A` — "A" for agent, beside the Agent Inbox's `⇧⌘I`. Free in
  Pine (44 built-in chords audited) and not a standard macOS menu equivalent.
  A new test fails if any two commands ever claim the same default chord.
  Next/Previous Project ship **without** a chord: which project to switch *to*
  is not expressible as a key equivalent, and no free chord was worth taking.
  Both stay rebindable through `keybindings.json`.
- **User overrides respected.** Every new menu item goes through
  `effectiveKeyboardShortcut(keybindings.effectiveChord(for:))` — this does not
  add to the 39 hard-coded sites of #1539.

## Truthful enablement

New Agent is offered only when the window can actually host one: a git
repository, at least one agent CLI on `PATH`, and no launch already in flight.
Switching is offered only when the window holds a second row. Both facts are a
plain value (`ProjectWindowCommandAvailability`) computed once and used by the
menu's `disabled`, by the palette's enablement, and by the invocation router's
gate — so a palette row or a user chord cannot bypass what the menu dims. The
palette explains *why* a disabled row is disabled, via two new requirement
cases.

## Notable

- `ProjectSwitcherRows` is extracted from `ProjectSwitcherView` so the toolbar
  and the menu bar cannot disagree about what the window holds. Only the
  toolbar's copy carries the switcher's accessibility identifiers — two copies
  under one identifier would make every XCUITest and VoiceOver lookup
  ambiguous.
- A menu-named agent that has vanished from the catalog between the menu
  opening and the click launches **nothing**, rather than falling back to the
  preferred agent and silently starting something else.

## Tests

- `PineTests/AgentLaunchCommandTests.swift` (23) — availability truth tables,
  agent selection, command metadata, default-chord uniqueness, palette
  surfacing, router dispatch and its gate, switch-request payload parsing.
- `PineTests/ProjectWindowSwitchOrderTests.swift` (6) — switcher order,
  wrap-around, lone row, unknown origin, non-standardized origin.
- `PineUITests/AgentMenuBarCommandsUITests.swift` (1) — every command is
  reachable from the menu bar in the running app.
- Regression runs: `CommandPaletteModelTests`,
  `UserCommandInvocationRouterTests`, `PineAppMenuCommandsTests`,
  `MenuIconTests`, `LocalizationCatalogCompletenessTests`,
  `ProjectWindowSessionTests`, `CloseProjectMenuTests`, `EditorWindowTests` —
  all green. `swiftlint --strict`: 0 violations.

### Mutation verification

Every guard was broken and the named test went red; all reverted.

| # | Mutation | Test that failed |
| --- | --- | --- |
| 1 | `canLaunchAgent` drops the `isGitRepository` clause | agent launch needs a repository, an agent, and an idle session |
| 2 | `canSwitchProject` accepts a single row (`> 1` → non-empty) | switching needs a second row and an idle session |
| 3 | An unknown agent id falls back to the preferred agent | a named request for a vanished agent launches nothing |
| 4 | `targets` lists worktrees before their project | targets flatten each project ahead of its own worktrees |
| 5 | `neighbour` accepts a one-row window | a lone target has no neighbour in either direction |
| 6 | `neighbour` uses the forward offset for both directions | previous steps to the preceding row and wraps at the start |
| 7 | `newAgent` requirement becomes `.always` | New Agent dispatch stops when the window cannot host an agent |
| 8 | `newAgent` claims `⇧⌘I` (the Agent Inbox's chord) | no two built-in commands claim the same default chord |
| 9 | Dispatch always sends `next` | project switching dispatch carries its direction |
| 10 | An unknown direction string defaults to `next` | an unusable payload is not a request |

## Localization

Five new keys, inserted key-by-key into `Localizable.xcstrings` (no whole-file
`json.dump`), all nine locales: `menu.nextProjectInWindow`,
`menu.previousProjectInWindow`, `menu.switchProjectInWindow`,
`commandPalette.unavailable.agentWorktree`,
`commandPalette.unavailable.projectSwitching`. New Agent reuses the existing
`projectSwitcher.newAgent`.

## AC#5 is not applicable: the issue's premise does not reproduce

The issue reproduces the bug with `View → Hide Toolbar`, and asks for a UI
test asserting the commands survive it. **That toggle does not exist in this
build**, so neither does the scenario.

How I checked: a throwaway UI test dumped every `menuItem` title in the
running app's accessibility tree — the whole menu bar, submenus included. The
View menu ends `… Reveal File in Finder, Reveal Project in Finder, New Agent…,
Agent Inbox, Agent Activity, Agent History, Enter Full Screen`. There is no
Show/Hide Toolbar item anywhere in the tree. Right-clicking the toolbar (at
three horizontal positions) surfaces no context menu either: macOS 26 serves
none for a SwiftUI window toolbar. So a user cannot hide Pine's toolbar at all.

I first satisfied AC#5 with a `--hide-window-toolbar` launch flag and removed
it on review. Those 23 lines of production surface would have manufactured a
state the product cannot otherwise enter, purely so a test could assert
against it — unlike `--disable-metal`, which works around a real constraint of
the CI environment. Reporting that the requirement is stale is more honest
than a green checkbox over a synthetic scenario.

What the issue is actually about — one entry point, invisible without the
toolbar control — is closed: menu bar, Command Palette, `⇧⌘A`, and full
rebindability, all covered by the tests above.

## Not verified

The HIG claim in the issue was not re-checked against the source —
`developer.apple.com` fetches are blocked in this environment.
