### PR TITLE
polish(accessibility): give the custom controls a role, a value, and a way in

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -217,6 +217,10 @@ nonisolated enum AccessibilityID {
     static let lineEndingIndicator = "lineEndingIndicator"
     static let fileSizeIndicator = "fileSizeIndicator"
     static let progressIndicator = "progressIndicator"
+    static let gitStatusSummary = "gitStatusSummary"
+    static let gitStatusModifiedCount = "gitStatusModifiedCount"
+    static let gitStatusAddedCount = "gitStatusAddedCount"
+    static let gitStatusUntrackedCount = "gitStatusUntrackedCount"
     static let agentStatusBar = "agentStatusBar"
     static let agentStatusBarItem = "agentStatusBarItem"
     static let agentAttentionBell = "agentAttentionBell"
@@ -252,6 +256,12 @@ nonisolated enum AccessibilityID {
             identity.paneID.id.uuidString,
             identity.tabID.uuidString,
         ].joined(separator: "_")
+    }
+
+    // MARK: - Go-to-Definition quick pick (#1533)
+    static let definitionQuickPickList = "definitionQuickPickList"
+    static func definitionQuickPickRow(_ index: Int) -> String {
+        "definitionQuickPickRow_\(index)"
     }
 
     // MARK: - LSP / Problems panel (#1010)

--- a/Pine/Agent/AgentInboxView.swift
+++ b/Pine/Agent/AgentInboxView.swift
@@ -292,6 +292,17 @@ struct AgentInboxView: View {
         .accessibilityHint(
             accessibilityHint(for: row)
         )
+        // Marking read was reachable by right-click alone. The context menu
+        // is not in the accessibility tree, and the envelope button lives in
+        // the recovery panel, which only appears for a recoverable task — so
+        // for every other row this rotor action is the only way in.
+        .accessibilityActions {
+            Button(row.isUnread
+                   ? Strings.agentInboxMarkRead
+                   : Strings.agentInboxMarkUnread) {
+                toggleReviewed(row)
+            }
+        }
     }
 
     private var presentedRecoveryRow: AgentInboxRow? {

--- a/Pine/LSP/DefinitionQuickPickView.swift
+++ b/Pine/LSP/DefinitionQuickPickView.swift
@@ -104,6 +104,13 @@ nonisolated struct DefinitionQuickPickItem: Identifiable, Equatable, Sendable {
         self.character = character
         self.id = "\(url.path):\(line):\(character)"
     }
+
+    /// What VoiceOver reads for one row: the symbol, then where it lives.
+    /// Both halves are drawn, and both are needed to tell two overloads of
+    /// the same name apart — which is the only reason this list exists.
+    static func accessibilityLabel(for item: DefinitionQuickPickItem) -> String {
+        item.detail.isEmpty ? item.label : "\(item.label), \(item.detail)"
+    }
 }
 
 /// SwiftUI overlay content for the definition quick-pick.
@@ -140,6 +147,9 @@ struct DefinitionQuickPickContent: View {
             RoundedRectangle(cornerRadius: 8)
                 .stroke(Color(NSColor.separatorColor.withAlphaComponent(0.5)), lineWidth: 1)
         )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(Strings.a11yDefinitionQuickPickLabel)
+        .accessibilityIdentifier(AccessibilityID.definitionQuickPickList)
     }
 }
 
@@ -148,15 +158,17 @@ struct DefinitionQuickPickContent: View {
 struct DefinitionQuickPickOverlay: View {
     let controller: DefinitionQuickPickController
 
+    @FocusState private var hasKeyboardFocus: Bool
+
     var body: some View {
         ZStack {
-            // Semi-transparent backdrop — click to dismiss.
+            // Semi-transparent backdrop — click to dismiss. It draws a gap,
+            // so it is not published; the key handlers moved off it because a
+            // view that never takes focus never receives a key press, which
+            // left the whole quick pick mouse-only.
             Color.black.opacity(0.01)
                 .onTapGesture { controller.cancel() }
-                .onKeyPress(.escape) { controller.cancel(); return .handled }
-                .onKeyPress(.upArrow) { controller.move(by: -1); return .handled }
-                .onKeyPress(.downArrow) { controller.move(by: 1); return .handled }
-                .onKeyPress(.return) { controller.selectCurrent(); return .handled }
+                .accessibilityHidden(true)
 
             VStack {
                 DefinitionQuickPickContent(controller: controller)
@@ -164,6 +176,14 @@ struct DefinitionQuickPickOverlay: View {
                     .padding(.top, 40)
                 Spacer()
             }
+            .focusable()
+            .focused($hasKeyboardFocus)
+            .focusEffectDisabled()
+            .onAppear { hasKeyboardFocus = true }
+            .onKeyPress(.escape) { controller.cancel(); return .handled }
+            .onKeyPress(.upArrow) { controller.move(by: -1); return .handled }
+            .onKeyPress(.downArrow) { controller.move(by: 1); return .handled }
+            .onKeyPress(.return) { controller.selectCurrent(); return .handled }
         }
     }
 }
@@ -187,6 +207,26 @@ private struct DefinitionRowContainer: View {
             .onTapGesture {
                 controller.select(at: index)
             }
+            // Combined into one stop with a button trait and a press: the row
+            // was three unnamed pieces of static text with the tap gesture —
+            // its only way in — invisible to the accessibility tree.
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(
+                Text(verbatim: DefinitionQuickPickItem.accessibilityLabel(
+                    for: item
+                ))
+            )
+            .accessibilityHint(Strings.a11yDefinitionQuickPickHint)
+            .accessibilityAddTraits(
+                isSelected ? [.isButton, .isSelected] : .isButton
+            )
+            .accessibilityIdentifier(
+                AccessibilityID.definitionQuickPickRow(index)
+            )
+            .accessibilityAction {
+                controller.select(at: index)
+                controller.selectCurrent()
+            }
     }
 }
 
@@ -201,6 +241,7 @@ private struct DefinitionRow: View {
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)
                 .frame(width: 16)
+                .accessibilityHidden(true)
             Text(item.label)
                 .font(.system(size: 12))
                 .foregroundStyle(.primary)

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -23547,6 +23547,126 @@
         }
       }
     },
+    "a11y.definitionQuickPick.label": {
+      "comment": "Accessibility name for the go-to-definition quick pick list.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definitionen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definitions"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definiciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définitions"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "定義"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정의"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definições"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Определения"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "定义"
+          }
+        }
+      }
+    },
+    "a11y.definitionQuickPick.item.hint": {
+      "comment": "Accessibility hint for a row in the go-to-definition quick pick.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnet diese Definition"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens this definition"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre esta definición"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvre cette définition"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この定義を開きます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 정의를 엽니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre esta definição"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открывает это определение"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开此定义"
+          }
+        }
+      }
+    },
     "a11y.statusBar.label": {
       "comment": "VoiceOver label for the editor status bar.",
       "extractionState": "extracted_with_value",
@@ -23663,6 +23783,486 @@
           "stringUnit": {
             "state": "new",
             "value": "Shows or hides the terminal"
+          }
+        }
+      }
+    },
+    "a11y.statusBar.git.modified %lld": {
+      "comment": "Accessibility name for the status bar git modified-file count. %lld is the number of files.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geändert: %lld"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modified: %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modificados: %lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifiés : %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変更: %lld 件"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "변경됨: %lld개"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modificados: %lld"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменено: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已修改：%lld"
+          }
+        }
+      }
+    },
+    "a11y.statusBar.git.added %lld": {
+      "comment": "Accessibility name for the status bar git added-file count. %lld is the number of files.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinzugefügt: %lld"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Added: %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añadidos: %lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajoutés : %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加: %lld 件"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "추가됨: %lld개"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionados: %lld"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавлено: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已添加：%lld"
+          }
+        }
+      }
+    },
+    "a11y.statusBar.git.untracked %lld": {
+      "comment": "Accessibility name for the status bar git untracked-file count. %lld is the number of files.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht verfolgt: %lld"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Untracked: %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin seguimiento: %lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non suivis : %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未追跡: %lld 件"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "추적되지 않음: %lld개"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não rastreados: %lld"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не отслеживается: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未跟踪：%lld"
+          }
+        }
+      }
+    },
+    "a11y.statusBar.git.summary": {
+      "comment": "Accessibility name for the group of git change counts in the status bar.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Git-Änderungen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Git changes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambios de Git"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifications Git"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Git の変更"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Git 변경 사항"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alterações do Git"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменения Git"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Git 更改"
+          }
+        }
+      }
+    },
+    "a11y.statusBar.cursorPosition": {
+      "comment": "Accessibility name for the status bar cursor position indicator.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cursorposition"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cursor position"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Posición del cursor"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Position du curseur"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カーソル位置"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "커서 위치"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Posição do cursor"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Позиция курсора"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "光标位置"
+          }
+        }
+      }
+    },
+    "a11y.statusBar.cursorPosition.value %lld %lld": {
+      "comment": "Spoken reading of the cursor position. %1$lld is the line, %2$lld the column.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeile %1$lld, Spalte %2$lld"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Line %1$lld, column %2$lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Línea %1$lld, columna %2$lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ligne %1$lld, colonne %2$lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld 行、%2$lld 列"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld행, %2$lld열"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Linha %1$lld, coluna %2$lld"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Строка %1$lld, столбец %2$lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第 %1$lld 行，第 %2$lld 列"
+          }
+        }
+      }
+    },
+    "a11y.statusBar.indentation": {
+      "comment": "Accessibility name for the status bar indentation style indicator.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einrückung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indentation"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sangría"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indentation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インデント"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "들여쓰기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recuo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отступы"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缩进"
+          }
+        }
+      }
+    },
+    "a11y.statusBar.fileSize": {
+      "comment": "Accessibility name for the status bar file size indicator.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateigröße"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File size"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamaño del archivo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taille du fichier"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルサイズ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "파일 크기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamanho do arquivo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Размер файла"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件大小"
           }
         }
       }

--- a/Pine/PaneDividerAccessibility.swift
+++ b/Pine/PaneDividerAccessibility.swift
@@ -1,0 +1,203 @@
+//
+//  PaneDividerAccessibility.swift
+//  Pine
+//
+//  Native splitter semantics for the SwiftUI pane divider (#1533).
+//
+//  The divider promised resizing in its accessibility hint and delivered a
+//  drag gesture, which is the one input a VoiceOver or Full Keyboard Access
+//  user does not have. SwiftUI has no splitter role and no way to publish a
+//  position: `.accessibilityValue` is dropped outright on an element whose
+//  bridged role is `AXUnknown`, which is what a bare `.accessibilityElement()`
+//  produces. So the semantics live on a real `NSView`, the same shape the
+//  sidebar already uses in `SidebarAccessibilityRow` — AppKit publishes
+//  `AXSplitter`, the position, and increment/decrement, and VoiceOver's
+//  standard adjust gesture reaches the pane tree.
+//
+
+import AppKit
+import SwiftUI
+
+/// Everything the divider publishes about itself.
+struct PaneDividerAccessibilityConfiguration: Equatable {
+    /// Orientation of the split, not of the divider: `.horizontal` puts the
+    /// panes side by side and draws a vertical divider between them.
+    let axis: SplitAxis
+    /// Fraction of the split occupied by the leading pane.
+    let ratio: CGFloat
+    let label: String
+    let help: String
+    let identifier: String
+
+    /// One increment. Matches the granularity a user can hit by dragging
+    /// without making the divider tedious to walk from end to end.
+    static let step: CGFloat = 0.05
+    /// The same bounds `PaneNode` clamps a dragged ratio to, so an adjusted
+    /// divider can never reach a position a dragged one could not.
+    static let minimumRatio: CGFloat = 0.1
+    static let maximumRatio: CGFloat = 0.9
+
+    static func clamp(_ ratio: CGFloat) -> CGFloat {
+        min(max(ratio, minimumRatio), maximumRatio)
+    }
+
+    /// The position VoiceOver reads, as a locale-formatted percentage of the
+    /// leading pane.
+    var accessibilityValue: String {
+        Self.percentage(Self.clamp(ratio))
+    }
+
+    static func percentage(_ ratio: CGFloat) -> String {
+        Double(ratio).formatted(.percent.precision(.fractionLength(0)))
+    }
+
+    /// The AppKit orientation of the divider itself.
+    var orientation: NSAccessibilityOrientation {
+        axis == .horizontal ? .vertical : .horizontal
+    }
+}
+
+/// The divider as VoiceOver and Full Keyboard Access see it.
+///
+/// Pointer input stays with the SwiftUI gesture underneath — `hitTest` returns
+/// `nil` — so this view adds semantics without taking a single mouse event.
+@MainActor
+final class PaneDividerAccessibilityView: NSView {
+    private(set) var configuration: PaneDividerAccessibilityConfiguration?
+    private var onAdjust: ((CGFloat) -> Void)?
+
+    /// Injectable so a test never depends on the developer's own Full
+    /// Keyboard Access setting, and so CI does not decide the result.
+    var isFullKeyboardAccessEnabled: () -> Bool = {
+        NSApp?.isFullKeyboardAccessEnabled ?? false
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setAccessibilityElement(true)
+        setAccessibilityRole(.splitter)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
+    // MARK: - Keyboard
+
+    /// Only joins the key view loop when the user has asked every control to
+    /// be reachable by Tab. Outside Full Keyboard Access a divider in the
+    /// loop would be a stop nobody asked for, between panes of text.
+    override var acceptsFirstResponder: Bool {
+        isFullKeyboardAccessEnabled()
+    }
+
+    override var canBecomeKeyView: Bool {
+        acceptsFirstResponder
+    }
+
+    override var focusRingMaskBounds: NSRect {
+        bounds
+    }
+
+    override func drawFocusRingMask() {
+        bounds.fill()
+    }
+
+    override func keyDown(with event: NSEvent) {
+        guard let steps = Self.adjustment(
+            forKeyCode: event.keyCode,
+            axis: configuration?.axis,
+            modifiers: event.modifierFlags
+        ) else {
+            super.keyDown(with: event)
+            return
+        }
+        if !adjust(by: steps) {
+            NSSound.beep()
+        }
+    }
+
+    /// Arrow keys along the split's own axis move the divider; anything else
+    /// belongs to whatever the user was doing before they tabbed here.
+    static func adjustment(
+        forKeyCode keyCode: UInt16,
+        axis: SplitAxis?,
+        modifiers: NSEvent.ModifierFlags
+    ) -> CGFloat? {
+        guard let axis else { return nil }
+        let interesting: NSEvent.ModifierFlags = [
+            .command, .option, .control, .shift,
+        ]
+        guard modifiers.isDisjoint(with: interesting) else { return nil }
+
+        let step = PaneDividerAccessibilityConfiguration.step
+        switch (axis, keyCode) {
+        case (.horizontal, 123), (.vertical, 126): return -step
+        case (.horizontal, 124), (.vertical, 125): return step
+        default: return nil
+        }
+    }
+
+    // MARK: - Configuration
+
+    func configure(
+        _ configuration: PaneDividerAccessibilityConfiguration,
+        onAdjust: @escaping (CGFloat) -> Void
+    ) {
+        self.configuration = configuration
+        self.onAdjust = onAdjust
+        setAccessibilityLabel(configuration.label)
+        setAccessibilityHelp(configuration.help)
+        setAccessibilityIdentifier(configuration.identifier)
+        setAccessibilityValue(configuration.accessibilityValue)
+        setAccessibilityOrientation(configuration.orientation)
+    }
+
+    // MARK: - Adjusting
+
+    /// Moves the divider by `steps` of the split, reporting whether it moved.
+    /// Returning `false` at either bound is what makes VoiceOver announce that
+    /// the divider is already as far as it goes.
+    @discardableResult
+    func adjust(by steps: CGFloat) -> Bool {
+        guard let configuration, let onAdjust else { return false }
+        let current = PaneDividerAccessibilityConfiguration
+            .clamp(configuration.ratio)
+        let target = PaneDividerAccessibilityConfiguration
+            .clamp(current + steps)
+        guard abs(target - current) > .ulpOfOne else { return false }
+        onAdjust(target)
+        return true
+    }
+
+    override func accessibilityPerformIncrement() -> Bool {
+        adjust(by: PaneDividerAccessibilityConfiguration.step)
+    }
+
+    override func accessibilityPerformDecrement() -> Bool {
+        adjust(by: -PaneDividerAccessibilityConfiguration.step)
+    }
+}
+
+/// Embeds ``PaneDividerAccessibilityView`` behind the drawn divider without
+/// changing layout or pointer hit testing.
+struct PaneDividerAccessibility: NSViewRepresentable {
+    let configuration: PaneDividerAccessibilityConfiguration
+    let onAdjust: (CGFloat) -> Void
+
+    func makeNSView(context: Context) -> PaneDividerAccessibilityView {
+        PaneDividerAccessibilityView(frame: .zero)
+    }
+
+    func updateNSView(
+        _ nsView: PaneDividerAccessibilityView,
+        context: Context
+    ) {
+        nsView.configure(configuration, onAdjust: onAdjust)
+    }
+}

--- a/Pine/PaneDividerView.swift
+++ b/Pine/PaneDividerView.swift
@@ -10,8 +10,14 @@ import SwiftUI
 /// A draggable divider between two panes.
 struct PaneDividerView: View {
     let axis: SplitAxis
+    /// Fraction of the split the leading pane currently occupies. Published as
+    /// the splitter's accessibility value and used as the base for adjustment.
+    let ratio: CGFloat
     var onDrag: (CGFloat) -> Void
     var onDragEnd: () -> Void
+    /// Called with an absolute ratio when the divider is moved by an
+    /// accessibility adjust or an arrow key rather than by dragging.
+    var onAdjustRatio: (CGFloat) -> Void
 
     /// Visual thickness of the divider line.
     static let thickness: CGFloat = 1
@@ -68,9 +74,22 @@ struct PaneDividerView: View {
                     isCursorPushed = false
                 }
             }
-            .accessibilityElement()
-            .accessibilityLabel(Strings.a11yPaneDividerLabel)
-            .accessibilityHint(Strings.a11yPaneDividerHint)
-            .accessibilityIdentifier(AccessibilityID.paneDivider)
+            // The AppKit element below is the divider's only accessibility
+            // representation: SwiftUI cannot publish a splitter role, a
+            // position, or an adjustable action, and the hint here promised
+            // a resize that only a mouse could perform.
+            .accessibilityHidden(true)
+            .background {
+                PaneDividerAccessibility(
+                    configuration: PaneDividerAccessibilityConfiguration(
+                        axis: axis,
+                        ratio: ratio,
+                        label: Strings.a11yPaneDividerLabel,
+                        help: Strings.a11yPaneDividerHint,
+                        identifier: AccessibilityID.paneDivider
+                    ),
+                    onAdjust: onAdjustRatio
+                )
+            }
     }
 }

--- a/Pine/PaneTreeView.swift
+++ b/Pine/PaneTreeView.swift
@@ -87,6 +87,7 @@ struct PaneSplitView: View {
 
                     PaneDividerView(
                         axis: axis,
+                        ratio: ratio,
                         onDrag: { offset in
                             dragOffset = offset
                         },
@@ -94,7 +95,8 @@ struct PaneSplitView: View {
                             let newRatio = clampedFirstSize / usableSize
                             applyRatio(newRatio)
                             dragOffset = 0
-                        }
+                        },
+                        onAdjustRatio: applyRatio
                     )
 
                     PaneTreeView(node: second, isRoot: false)
@@ -107,6 +109,7 @@ struct PaneSplitView: View {
 
                     PaneDividerView(
                         axis: axis,
+                        ratio: ratio,
                         onDrag: { offset in
                             dragOffset = offset
                         },
@@ -114,7 +117,8 @@ struct PaneSplitView: View {
                             let newRatio = clampedFirstSize / usableSize
                             applyRatio(newRatio)
                             dragOffset = 0
-                        }
+                        },
+                        onAdjustRatio: applyRatio
                     )
 
                     PaneTreeView(node: second, isRoot: false)

--- a/Pine/QuickTerminal/QuickTerminalContentView.swift
+++ b/Pine/QuickTerminal/QuickTerminalContentView.swift
@@ -40,12 +40,11 @@ struct QuickTerminalContentView: View {
         .accessibilityIdentifier(AccessibilityID.quickTerminalContent)
     }
 
+    /// Kept as Quick Terminal's own entry point, delegating to the shared
+    /// identity so the two terminal surfaces cannot drift apart again.
     static func agentIdentityAccessibilityLabel(
         for tab: TerminalTab
     ) -> String {
-        guard let session = tab.agentSession else { return tab.name }
-        let agent = session.agentType.displayName
-        let state = AgentTabBadge.userFacingState(for: session).displayName
-        return "\(tab.name), \(agent), \(state)"
+        TerminalTabIdentityLabel.accessibilityLabel(for: tab)
     }
 }

--- a/Pine/StatusBarView.swift
+++ b/Pine/StatusBarView.swift
@@ -45,6 +45,9 @@ struct StatusBarView: View {
                     HStack(spacing: 4) {
                         Image(systemName: summary.errorCount > 0 ? "xmark.octagon.fill" : "exclamationmark.bubble.fill")
                             .font(.system(size: LayoutMetrics.captionFontSize))
+                            // The severity is already in `description`; the
+                            // glyph would only add an unnamed image stop.
+                            .accessibilityHidden(true)
                         Text(verbatim: summary.description)
                             .font(.system(size: LayoutMetrics.bodySmallFontSize))
                     }
@@ -113,6 +116,13 @@ struct StatusBarView: View {
                                 Image(systemName: "pencil")
                             }
                             .foregroundStyle(.orange)
+                            .gitCountAccessibility(
+                                label: Strings.a11yStatusBarModifiedCount(
+                                    counts.modified
+                                ),
+                                identifier: AccessibilityID
+                                    .gitStatusModifiedCount
+                            )
                         }
                         if counts.added > 0 {
                             Label {
@@ -121,6 +131,12 @@ struct StatusBarView: View {
                                 Image(systemName: "plus")
                             }
                             .foregroundStyle(.green)
+                            .gitCountAccessibility(
+                                label: Strings.a11yStatusBarAddedCount(
+                                    counts.added
+                                ),
+                                identifier: AccessibilityID.gitStatusAddedCount
+                            )
                         }
                         if counts.untracked > 0 {
                             Label {
@@ -129,9 +145,22 @@ struct StatusBarView: View {
                                 Image(systemName: "questionmark")
                             }
                             .foregroundStyle(.teal)
+                            .gitCountAccessibility(
+                                label: Strings.a11yStatusBarUntrackedCount(
+                                    counts.untracked
+                                ),
+                                identifier: AccessibilityID
+                                    .gitStatusUntrackedCount
+                            )
                         }
                     }
                     .font(.system(size: LayoutMetrics.captionFontSize))
+                    // `children: .contain` keeps the three counts as separate
+                    // stops. Combining them would read one run-on phrase and
+                    // lose the per-kind identifiers UI tests navigate by.
+                    .accessibilityElement(children: .contain)
+                    .accessibilityLabel(Strings.a11yStatusBarGitSummary)
+                    .accessibilityIdentifier(AccessibilityID.gitStatusSummary)
                 }
             }
 
@@ -142,6 +171,16 @@ struct StatusBarView: View {
                 Text(verbatim: "Ln \(activeTab.cursorLine), Col \(activeTab.cursorColumn)")
                     .font(.system(size: LayoutMetrics.bodySmallFontSize))
                     .foregroundStyle(.secondary)
+                    // "Ln" and "Col" are drawn abbreviations; VoiceOver
+                    // pronounces them as words. The name stays constant so a
+                    // moving cursor announces as a value change.
+                    .accessibilityLabel(Strings.a11yStatusBarCursorPosition)
+                    .accessibilityValue(
+                        Strings.a11yStatusBarCursorPositionValue(
+                            line: activeTab.cursorLine,
+                            column: activeTab.cursorColumn
+                        )
+                    )
                     .accessibilityIdentifier(AccessibilityID.cursorPosition)
 
                 statusDivider
@@ -150,6 +189,8 @@ struct StatusBarView: View {
                 Text(verbatim: activeTab.cachedIndentation.displayName)
                     .font(.system(size: LayoutMetrics.bodySmallFontSize))
                     .foregroundStyle(.secondary)
+                    .accessibilityLabel(Strings.a11yStatusBarIndentation)
+                    .accessibilityValue(activeTab.cachedIndentation.displayName)
                     .accessibilityIdentifier(AccessibilityID.indentationIndicator)
 
                 statusDivider
@@ -211,6 +252,8 @@ struct StatusBarView: View {
                     Text(verbatim: FileSizeFormatter.format(size))
                         .font(.system(size: LayoutMetrics.bodySmallFontSize))
                         .foregroundStyle(.secondary)
+                        .accessibilityLabel(Strings.a11yStatusBarFileSize)
+                        .accessibilityValue(FileSizeFormatter.format(size))
                         .accessibilityIdentifier(AccessibilityID.fileSizeIndicator)
                 }
             }
@@ -241,6 +284,9 @@ struct StatusBarView: View {
         Text(verbatim: "·")
             .font(.system(size: LayoutMetrics.bodySmallFontSize))
             .foregroundStyle(.quaternary)
+            // A drawn gap, not content. Published, it lands between every
+            // pair of indicators as an "interpunct" VoiceOver reads aloud.
+            .accessibilityHidden(true)
     }
 
     private var gitStatusCounts: (modified: Int, added: Int, untracked: Int) {
@@ -254,5 +300,25 @@ struct StatusBarView: View {
             }
         }
         return (m, a, u)
+    }
+}
+
+// MARK: - Git count accessibility
+
+private extension View {
+    /// Replaces a git count's contents with one named announcement.
+    ///
+    /// The count has to live in the *label*: macOS drops
+    /// `.accessibilityValue` on an element whose bridged role is
+    /// `AXUnknown`, which is what a `Label` collapsed with
+    /// `children: .ignore` becomes. Split across label and value, VoiceOver
+    /// would announce the kind and silently swallow the number.
+    func gitCountAccessibility(
+        label: String,
+        identifier: String
+    ) -> some View {
+        accessibilityElement(children: .ignore)
+            .accessibilityLabel(label)
+            .accessibilityIdentifier(identifier)
     }
 }

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -2537,6 +2537,70 @@ enum Strings {
     static let a11yGitStatusUntracked: String =
         String(localized: "a11y.gitStatus.untracked", defaultValue: "Untracked")
 
+    // MARK: - Status bar indicator names (#1533)
+    //
+    // The count belongs in the *name*, not in a separate value: macOS drops
+    // `.accessibilityValue` on the `AXUnknown` element a collapsed `Label`
+    // becomes, so a split announcement loses the number entirely. The kind
+    // reads as a category ("Modified: 3"), which needs no plural agreement
+    // in any supported locale.
+
+    static func a11yStatusBarModifiedCount(_ count: Int) -> String {
+        String(localized: "a11y.statusBar.git.modified \(count)")
+    }
+
+    static func a11yStatusBarAddedCount(_ count: Int) -> String {
+        String(localized: "a11y.statusBar.git.added \(count)")
+    }
+
+    static func a11yStatusBarUntrackedCount(_ count: Int) -> String {
+        String(localized: "a11y.statusBar.git.untracked \(count)")
+    }
+
+    static let a11yStatusBarGitSummary: String =
+        String(
+            localized: "a11y.statusBar.git.summary",
+            defaultValue: "Git changes"
+        )
+
+    static let a11yStatusBarCursorPosition: String =
+        String(
+            localized: "a11y.statusBar.cursorPosition",
+            defaultValue: "Cursor position"
+        )
+
+    static func a11yStatusBarCursorPositionValue(
+        line: Int,
+        column: Int
+    ) -> String {
+        String(localized: "a11y.statusBar.cursorPosition.value \(line) \(column)")
+    }
+
+    static let a11yStatusBarIndentation: String =
+        String(
+            localized: "a11y.statusBar.indentation",
+            defaultValue: "Indentation"
+        )
+
+    static let a11yStatusBarFileSize: String =
+        String(
+            localized: "a11y.statusBar.fileSize",
+            defaultValue: "File size"
+        )
+
+    // MARK: - Go-to-Definition quick pick (#1533)
+
+    static let a11yDefinitionQuickPickLabel: String =
+        String(
+            localized: "a11y.definitionQuickPick.label",
+            defaultValue: "Definitions"
+        )
+    static let a11yDefinitionQuickPickHint: String =
+        String(
+            localized: "a11y.definitionQuickPick.item.hint",
+            defaultValue: "Opens this definition"
+        )
+
     // MARK: - Global Tab Switcher overlay (#1239)
 
     /// Title shown at the top of the Control-Tab overlay.

--- a/Pine/TerminalBarView.swift
+++ b/Pine/TerminalBarView.swift
@@ -132,6 +132,21 @@ struct TerminalAgentResumeAction: Identifiable {
 struct TerminalTabIdentityLabel: View {
     let tab: TerminalTab
 
+    /// The one spoken identity for a terminal, shared by the project tab bar,
+    /// Quick Terminal and the terminal surface itself.
+    ///
+    /// The agent badge is drawn state — an amber dot that says an agent is
+    /// blocked waiting for input. Announcing only `tab.name` drops it, which
+    /// is exactly what the project tab bar used to do while Quick Terminal
+    /// got it right; the two surfaces are not allowed to disagree about what
+    /// a terminal is called.
+    static func accessibilityLabel(for tab: TerminalTab) -> String {
+        guard let session = tab.agentSession else { return tab.name }
+        let agent = session.agentType.displayName
+        let state = AgentTabBadge.userFacingState(for: session).displayName
+        return "\(tab.name), \(agent), \(state)"
+    }
+
     var body: some View {
         HStack(spacing: 4) {
             Image(systemName: "terminal")
@@ -257,7 +272,10 @@ struct TerminalNativeTabItem: View {
         }
         .accessibilityRepresentation {
             HStack {
-                Button(tab.name, action: onSelect)
+                Button(
+                    TerminalTabIdentityLabel.accessibilityLabel(for: tab),
+                    action: onSelect
+                )
                     .accessibilityIdentifier(AccessibilityID.terminalTab(tab.stableLabel))
                     .accessibilityAddTraits(isActive ? .isSelected : [])
                     .accessibilityActions {

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -182,6 +182,16 @@ nonisolated enum AcknowledgedPTYWriter {
 /// full-bounds redraws (so SwiftTerm repaints as many cells as possible),
 /// but deliberately does NOT zero `layer.contents` — see issue #1094.
 final class PineTerminalView: LocalProcessTerminalView {
+    /// Supplies the terminal's spoken name on demand (#1533).
+    ///
+    /// Read at query time so a shell title change or a newly detected agent
+    /// is announced without anyone having to push a fresh label.
+    var accessibilityLabelProvider: (() -> String?)?
+
+    override func accessibilityLabel() -> String? {
+        accessibilityLabelProvider?() ?? super.accessibilityLabel()
+    }
+
     private var redrawBackgroundColor: CGColor?
     private var initialMetalRedrawWorkItems: [DispatchWorkItem] = []
     /// Serializes Pine's cursor policy with SwiftTerm's PTY parser. Process
@@ -2056,6 +2066,17 @@ final class TerminalTab: Identifiable, Hashable {
             MainActor.assumeIsolated {
                 self?.applyPreferredCursorStyle()
             }
+        }
+
+        // The terminal had a role and an identifier but no name at all, so
+        // VoiceOver announced every terminal in the window as "text area".
+        // Supplied as a closure rather than a pushed string because both
+        // halves of the name move on their own: the shell renames the tab
+        // through OSC, and agent detection attaches a session later. Anything
+        // pushed would be stale by the time it was read.
+        terminalView.accessibilityLabelProvider = { [weak self] in
+            guard let self else { return nil }
+            return TerminalTabIdentityLabel.accessibilityLabel(for: self)
         }
     }
 

--- a/PineTests/AccessibilityTreeProbe.swift
+++ b/PineTests/AccessibilityTreeProbe.swift
@@ -1,0 +1,295 @@
+//
+//  AccessibilityTreeProbe.swift
+//  PineTests
+//
+//  Reads the accessibility tree a hosted SwiftUI view actually publishes.
+//
+//  Why not assert on the view code instead: a SwiftUI accessibility modifier
+//  is a request, not a guarantee. macOS drops `.accessibilityValue` on an
+//  element whose bridged role is `AXUnknown`, and drops `.accessibilityLabel`
+//  on `Menu` entirely. A test that reads the modifier back — or that trusts
+//  `XCUIElement.label`, which answers from the model — passes on exactly the
+//  defect it was written to catch. The only honest source is the tree
+//  VoiceOver reads, so that is what this probe walks.
+//
+//  Mechanics, matching the approach documented in
+//  `RecoveryDialogEscapeSafetyTests`:
+//
+//  - SwiftUI does not put its accessibility elements in the view hierarchy.
+//    Under an `NSHostingView` they are private objects reachable only through
+//    the public `accessibilityChildren()` selector, so traversal goes through
+//    KVC guarded by `responds(to:)` rather than through a Swift cast.
+//  - The tree is built lazily and does not exist until an accessibility
+//    client has asked for it. Querying our *own* pid is that ask, and needs
+//    no TCC grant — the trust check gates inspecting other processes.
+//
+//  Nothing here is used by shipping code: production stays on public SwiftUI
+//  and `NSAccessibility` API, and this file only reads what that produces.
+//
+
+import AppKit
+import ApplicationServices
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+/// The accessibility selectors a bridged element answers but does not declare
+/// conformance to, so `as?` cannot reach them. Every call site guards with
+/// `responds(to:)` first.
+@MainActor
+@objc private protocol AccessibilityActionPerforming {
+    func accessibilityPerformPress() -> Bool
+    func accessibilityPerformIncrement() -> Bool
+    func accessibilityPerformDecrement() -> Bool
+}
+
+@MainActor
+enum AccessibilityTreeProbe {
+
+    /// A hosted view whose accessibility tree has been materialised.
+    struct Hosted {
+        let hostingView: NSView
+        let window: NSWindow
+
+        /// The root of the published tree.
+        var root: NSObject { hostingView }
+
+        func tearDown() {
+            window.contentView = nil
+            window.close()
+        }
+    }
+
+    // MARK: - Hosting
+
+    /// Hosts `content` off screen and returns it with a live accessibility
+    /// tree. Borderless and parked far off screen so nothing flashes in front
+    /// of whoever is running the suite; `isReleasedWhenClosed` is off because
+    /// the AppKit default would free the window under the caller's reference.
+    static func host(
+        _ content: some View,
+        size: NSSize,
+        locale: String = "en"
+    ) -> Hosted {
+        let rootView = content.environment(\.locale, Locale(identifier: locale))
+        let hostingView = NSHostingView(rootView: rootView)
+        hostingView.frame = NSRect(origin: .zero, size: size)
+        let window = NSWindow(
+            contentRect: hostingView.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = hostingView
+        window.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
+        // Ordered in, never made key. `NSApp.keyWindow` is process-wide state
+        // that other suites assert against, and a probe window stealing it is
+        // a way to fail somebody else's test from across the suite boundary.
+        window.orderFront(nil)
+        hostingView.layoutSubtreeIfNeeded()
+        awaken()
+        hostingView.layoutSubtreeIfNeeded()
+        return Hosted(hostingView: hostingView, window: window)
+    }
+
+    private static var isAwake = false
+
+    /// Makes AppKit materialise the accessibility tree for this process.
+    ///
+    /// The query itself is what switches accessibility on; until some client
+    /// asks, a hosting view reports no accessibility children at all.
+    ///
+    /// Done once per process, not once per hosted view. Accessibility is a
+    /// process-wide switch, and the run-loop spin that settles it holds the
+    /// main actor — repeating it for every host starves neighbouring
+    /// `@MainActor` suites that are waiting on short deadlines, which is a
+    /// way to make somebody else's test flaky without touching their code.
+    static func awaken() {
+        guard !isAwake else { return }
+        isAwake = true
+        let application = AXUIElementCreateApplication(getpid())
+        var children: CFTypeRef?
+        _ = AXUIElementCopyAttributeValue(
+            application,
+            kAXChildrenAttribute as CFString,
+            &children
+        )
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+    }
+
+    // MARK: - Traversal
+
+    /// Every element in the published tree rooted at `root`, in visit order.
+    static func elements(under root: NSObject) -> [NSObject] {
+        var found: [NSObject] = []
+        var queue: [NSObject] = [root]
+        var visited = 0
+
+        while !queue.isEmpty, visited < 10_000 {
+            let current = queue.removeFirst()
+            visited += 1
+            found.append(current)
+            for child in children(of: current) {
+                queue.append(child)
+            }
+        }
+        return found
+    }
+
+    static func children(of element: NSObject) -> [NSObject] {
+        (attribute("accessibilityChildren", of: element) as? [Any] ?? [])
+            .compactMap { $0 as? NSObject }
+    }
+
+    /// The first element published under `root` carrying `identifier`.
+    static func element(
+        under root: NSObject,
+        identifier: String
+    ) -> NSObject? {
+        elements(under: root).first { self.identifier(of: $0) == identifier }
+    }
+
+    /// Every element published under `root` whose identifier starts with
+    /// `prefix`, in tree order.
+    static func elements(
+        under root: NSObject,
+        identifierPrefix prefix: String
+    ) -> [NSObject] {
+        elements(under: root).filter {
+            self.identifier(of: $0)?.hasPrefix(prefix) == true
+        }
+    }
+
+    /// Every non-empty label published under `root`, in tree order. Use this
+    /// to assert that something a sighted user sees is *absent* from what
+    /// VoiceOver hears.
+    static func labels(under root: NSObject) -> [String] {
+        elements(under: root).compactMap { element in
+            let spoken = [label(of: element), value(of: element)]
+                .compactMap { $0 }
+                .joined(separator: " ")
+            return spoken.isEmpty ? nil : spoken
+        }
+    }
+
+    // MARK: - Attributes
+
+    static func attribute(_ name: String, of element: NSObject) -> Any? {
+        guard element.responds(to: NSSelectorFromString(name)) else {
+            return nil
+        }
+        return element.value(forKey: name)
+    }
+
+    static func role(of element: NSObject) -> NSAccessibility.Role? {
+        (attribute("accessibilityRole", of: element) as? String)
+            .map(NSAccessibility.Role.init(rawValue:))
+    }
+
+    static func subrole(of element: NSObject) -> NSAccessibility.Subrole? {
+        (attribute("accessibilitySubrole", of: element) as? String)
+            .map(NSAccessibility.Subrole.init(rawValue:))
+    }
+
+    static func label(of element: NSObject) -> String? {
+        attribute("accessibilityLabel", of: element) as? String
+    }
+
+    static func value(of element: NSObject) -> String? {
+        switch attribute("accessibilityValue", of: element) {
+        case let text as String: return text
+        case let number as NSNumber: return number.stringValue
+        default: return nil
+        }
+    }
+
+    static func help(of element: NSObject) -> String? {
+        attribute("accessibilityHelp", of: element) as? String
+    }
+
+    static func identifier(of element: NSObject) -> String? {
+        let identifier = attribute("accessibilityIdentifier", of: element)
+        guard let identifier = identifier as? String,
+              !identifier.isEmpty else {
+            return nil
+        }
+        return identifier
+    }
+
+    static func isSelected(of element: NSObject) -> Bool {
+        (attribute("isAccessibilitySelected", of: element) as? Bool) ?? false
+    }
+
+    static func orientation(
+        of element: NSObject
+    ) -> NSAccessibilityOrientation? {
+        guard let raw = attribute("accessibilityOrientation", of: element)
+            as? Int else {
+            return nil
+        }
+        return NSAccessibilityOrientation(rawValue: raw)
+    }
+
+    /// The rotor actions VoiceOver offers on this element.
+    static func customActions(
+        of element: NSObject
+    ) -> [NSAccessibilityCustomAction] {
+        attribute("accessibilityCustomActions", of: element)
+            as? [NSAccessibilityCustomAction] ?? []
+    }
+
+    static func customActionNames(of element: NSObject) -> [String] {
+        customActions(of: element).map(\.name)
+    }
+
+    // MARK: - Performing
+
+    /// Performs the action VoiceOver's activate gesture sends. Returns `nil`
+    /// when the element publishes no press at all, which is the difference
+    /// between "VoiceOver can use this" and "VoiceOver can only read it".
+    static func performPress(_ element: NSObject) -> Bool? {
+        perform(element, selector: "accessibilityPerformPress") {
+            $0.accessibilityPerformPress()
+        }
+    }
+
+    static func performIncrement(_ element: NSObject) -> Bool? {
+        perform(element, selector: "accessibilityPerformIncrement") {
+            $0.accessibilityPerformIncrement()
+        }
+    }
+
+    static func performDecrement(_ element: NSObject) -> Bool? {
+        perform(element, selector: "accessibilityPerformDecrement") {
+            $0.accessibilityPerformDecrement()
+        }
+    }
+
+    /// Invokes the rotor action named `name`, or returns `nil` when the
+    /// element does not offer one.
+    static func performCustomAction(
+        named name: String,
+        on element: NSObject
+    ) -> Bool? {
+        guard let action = customActions(of: element)
+            .first(where: { $0.name == name }) else {
+            return nil
+        }
+        return action.handler?() ?? false
+    }
+
+    private static func perform(
+        _ element: NSObject,
+        selector: String,
+        _ body: (AccessibilityActionPerforming) -> Bool
+    ) -> Bool? {
+        guard element.responds(to: NSSelectorFromString(selector)) else {
+            return nil
+        }
+        return body(
+            unsafeBitCast(element, to: AccessibilityActionPerforming.self)
+        )
+    }
+}

--- a/PineTests/AgentInboxMarkReadAccessibilityTests.swift
+++ b/PineTests/AgentInboxMarkReadAccessibilityTests.swift
@@ -1,0 +1,236 @@
+//
+//  AgentInboxMarkReadAccessibilityTests.swift
+//  PineTests
+//
+//  Whether an Inbox row can be marked read without a right-click (#1533).
+//
+//  Marking read had exactly two routes. The context menu, which is not in the
+//  accessibility tree and needs a pointer to raise. And the envelope button in
+//  the recovery panel, which only appears for a task that is recoverable *and*
+//  currently expanded — so for an ordinary row there was no route at all.
+//
+//  The rotor action added here is the route, and this suite invokes it rather
+//  than reading it back: an action published with the right name and no wiring
+//  is indistinguishable from the outside.
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+@Suite("Agent Inbox mark-read accessibility (#1533)", .serialized)
+@MainActor
+struct AgentInboxMarkReadAccessibilityTests {
+
+    private static let inboxSize = NSSize(width: 520, height: 540)
+
+    @Test("every row offers marking read or unread as a rotor action")
+    func everyRowOffersTheAction() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let hosted = fixture.host()
+        defer { hosted.tearDown() }
+
+        let rows = fixture.rows
+        #expect(rows.count > 1, "the fixture must cover more than one row")
+
+        for task in rows {
+            let element = try #require(
+                AccessibilityTreeProbe.element(
+                    under: hosted.root,
+                    identifier: AccessibilityID.agentInboxRow(task.id)
+                ),
+                "the row for \(task.id) is not in the published tree"
+            )
+            let offered = AccessibilityTreeProbe.customActionNames(of: element)
+            let expected = task.isUnread
+                ? Self.markRead
+                : Self.markUnread
+
+            #expect(
+                offered.contains(expected),
+                """
+                the row offers \(offered) — marking read is reachable by \
+                right-click alone, and a context menu is not in the tree
+                """
+            )
+        }
+    }
+
+    /// The name has to follow the row's state, or VoiceOver offers "Mark as
+    /// Read" on a row that is already read.
+    @Test("the action is named for what it will do to this row")
+    func actionNameFollowsRowState() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let hosted = fixture.host()
+        defer { hosted.tearDown() }
+
+        let unread = try #require(fixture.rows.first { $0.isUnread })
+        let read = try #require(fixture.rows.first { !$0.isUnread })
+
+        let unreadActions = try Self.actionNames(for: unread.id, in: hosted)
+        let readActions = try Self.actionNames(for: read.id, in: hosted)
+
+        #expect(
+            unreadActions.contains(Self.markRead),
+            "an unread row offers \(unreadActions)"
+        )
+        #expect(
+            !unreadActions.contains(Self.markUnread),
+            "an unread row also offers marking it unread again"
+        )
+        #expect(
+            readActions.contains(Self.markUnread),
+            "a read row offers \(readActions)"
+        )
+        #expect(
+            !readActions.contains(Self.markRead),
+            "a read row also offers marking it read again"
+        )
+    }
+
+    /// The load-bearing one: perform the action VoiceOver performs and
+    /// require the registry to have changed.
+    @Test("performing the action marks the task read")
+    func performingTheActionMarksItRead() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let hosted = fixture.host()
+        defer { hosted.tearDown() }
+
+        let unread = try #require(fixture.rows.first { $0.isUnread })
+        let element = try #require(
+            AccessibilityTreeProbe.element(
+                under: hosted.root,
+                identifier: AccessibilityID.agentInboxRow(unread.id)
+            )
+        )
+
+        #expect(
+            AccessibilityTreeProbe.performCustomAction(
+                named: Self.markRead,
+                on: element
+            ) == true,
+            "the published action is not wired to anything"
+        )
+        #expect(
+            fixture.registry.agentTasks.task(for: unread.id)?.isUnread == false,
+            """
+            the task is still unread after VoiceOver performed "Mark as Read" \
+            on it
+            """
+        )
+    }
+
+    /// And back again, from the row's own state rather than a stored toggle.
+    @Test("performing the action on a read task marks it unread")
+    func performingTheActionMarksItUnread() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let hosted = fixture.host()
+        defer { hosted.tearDown() }
+
+        let read = try #require(fixture.rows.first { !$0.isUnread })
+        let element = try #require(
+            AccessibilityTreeProbe.element(
+                under: hosted.root,
+                identifier: AccessibilityID.agentInboxRow(read.id)
+            )
+        )
+
+        #expect(
+            AccessibilityTreeProbe.performCustomAction(
+                named: Self.markUnread,
+                on: element
+            ) == true
+        )
+        #expect(
+            fixture.registry.agentTasks.task(for: read.id)?.isUnread == true
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// `Strings.agentInboxMarkRead` is a `LocalizedStringKey`, so SwiftUI
+    /// resolves it through the environment locale the probe pins rather than
+    /// the process locale. `String(localized:locale:)` cannot express that —
+    /// its `locale` only formats interpolations — so the expectation reads
+    /// the same `en.lproj` SwiftUI just read. Anything else passes on CI's
+    /// English runner and fails on a Russian developer machine.
+    private static let markRead = englishValue(forKey: "agentInbox.markRead")
+    private static let markUnread = englishValue(
+        forKey: "agentInbox.markUnread"
+    )
+
+    private static func englishValue(forKey key: String) -> String {
+        guard let path = Bundle.main.path(forResource: "en", ofType: "lproj"),
+              let bundle = Bundle(path: path) else {
+            return key
+        }
+        return bundle.localizedString(forKey: key, value: nil, table: nil)
+    }
+
+    private static func actionNames(
+        for taskID: UUID,
+        in hosted: AccessibilityTreeProbe.Hosted
+    ) throws -> [String] {
+        let element = try #require(
+            AccessibilityTreeProbe.element(
+                under: hosted.root,
+                identifier: AccessibilityID.agentInboxRow(taskID)
+            )
+        )
+        return AccessibilityTreeProbe.customActionNames(of: element)
+    }
+
+    @MainActor
+    private final class Fixture {
+        let registry: ProjectRegistry
+        private let suiteName: String
+        private let defaults: UserDefaults
+
+        init() throws {
+            suiteName = "AgentInboxMarkReadAccessibilityTests.\(UUID().uuidString)"
+            defaults = try #require(UserDefaults(suiteName: suiteName))
+            defaults.removePersistentDomain(forName: suiteName)
+            registry = ProjectRegistry(
+                defaults: defaults,
+                agentTasks: AgentTaskRegistry(),
+                agentDetectionProcessRunner: { _, _, _, _ in
+                    ProcessRunResult(
+                        stdout: "",
+                        stderr: "",
+                        exitCode: 0,
+                        timedOut: false
+                    )
+                },
+                agentDetectionPollInterval: 3_600,
+                agentDetectionInitialPollDelay: 3_600
+            )
+            registry.recentProjects = []
+            registry.agentTasks.seedMarketingInboxForUITesting(
+                at: Date(timeIntervalSince1970: 1_700_000_000)
+            )
+        }
+
+        /// The seeded tasks, which deliberately mix read and unread.
+        var rows: [AgentTask] {
+            registry.agentTasks.tasks
+        }
+
+        func host() -> AccessibilityTreeProbe.Hosted {
+            AccessibilityTreeProbe.host(
+                AgentInboxView(registry: registry),
+                size: AgentInboxMarkReadAccessibilityTests.inboxSize
+            )
+        }
+
+        func cleanup() {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+    }
+}

--- a/PineTests/AgentInboxTests.swift
+++ b/PineTests/AgentInboxTests.swift
@@ -53,8 +53,17 @@ private actor BlockingInboxProjectCanonicalizer {
         return ProjectRegistry.canonicalProjectURL(url)
     }
 
+    /// Waits for the recovery path to reach canonicalization.
+    ///
+    /// The budget is generous on purpose. `recoverAgentTaskFromInbox` runs on
+    /// the main actor, and Swift Testing runs suites in parallel, so the 200 ms
+    /// this used to allow was really a race against however busy the main
+    /// actor happened to be — any `@MainActor` neighbour that hosts a view for
+    /// a fifth of a second turned this into a failure with nothing wrong in
+    /// either test. Still bounded, so a genuinely stuck recovery still fails
+    /// rather than hanging the suite (#1533).
     func waitUntilEntered() async -> Bool {
-        for _ in 0..<200 {
+        for _ in 0..<5_000 {
             if entered { return true }
             try? await Task.sleep(for: .milliseconds(1))
         }

--- a/PineTests/DefinitionQuickPickAccessibilityTests.swift
+++ b/PineTests/DefinitionQuickPickAccessibilityTests.swift
@@ -1,0 +1,266 @@
+//
+//  DefinitionQuickPickAccessibilityTests.swift
+//  PineTests
+//
+//  Whether the go-to-definition quick pick can be used at all without a mouse
+//  (#1533).
+//
+//  Two separate defects lived here. The rows were `onTapGesture` on an
+//  `HStack`, so the accessibility tree carried unnamed fragments of static
+//  text and no way to activate anything. And the Escape/arrow/Return handlers
+//  sat on a backdrop that was never focusable — a view that cannot take focus
+//  never receives a key press, so the keyboard path was decorative.
+//
+//  The row assertions read the published tree and then *press* what they
+//  find, because publishing a button that is wired to nothing looks identical
+//  from the outside.
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+@Suite("Definition quick pick accessibility (#1533)", .serialized)
+@MainActor
+struct DefinitionQuickPickAccessibilityTests {
+
+    private static let overlaySize = NSSize(width: 640, height: 480)
+
+    // MARK: - Rows
+
+    @Test("every row is published as one named, activatable stop")
+    func rowsArePublishedAsNamedButtons() throws {
+        let controller = makeController()
+        let hosted = host(controller)
+        defer { hosted.tearDown() }
+
+        for (index, item) in controller.items.enumerated() {
+            let row = try #require(
+                AccessibilityTreeProbe.element(
+                    under: hosted.root,
+                    identifier: AccessibilityID.definitionQuickPickRow(index)
+                ),
+                """
+                row \(index) is not in the published tree — the quick pick is \
+                reachable by mouse only
+                """
+            )
+            let announced = try #require(
+                AccessibilityTreeProbe.label(of: row),
+                "row \(index) publishes no name"
+            )
+
+            #expect(
+                announced.contains(item.label),
+                "row \(index) announces \"\(announced)\" without its symbol"
+            )
+            #expect(
+                announced.contains(item.detail),
+                """
+                row \(index) announces "\(announced)" without its location. \
+                Every row in this list shares a symbol name — the location is \
+                the only thing that tells them apart, which is the entire \
+                reason the list is shown.
+                """
+            )
+            #expect(
+                AccessibilityTreeProbe.role(of: row) == .button,
+                "row \(index) is not published as something to activate"
+            )
+        }
+    }
+
+    @Test("the selected row is published as selected, and only that one")
+    func selectionIsPublished() throws {
+        let controller = makeController()
+        controller.select(at: 2)
+        let hosted = host(controller)
+        defer { hosted.tearDown() }
+
+        let selected = try (0..<controller.items.count).filter { index in
+            let row = try #require(
+                AccessibilityTreeProbe.element(
+                    under: hosted.root,
+                    identifier: AccessibilityID.definitionQuickPickRow(index)
+                )
+            )
+            return AccessibilityTreeProbe.isSelected(of: row)
+        }
+
+        #expect(
+            selected == [2],
+            """
+            \(selected) rows are published as selected. Without the trait, \
+            arrowing through the list moves a highlight VoiceOver cannot see.
+            """
+        )
+    }
+
+    /// The load-bearing one. Press the row the way VoiceOver presses it and
+    /// require the selection to have actually been made.
+    @Test("pressing a row through the accessibility tree opens that definition")
+    func pressingARowSelectsIt() throws {
+        let controller = makeController()
+        var chosen: [DefinitionQuickPickItem] = []
+        controller.onSelect = { chosen.append($0) }
+        let hosted = host(controller)
+        defer { hosted.tearDown() }
+
+        let row = try #require(
+            AccessibilityTreeProbe.element(
+                under: hosted.root,
+                identifier: AccessibilityID.definitionQuickPickRow(1)
+            )
+        )
+
+        #expect(
+            AccessibilityTreeProbe.performPress(row) == true,
+            """
+            the row publishes no press. Its only activation was a tap \
+            gesture, which the accessibility tree cannot reach.
+            """
+        )
+        #expect(chosen.map(\.id) == [Self.expectedItems[1].id])
+        #expect(!controller.isVisible, "choosing a definition must dismiss")
+    }
+
+    // MARK: - Container
+
+    @Test("the list is a named container and the backdrop is not published")
+    func listIsNamedAndBackdropIsSilent() throws {
+        let controller = makeController()
+        let hosted = host(controller)
+        defer { hosted.tearDown() }
+
+        let list = try #require(
+            AccessibilityTreeProbe.element(
+                under: hosted.root,
+                identifier: AccessibilityID.definitionQuickPickList
+            ),
+            "the quick pick list publishes no container"
+        )
+        #expect(
+            AccessibilityTreeProbe.label(of: list)
+                == Strings.a11yDefinitionQuickPickLabel
+        )
+
+        let rows = AccessibilityTreeProbe.elements(
+            under: hosted.root,
+            identifierPrefix: "definitionQuickPickRow_"
+        )
+        #expect(rows.count == controller.items.count)
+
+        // The backdrop is a full-bleed rectangle carrying its own dismissal
+        // tap. Published, it becomes an unnamed activatable stop the size of
+        // the window, sitting over the list and cancelling on activation.
+        let activatable = AccessibilityTreeProbe.elements(under: hosted.root)
+            .filter { AccessibilityTreeProbe.role(of: $0) == .button }
+        let activatableIdentifiers = activatable
+            .map { AccessibilityTreeProbe.identifier(of: $0) ?? "«unnamed»" }
+        #expect(
+            activatableIdentifiers.sorted()
+                == (0..<controller.items.count)
+                    .map(AccessibilityID.definitionQuickPickRow)
+                    .sorted(),
+            """
+            the quick pick publishes \(activatableIdentifiers) as activatable \
+            — anything beyond the rows is the dismissal backdrop, which \
+            VoiceOver would offer as an unnamed button covering the list
+            """
+        )
+    }
+
+    // MARK: - Keyboard
+
+    /// The controller half of the keyboard path. `onKeyPress` now sits on a
+    /// focusable view, but what those handlers call has to survive too.
+    @Test("arrow, Return and Escape reach the controller and wrap at the ends")
+    func keyboardCommandsDriveTheController() throws {
+        let controller = makeController()
+        var chosen: [DefinitionQuickPickItem] = []
+        var dismissals = 0
+        controller.onSelect = { chosen.append($0) }
+        controller.onDismiss = { dismissals += 1 }
+
+        controller.move(by: 1)
+        #expect(controller.selectedIndex == 1)
+        controller.move(by: -1)
+        #expect(controller.selectedIndex == 0)
+        controller.move(by: -1)
+        #expect(
+            controller.selectedIndex == controller.items.count - 1,
+            "arrowing up from the first row must wrap to the last"
+        )
+        controller.move(by: 1)
+        #expect(controller.selectedIndex == 0)
+
+        controller.selectCurrent()
+        #expect(chosen.map(\.id) == [Self.expectedItems[0].id])
+
+        controller.present(items: Self.expectedItems)
+        controller.cancel()
+        #expect(dismissals == 1)
+        #expect(!controller.isVisible)
+    }
+
+    /// A row whose location is empty must not be announced with a dangling
+    /// separator — VoiceOver reads punctuation out loud.
+    @Test("a row with no location is announced as its symbol alone")
+    func rowWithoutDetailIsAnnouncedPlainly() {
+        let item = DefinitionQuickPickItem(
+            label: "resolve",
+            detail: "",
+            url: URL(fileURLWithPath: "/tmp/a.swift"),
+            line: 1,
+            character: 0
+        )
+
+        #expect(
+            DefinitionQuickPickItem.accessibilityLabel(for: item) == "resolve"
+        )
+    }
+
+    // MARK: - Fixture
+
+    private static let expectedItems: [DefinitionQuickPickItem] = [
+        DefinitionQuickPickItem(
+            label: "resolve(_:)",
+            detail: "Resolver.swift:12",
+            url: URL(fileURLWithPath: "/tmp/Resolver.swift"),
+            line: 12,
+            character: 4
+        ),
+        DefinitionQuickPickItem(
+            label: "resolve(_:)",
+            detail: "Resolver+Cache.swift:48",
+            url: URL(fileURLWithPath: "/tmp/Resolver+Cache.swift"),
+            line: 48,
+            character: 4
+        ),
+        DefinitionQuickPickItem(
+            label: "resolve(_:)",
+            detail: "ResolverTests.swift:9",
+            url: URL(fileURLWithPath: "/tmp/ResolverTests.swift"),
+            line: 9,
+            character: 4
+        ),
+    ]
+
+    private func makeController() -> DefinitionQuickPickController {
+        let controller = DefinitionQuickPickController()
+        controller.present(items: Self.expectedItems)
+        return controller
+    }
+
+    private func host(
+        _ controller: DefinitionQuickPickController
+    ) -> AccessibilityTreeProbe.Hosted {
+        AccessibilityTreeProbe.host(
+            DefinitionQuickPickOverlay(controller: controller),
+            size: Self.overlaySize
+        )
+    }
+}

--- a/PineTests/PaneDividerAccessibilityTests.swift
+++ b/PineTests/PaneDividerAccessibilityTests.swift
@@ -1,0 +1,381 @@
+//
+//  PaneDividerAccessibilityTests.swift
+//  PineTests
+//
+//  Whether the pane divider can be moved without a mouse (#1533).
+//
+//  The divider always had a label and a hint that promised resizing. What it
+//  did not have was a role that says "this is adjustable", a value that says
+//  where it is, or an action that moves it — so VoiceOver read out a promise
+//  and offered nothing to act on. Every assertion below therefore reads the
+//  published accessibility tree and, where it can, drives the divider through
+//  it: an action that is published but wired to nothing fails here.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+@Suite("Pane divider accessibility (#1533)", .serialized)
+@MainActor
+struct PaneDividerAccessibilityTests {
+
+    private static let dividerSize = NSSize(width: 40, height: 200)
+
+    // MARK: - What the tree publishes
+
+    @Test("the divider publishes a splitter role, not an unnamed group")
+    func dividerPublishesSplitterRole() throws {
+        let harness = Harness(axis: .horizontal, ratio: 0.5)
+        let hosted = harness.host()
+        defer { hosted.tearDown() }
+
+        let divider = try #require(
+            AccessibilityTreeProbe.element(
+                under: hosted.root,
+                identifier: AccessibilityID.paneDivider
+            ),
+            "the divider is not in the published accessibility tree"
+        )
+
+        #expect(
+            AccessibilityTreeProbe.role(of: divider) == .splitter,
+            """
+            the divider publishes \
+            \(String(describing: AccessibilityTreeProbe.role(of: divider))) — \
+            without AXSplitter, VoiceOver has no reason to offer the adjust \
+            gesture that moves it
+            """
+        )
+        #expect(
+            AccessibilityTreeProbe.label(of: divider)
+                == Strings.a11yPaneDividerLabel
+        )
+        #expect(
+            AccessibilityTreeProbe.help(of: divider)
+                == Strings.a11yPaneDividerHint
+        )
+    }
+
+    /// A splitter between side-by-side panes is a vertical one. Getting this
+    /// backwards makes VoiceOver describe the wrong drag direction.
+    @Test("the divider's orientation follows the split axis")
+    func dividerOrientationFollowsAxis() throws {
+        let cases: [(SplitAxis, NSAccessibilityOrientation)] = [
+            (.horizontal, .vertical),
+            (.vertical, .horizontal),
+        ]
+
+        for (axis, expected) in cases {
+            let harness = Harness(axis: axis, ratio: 0.5)
+            let hosted = harness.host()
+            defer { hosted.tearDown() }
+
+            let divider = try #require(
+                AccessibilityTreeProbe.element(
+                    under: hosted.root,
+                    identifier: AccessibilityID.paneDivider
+                )
+            )
+            #expect(
+                AccessibilityTreeProbe.orientation(of: divider) == expected,
+                "a \(axis) split publishes the wrong divider orientation"
+            )
+        }
+    }
+
+    /// The value has to be the position, not a constant. Two hosts at two
+    /// ratios; a hardcoded string passes neither.
+    @Test("the divider publishes its position and that position tracks the ratio")
+    func dividerPublishesItsPosition() throws {
+        let quarter = Harness(axis: .horizontal, ratio: 0.25).host()
+        defer { quarter.tearDown() }
+        let threeQuarters = Harness(axis: .horizontal, ratio: 0.75).host()
+        defer { threeQuarters.tearDown() }
+
+        let quarterValue = try #require(
+            dividerValue(in: quarter),
+            "the divider publishes no value, so its position is unreadable"
+        )
+        let threeQuartersValue = try #require(dividerValue(in: threeQuarters))
+
+        #expect(
+            digits(in: quarterValue) == "25",
+            "a divider at 0.25 announces \"\(quarterValue)\""
+        )
+        #expect(
+            digits(in: threeQuartersValue) == "75",
+            "a divider at 0.75 announces \"\(threeQuartersValue)\""
+        )
+    }
+
+    // MARK: - Driving it through the tree
+
+    /// The load-bearing test: perform the action VoiceOver performs, and
+    /// require the pane tree to have actually moved.
+    @Test("VoiceOver's increment and decrement move the divider")
+    func incrementAndDecrementMoveTheDivider() throws {
+        let harness = Harness(axis: .horizontal, ratio: 0.5)
+        let hosted = harness.host()
+        defer { hosted.tearDown() }
+
+        let divider = try #require(
+            AccessibilityTreeProbe.element(
+                under: hosted.root,
+                identifier: AccessibilityID.paneDivider
+            )
+        )
+
+        let incremented = AccessibilityTreeProbe.performIncrement(divider)
+        #expect(
+            incremented == true,
+            """
+            the divider publishes no working increment — this is the whole \
+            defect: a splitter VoiceOver can read but not move
+            """
+        )
+        #expect(harness.adjustments == [0.55])
+
+        let decremented = AccessibilityTreeProbe.performDecrement(divider)
+        #expect(decremented == true)
+        #expect(
+            harness.adjustments == [0.55, 0.45],
+            """
+            decrement moved the divider to \(harness.adjustments) — each \
+            adjustment is measured from the ratio the divider was given, so \
+            a step applied to the wrong base shows up here
+            """
+        )
+    }
+
+    /// The bounds a drag is clamped to are the bounds an adjustment gets.
+    /// Reporting `true` at the end of the range would have VoiceOver announce
+    /// a move that never happened.
+    @Test("the divider refuses to adjust past the range a drag can reach")
+    func adjustmentStopsAtTheDragBounds() throws {
+        let atMaximum = Harness(axis: .horizontal, ratio: 0.9)
+        let maximumHost = atMaximum.host()
+        defer { maximumHost.tearDown() }
+        let maximumDivider = try #require(
+            AccessibilityTreeProbe.element(
+                under: maximumHost.root,
+                identifier: AccessibilityID.paneDivider
+            )
+        )
+
+        #expect(AccessibilityTreeProbe.performIncrement(maximumDivider) == false)
+        #expect(atMaximum.adjustments.isEmpty)
+        #expect(AccessibilityTreeProbe.performDecrement(maximumDivider) == true)
+        #expect(atMaximum.adjustments == [0.85])
+
+        let atMinimum = Harness(axis: .horizontal, ratio: 0.1)
+        let minimumHost = atMinimum.host()
+        defer { minimumHost.tearDown() }
+        let minimumDivider = try #require(
+            AccessibilityTreeProbe.element(
+                under: minimumHost.root,
+                identifier: AccessibilityID.paneDivider
+            )
+        )
+
+        #expect(AccessibilityTreeProbe.performDecrement(minimumDivider) == false)
+        #expect(atMinimum.adjustments.isEmpty)
+    }
+
+    /// A step from just inside the bound lands exactly on it rather than
+    /// overshooting into a ratio a drag could never produce.
+    @Test("an adjustment near a bound lands on the bound")
+    func adjustmentClampsToTheBound() {
+        var adjusted: [CGFloat] = []
+        let view = PaneDividerAccessibilityView(frame: .zero)
+        view.configure(
+            configuration(axis: .horizontal, ratio: 0.88)
+        ) { adjusted.append($0) }
+
+        #expect(view.adjust(by: 0.05))
+        #expect(adjusted == [0.9])
+    }
+
+    // MARK: - Full Keyboard Access
+
+    /// Arrow keys along the split's axis move the divider; the perpendicular
+    /// pair and any modified arrow belong to whoever had focus before.
+    @Test("arrow keys along the split axis adjust, others fall through")
+    func arrowKeysAdjustAlongTheAxis() throws {
+        let leftArrow: UInt16 = 123
+        let rightArrow: UInt16 = 124
+        let upArrow: UInt16 = 126
+        let downArrow: UInt16 = 125
+        let step = PaneDividerAccessibilityConfiguration.step
+
+        let horizontal: [(UInt16, CGFloat?)] = [
+            (leftArrow, -step),
+            (rightArrow, step),
+            (upArrow, nil),
+            (downArrow, nil),
+        ]
+        for (keyCode, expected) in horizontal {
+            #expect(
+                PaneDividerAccessibilityView.adjustment(
+                    forKeyCode: keyCode,
+                    axis: .horizontal,
+                    modifiers: []
+                ) == expected,
+                "key \(keyCode) on a horizontal split"
+            )
+        }
+
+        let vertical: [(UInt16, CGFloat?)] = [
+            (upArrow, -step),
+            (downArrow, step),
+            (leftArrow, nil),
+            (rightArrow, nil),
+        ]
+        for (keyCode, expected) in vertical {
+            #expect(
+                PaneDividerAccessibilityView.adjustment(
+                    forKeyCode: keyCode,
+                    axis: .vertical,
+                    modifiers: []
+                ) == expected,
+                "key \(keyCode) on a vertical split"
+            )
+        }
+
+        for modifier: NSEvent.ModifierFlags in [
+            .command, .option, .control, .shift,
+        ] {
+            #expect(
+                PaneDividerAccessibilityView.adjustment(
+                    forKeyCode: rightArrow,
+                    axis: .horizontal,
+                    modifiers: modifier
+                ) == nil,
+                "a modified arrow must stay with the previous responder"
+            )
+        }
+    }
+
+    /// A physical key press has to reach the same adjustment, not just the
+    /// classifier: `keyDown` routing is what a Full Keyboard Access user hits.
+    @Test("a physical arrow key press moves the divider")
+    func physicalArrowKeyMovesTheDivider() throws {
+        var adjusted: [CGFloat] = []
+        let view = PaneDividerAccessibilityView(frame: .zero)
+        view.configure(
+            configuration(axis: .horizontal, ratio: 0.5)
+        ) { adjusted.append($0) }
+
+        view.keyDown(with: try keyEvent(keyCode: 124))
+        #expect(adjusted == [0.55])
+
+        view.keyDown(with: try keyEvent(keyCode: 123))
+        #expect(adjusted == [0.55, 0.45])
+    }
+
+    /// The divider joins the key view loop only under Full Keyboard Access.
+    /// Always accepting focus would put a stop between two panes of text for
+    /// every user who never asked for one.
+    @Test("the divider takes keyboard focus only under Full Keyboard Access")
+    func focusFollowsFullKeyboardAccess() {
+        let view = PaneDividerAccessibilityView(frame: .zero)
+
+        view.isFullKeyboardAccessEnabled = { false }
+        #expect(!view.acceptsFirstResponder)
+        #expect(!view.canBecomeKeyView)
+
+        view.isFullKeyboardAccessEnabled = { true }
+        #expect(view.acceptsFirstResponder)
+        #expect(view.canBecomeKeyView)
+    }
+
+    // MARK: - Pointer input is untouched
+
+    @Test("the accessibility element never takes a mouse event")
+    func accessibilityElementDoesNotHitTest() {
+        let view = PaneDividerAccessibilityView(
+            frame: NSRect(x: 0, y: 0, width: 8, height: 200)
+        )
+
+        #expect(view.hitTest(NSPoint(x: 4, y: 100)) == nil)
+    }
+
+    // MARK: - Helpers
+
+    private func configuration(
+        axis: SplitAxis,
+        ratio: CGFloat
+    ) -> PaneDividerAccessibilityConfiguration {
+        PaneDividerAccessibilityConfiguration(
+            axis: axis,
+            ratio: ratio,
+            label: Strings.a11yPaneDividerLabel,
+            help: Strings.a11yPaneDividerHint,
+            identifier: AccessibilityID.paneDivider
+        )
+    }
+
+    private func dividerValue(
+        in hosted: AccessibilityTreeProbe.Hosted
+    ) -> String? {
+        AccessibilityTreeProbe.element(
+            under: hosted.root,
+            identifier: AccessibilityID.paneDivider
+        ).flatMap(AccessibilityTreeProbe.value(of:))
+    }
+
+    /// The digits in a locale-formatted percentage, so the assertion survives
+    /// a runner whose locale writes "25 %" or "％".
+    private func digits(in text: String) -> String {
+        String(text.filter(\.isNumber))
+    }
+
+    private func keyEvent(keyCode: UInt16) throws -> NSEvent {
+        try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: keyCode
+        ))
+    }
+
+    /// Hosts the real `PaneDividerView` and records what it asks the pane
+    /// tree to do. Recording the ratio rather than a bare call count is what
+    /// makes a step applied to the wrong base visible.
+    @MainActor
+    private final class Harness {
+        private(set) var adjustments: [CGFloat] = []
+        private let axis: SplitAxis
+        private let ratio: CGFloat
+
+        init(axis: SplitAxis, ratio: CGFloat) {
+            self.axis = axis
+            self.ratio = ratio
+        }
+
+        func host() -> AccessibilityTreeProbe.Hosted {
+            AccessibilityTreeProbe.host(
+                PaneDividerView(
+                    axis: axis,
+                    ratio: ratio,
+                    onDrag: { _ in },
+                    onDragEnd: {},
+                    onAdjustRatio: { [weak self] in
+                        self?.adjustments.append(
+                            (($0 * 100).rounded() / 100)
+                        )
+                    }
+                ),
+                size: PaneDividerAccessibilityTests.dividerSize
+            )
+        }
+    }
+}

--- a/PineTests/StatusBarAccessibilityHostedTests.swift
+++ b/PineTests/StatusBarAccessibilityHostedTests.swift
@@ -1,0 +1,342 @@
+//
+//  StatusBarAccessibilityHostedTests.swift
+//  PineTests
+//
+//  What the status bar sounds like (#1533).
+//
+//  Every assertion here reads the accessibility tree the hosted bar publishes,
+//  never the view code. That distinction is the whole point of this suite:
+//  the git summary's defect was that `Text(verbatim: "3")` reaches VoiceOver
+//  as the word "three" and nothing else, and a test that checked the view had
+//  a `Text` with "3" in it would have agreed with the defect.
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+@Suite("Status bar hosted accessibility (#1533)", .serialized)
+@MainActor
+struct StatusBarAccessibilityHostedTests {
+
+    private static let barSize = NSSize(width: 900, height: 28)
+
+    // MARK: - Git summary
+
+    /// The regression this suite exists for. Three counts with three distinct
+    /// values, so a label that names the wrong kind cannot pass by accident.
+    @Test("the git summary names every count instead of speaking bare numbers")
+    func gitSummaryNamesItsCounts() throws {
+        let hosted = hostBar(modified: 3, added: 1, untracked: 5)
+        defer { hosted.tearDown() }
+
+        let spoken = AccessibilityTreeProbe.labels(under: hosted.root)
+        let bare = spoken.filter { phrase in
+            !phrase.isEmpty && phrase.allSatisfy(\.isNumber)
+        }
+
+        #expect(
+            bare.isEmpty,
+            """
+            VoiceOver reads \(bare) out of the status bar with no word \
+            attached. A bare "3" is the git modified count, and there is \
+            nothing in the announcement that says so.
+            """
+        )
+    }
+
+    /// Naming the counts is only half of it — the names have to be attached to
+    /// the right numbers. Distinct counts make a copy-paste swap fail here.
+    @Test("each git count is announced with its own kind")
+    func gitCountsKeepTheirOwnNames() throws {
+        let hosted = hostBar(modified: 3, added: 1, untracked: 5)
+        defer { hosted.tearDown() }
+
+        let summary = try #require(
+            AccessibilityTreeProbe.element(
+                under: hosted.root,
+                identifier: AccessibilityID.gitStatusSummary
+            ),
+            "the git summary publishes no container element"
+        )
+        let byIdentifier = [
+            AccessibilityID.gitStatusModifiedCount: "3",
+            AccessibilityID.gitStatusAddedCount: "1",
+            AccessibilityID.gitStatusUntrackedCount: "5",
+        ]
+
+        for (identifier, count) in byIdentifier {
+            let element = try #require(
+                AccessibilityTreeProbe.element(
+                    under: summary,
+                    identifier: identifier
+                ),
+                "\(identifier) is missing from the published tree"
+            )
+            let announced = try #require(
+                AccessibilityTreeProbe.label(of: element),
+                "\(identifier) publishes no label"
+            )
+            #expect(
+                announced.contains(count),
+                "\(identifier) announces \"\(announced)\", not the count \(count)"
+            )
+            let namesTheKind = announced.contains { $0.isLetter }
+            #expect(
+                namesTheKind,
+                """
+                \(identifier) announces "\(announced)" — digits only, so \
+                VoiceOver still never says which kind of change it is
+                """
+            )
+        }
+    }
+
+    /// The three names must differ from one another. A single format applied
+    /// to all three counts would satisfy every assertion above.
+    @Test("the three git counts are announced with three different names")
+    func gitCountNamesAreDistinct() throws {
+        let hosted = hostBar(modified: 3, added: 1, untracked: 5)
+        defer { hosted.tearDown() }
+
+        let names = try [
+            AccessibilityID.gitStatusModifiedCount,
+            AccessibilityID.gitStatusAddedCount,
+            AccessibilityID.gitStatusUntrackedCount,
+        ].map { identifier -> String in
+            let element = try #require(
+                AccessibilityTreeProbe.element(
+                    under: hosted.root,
+                    identifier: identifier
+                )
+            )
+            let announced = try #require(
+                AccessibilityTreeProbe.label(of: element)
+            )
+            return announced.filter { !$0.isNumber }
+        }
+
+        #expect(
+            Set(names).count == names.count,
+            "the git counts share the wording \(names)"
+        )
+    }
+
+    /// A count of zero is not rendered at all, so it must not be announced.
+    @Test("a kind with no changes is not announced")
+    func absentGitKindsAreNotAnnounced() throws {
+        let hosted = hostBar(modified: 2, added: 0, untracked: 0)
+        defer { hosted.tearDown() }
+
+        #expect(
+            AccessibilityTreeProbe.element(
+                under: hosted.root,
+                identifier: AccessibilityID.gitStatusModifiedCount
+            ) != nil
+        )
+        #expect(
+            AccessibilityTreeProbe.element(
+                under: hosted.root,
+                identifier: AccessibilityID.gitStatusAddedCount
+            ) == nil,
+            "an added count of zero is invisible but still announced"
+        )
+        #expect(
+            AccessibilityTreeProbe.element(
+                under: hosted.root,
+                identifier: AccessibilityID.gitStatusUntrackedCount
+            ) == nil
+        )
+    }
+
+    // MARK: - Separators
+
+    /// `·` is a drawn gap. Read aloud between every indicator it is noise.
+    @Test("the interpunct separators are absent from the published tree")
+    func separatorsAreNotPublished() throws {
+        let hosted = hostBar(modified: 3, added: 1, untracked: 5)
+        defer { hosted.tearDown() }
+
+        let spoken = AccessibilityTreeProbe.labels(under: hosted.root)
+        let separators = spoken.filter { $0.contains("·") }
+
+        #expect(
+            separators.isEmpty,
+            """
+            VoiceOver reads \(separators.count) interpunct separator(s) out \
+            of the status bar: \(separators)
+            """
+        )
+    }
+
+    // MARK: - Named indicators
+
+    @Test("the cursor indicator is named and spells out line and column")
+    func cursorPositionIsNamedAndSpelled() throws {
+        let hosted = hostBar(
+            modified: 0,
+            added: 0,
+            untracked: 0,
+            cursorLine: 42,
+            cursorColumn: 7
+        )
+        defer { hosted.tearDown() }
+
+        let element = try #require(
+            AccessibilityTreeProbe.element(
+                under: hosted.root,
+                identifier: AccessibilityID.cursorPosition
+            ),
+            "the cursor indicator is not in the published tree"
+        )
+        let name = try #require(
+            AccessibilityTreeProbe.label(of: element),
+            "the cursor indicator has no name — VoiceOver reads only its text"
+        )
+        let announced = try #require(
+            AccessibilityTreeProbe.value(of: element),
+            "the cursor indicator publishes no value"
+        )
+
+        let namedInWords = name.contains { $0.isLetter }
+        #expect(namedInWords)
+        #expect(
+            !name.contains("42") && !name.contains("Ln"),
+            """
+            the cursor indicator's name is "\(name)" — a name has to stay \
+            the same as the cursor moves, or VoiceOver has nothing stable to \
+            announce the change against
+            """
+        )
+        #expect(announced.contains("42"), "the line number is not announced")
+        #expect(announced.contains("7"), "the column number is not announced")
+        #expect(
+            !announced.contains("Ln"),
+            """
+            the cursor value still reads the drawn abbreviation "Ln", which \
+            VoiceOver pronounces as a word rather than "line"
+            """
+        )
+    }
+
+    /// Requiring a non-empty label is not enough, and the mutation run proved
+    /// it: with `.accessibilityLabel` deleted, SwiftUI falls back to echoing
+    /// the reading itself, so the element still has *a* label — "2 KB" — and a
+    /// naive test passes on the exact defect. A name has to be a name: it says
+    /// what is being measured, so it carries no digits and is not a copy of
+    /// the value.
+    @Test("the indentation and file size indicators are named, not echoed")
+    func secondaryIndicatorsAreNamed() throws {
+        let hosted = hostBar(modified: 0, added: 0, untracked: 0)
+        defer { hosted.tearDown() }
+
+        for identifier in [
+            AccessibilityID.indentationIndicator,
+            AccessibilityID.fileSizeIndicator,
+        ] {
+            let element = try #require(
+                AccessibilityTreeProbe.element(
+                    under: hosted.root,
+                    identifier: identifier
+                ),
+                "\(identifier) is not in the published tree"
+            )
+            let name = try #require(
+                AccessibilityTreeProbe.label(of: element),
+                """
+                \(identifier) publishes no name, so VoiceOver announces its \
+                bare contents with no clue what they measure
+                """
+            )
+            let reading = try #require(
+                AccessibilityTreeProbe.value(of: element),
+                "\(identifier) publishes a name but no reading"
+            )
+
+            let namedInWords = name.contains { $0.isLetter }
+            let namedInDigits = name.contains { $0.isNumber }
+            #expect(namedInWords, "\(identifier) is named \"\(name)\"")
+            #expect(
+                !namedInDigits,
+                """
+                \(identifier) is named "\(name)". A name carrying the reading \
+                is the reading echoed back, not a name — it changes as the \
+                value changes and never says what is being measured.
+                """
+            )
+            #expect(
+                name != reading,
+                "\(identifier) announces \"\(name)\" twice"
+            )
+            #expect(!reading.isEmpty)
+        }
+    }
+
+    // MARK: - Fixture
+
+    private func hostBar(
+        modified: Int,
+        added: Int,
+        untracked: Int,
+        cursorLine: Int = 2,
+        cursorColumn: Int = 8
+    ) -> AccessibilityTreeProbe.Hosted {
+        let tabs = tabManager(
+            cursorLine: cursorLine,
+            cursorColumn: cursorColumn
+        )
+        return AccessibilityTreeProbe.host(
+            StatusBarView(
+                gitProvider: gitProvider(
+                    modified: modified,
+                    added: added,
+                    untracked: untracked
+                ),
+                paneManager: PaneManager(existingTabManager: tabs),
+                tabManager: tabs
+            ),
+            size: Self.barSize
+        )
+    }
+
+    private func tabManager(cursorLine: Int, cursorColumn: Int) -> TabManager {
+        let manager = TabManager()
+        var tab = EditorTab(
+            url: URL(fileURLWithPath: "/test/main.swift"),
+            content: "let x = 1\nlet y = 2\n",
+            savedContent: "let x = 1\nlet y = 2\n"
+        )
+        tab.cursorLine = cursorLine
+        tab.cursorColumn = cursorColumn
+        tab.fileSizeBytes = 2_048
+        tab.recomputeContentCaches()
+        manager.tabs = [tab]
+        manager.activeTabID = tab.id
+        return manager
+    }
+
+    private func gitProvider(
+        modified: Int,
+        added: Int,
+        untracked: Int
+    ) -> GitStatusProvider {
+        let provider = GitStatusProvider()
+        provider.isGitRepository = true
+        provider.currentBranch = "main"
+        var statuses: [String: GitFileStatus] = [:]
+        for index in 0..<modified {
+            statuses["/test/modified\(index).swift"] = .modified
+        }
+        for index in 0..<added {
+            statuses["/test/added\(index).swift"] = .added
+        }
+        for index in 0..<untracked {
+            statuses["/test/untracked\(index).txt"] = .untracked
+        }
+        provider.fileStatuses = statuses
+        return provider
+    }
+}

--- a/PineTests/TerminalAccessibilityIdentityTests.swift
+++ b/PineTests/TerminalAccessibilityIdentityTests.swift
@@ -1,0 +1,186 @@
+//
+//  TerminalAccessibilityIdentityTests.swift
+//  PineTests
+//
+//  What a terminal is called, on both surfaces that show one (#1533).
+//
+//  Two defects, one cause. The terminal view carried a role and an identifier
+//  but no name, so VoiceOver announced every terminal in the window as "text
+//  area". And the project tab bar's `accessibilityRepresentation` replaced the
+//  whole tab with `Button(tab.name)`, which threw away the agent badge — the
+//  amber marker that says an agent is blocked waiting for input. Quick
+//  Terminal announced it correctly the whole time; the two surfaces had
+//  drifted apart.
+//
+
+import AppKit
+import Foundation
+import SwiftTerm
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+@Suite("Terminal accessibility identity (#1533)", .serialized)
+@MainActor
+struct TerminalAccessibilityIdentityTests {
+
+    // MARK: - The surface has a name
+
+    @Test("the terminal surface publishes a name, not just a role")
+    func terminalSurfaceIsNamed() throws {
+        let tab = TerminalTab(name: "Terminal 1")
+        defer { tab.stop() }
+
+        #expect(
+            tab.terminalView.accessibilityRole() == .textArea,
+            "the pre-existing role must survive"
+        )
+        #expect(
+            tab.terminalView.accessibilityIdentifier()
+                == AccessibilityID.terminalSurface
+        )
+        #expect(
+            tab.terminalView.accessibilityLabel() == "Terminal 1",
+            """
+            the terminal surface announces \
+            \(String(describing: tab.terminalView.accessibilityLabel())) — \
+            with no name, every terminal in a split window is "text area"
+            """
+        )
+    }
+
+    /// The name is read at query time, so a shell that renames its tab
+    /// through OSC is heard. A label pushed once at construction is not.
+    @Test("a renamed terminal announces its new name without being re-pushed")
+    func terminalSurfaceNameFollowsTheShell() throws {
+        let tab = TerminalTab(name: "Terminal 1")
+        defer { tab.stop() }
+
+        tab.name = "~/pine — vim"
+
+        #expect(
+            tab.terminalView.accessibilityLabel() == "~/pine — vim",
+            "the surface is still announcing the name it was born with"
+        )
+    }
+
+    /// The same for an agent attached after the terminal already existed,
+    /// which is the only way agent detection ever attaches one.
+    @Test("an agent detected later is announced by the terminal surface")
+    func terminalSurfaceNameFollowsAgentDetection() throws {
+        let tab = TerminalTab(name: "Terminal 2")
+        defer { tab.stop() }
+        let session = Self.session(agentType: .claudeCode)
+
+        tab.agentSession = session
+
+        let announced = try #require(tab.terminalView.accessibilityLabel())
+        #expect(announced.contains("Terminal 2"))
+        #expect(announced.contains(session.agentType.displayName))
+        #expect(
+            announced.contains(
+                AgentTabBadge.userFacingState(for: session).displayName
+            ),
+            "the surface announces \"\(announced)\" without the agent's state"
+        )
+    }
+
+    // MARK: - The tab bar keeps the badge
+
+    /// The regression: the project tab bar's accessibility representation
+    /// overwrote the label with the bare tab name.
+    @Test("the project tab bar announces the agent badge it draws")
+    func projectTabAnnouncesTheAgentBadge() throws {
+        let tab = TerminalTab(name: "Terminal 3")
+        defer { tab.stop() }
+        let session = Self.session(agentType: .codex)
+        tab.agentSession = session
+
+        let hosted = AccessibilityTreeProbe.host(
+            TerminalNativeTabItem(
+                tab: tab,
+                isActive: true,
+                canClose: true,
+                onSelect: {},
+                onClose: {}
+            ),
+            size: NSSize(width: 220, height: 28)
+        )
+        defer { hosted.tearDown() }
+
+        let element = try #require(
+            AccessibilityTreeProbe.element(
+                under: hosted.root,
+                identifier: AccessibilityID.terminalTab(tab.stableLabel)
+            ),
+            "the terminal tab is not in the published tree"
+        )
+        let announced = try #require(
+            AccessibilityTreeProbe.label(of: element)
+        )
+
+        #expect(announced.contains("Terminal 3"))
+        #expect(
+            announced.contains(session.agentType.displayName),
+            """
+            the tab announces "\(announced)". The badge beside the name is the \
+            only signal that an agent is running in this terminal, and \
+            `accessibilityRepresentation` replaced the label that carried it.
+            """
+        )
+        #expect(
+            announced.contains(
+                AgentTabBadge.userFacingState(for: session).displayName
+            )
+        )
+    }
+
+    /// Both surfaces have to agree. This is the assertion that fails if one
+    /// of them is changed alone.
+    @Test("Quick Terminal and the project tab bar speak the same identity")
+    func bothSurfacesShareOneIdentity() throws {
+        let tab = TerminalTab(name: "Terminal 4")
+        defer { tab.stop() }
+        tab.agentSession = Self.session(agentType: .gemini)
+
+        #expect(
+            QuickTerminalContentView.agentIdentityAccessibilityLabel(for: tab)
+                == TerminalTabIdentityLabel.accessibilityLabel(for: tab)
+        )
+        #expect(
+            tab.terminalView.accessibilityLabel()
+                == TerminalTabIdentityLabel.accessibilityLabel(for: tab)
+        )
+    }
+
+    /// A terminal with no agent must not be announced with trailing commas
+    /// where the badge would have been — VoiceOver reads punctuation aloud.
+    @Test("a terminal with no agent is announced as its name alone")
+    func plainTerminalIsAnnouncedPlainly() throws {
+        let tab = TerminalTab(name: "Terminal 5")
+        defer { tab.stop() }
+
+        #expect(
+            TerminalTabIdentityLabel.accessibilityLabel(for: tab)
+                == "Terminal 5"
+        )
+    }
+
+    // MARK: - Fixture
+
+    private static func session(agentType: AgentType) -> AgentSession {
+        let session = AgentSession(
+            agentType: agentType,
+            startedAt: Date(timeIntervalSince1970: 5_000)
+        )
+        _ = session.bindProcessEvidence(AgentProcessEvidence(
+            processIdentifier: 5_001,
+            processGeneration: 1,
+            startIdentifier: "terminal-identity-fixture",
+            observedStartedAt: Date(timeIntervalSince1970: 5_000),
+            startIsAuthoritative: true
+        ))
+        return session
+    }
+}

--- a/docs/accessibility-release-checklist.md
+++ b/docs/accessibility-release-checklist.md
@@ -23,12 +23,25 @@ plus the language, appearance, and accessibility settings used.
    buttons, and sliders for clipping. Confirm controls announce their current
    value and enabled state.
 3. Create a terminal and verify New Tab, maximize/restore, close, and terminal
-   tabs expose localized names and their default action.
+   tabs expose localized names and their default action. Start an agent in a
+   terminal and confirm both the tab and the terminal itself announce the
+   agent and its state, not just the tab's name.
 4. Open Quick Open, Symbol Navigator, Command Palette, and Agent Inbox. Check
-   the search field, selected result, empty state, and actionable rows.
-5. Trigger unsaved-changes, application-Quit, and update surfaces. Check the
+   the search field, selected result, empty state, and actionable rows. On an
+   Inbox row, confirm the rotor offers Mark as Read / Mark as Unread and that
+   it names the direction that row is going.
+5. Split a pane. Confirm the divider announces as a splitter with its current
+   position, that the VoiceOver adjust gesture moves it, and — with Full
+   Keyboard Access on — that Tab reaches it and the arrow keys along the
+   split's axis move it.
+6. Go to a symbol with more than one definition. Confirm the quick pick can be
+   navigated and chosen entirely from the keyboard, and that each row
+   announces both the symbol and its location.
+7. Read the status bar end to end. Each git count must name what it counts, and
+   nothing may announce a bare number or an interpunct separator.
+8. Trigger unsaved-changes, application-Quit, and update surfaces. Check the
    title, explanation, default button, cancel path, and keyboard focus order.
-6. Repeat the visual pass in light and dark appearance. With Differentiate
+9. Repeat the visual pass in light and dark appearance. With Differentiate
    Without Color enabled, confirm status and selection do not rely on color
    alone; with Reduce Motion enabled, confirm transitions are immediate.
 


### PR DESCRIPTION
# polish(accessibility): give the custom controls a role, a value, and a way in

Part of #1533.

## What was wrong

Five surfaces from #1533's checklist, all the same shape of defect: something
is drawn, something can be done with a mouse, and the accessibility tree says
neither.

- **Pane divider** — `Pine/PaneDividerView.swift`. A label and a hint that
  promised "Drag to resize the panes", attached to an element with no splitter
  role, no position, and no action. The one input it offered was the one a
  VoiceOver or Full Keyboard Access user does not have.
- **Go-to-Definition quick pick** — `Pine/LSP/DefinitionQuickPickView.swift`.
  Rows were `onTapGesture` on an `HStack`, so the tree carried unnamed
  fragments of static text and nothing to activate. And the Escape / arrow /
  Return handlers sat on a backdrop that was never `.focusable()` — a view
  that cannot take focus never receives a key press, so the keyboard path had
  never worked for anybody.
- **Status bar** — `Pine/StatusBarView.swift`. The git summary announced as
  "3", "1", "5" with no word attached; the `·` separators were read aloud
  between every indicator; the cursor, indentation and file-size readings had
  no names.
- **Agent Inbox** — `Pine/Agent/AgentInboxView.swift`. Mark as Read/Unread was
  reachable by right-click only. A context menu is not in the accessibility
  tree, and the envelope button lives in the recovery panel, which appears
  only for a task that is both recoverable and expanded.
- **Terminal** — `Pine/TerminalSession.swift`, `Pine/TerminalBarView.swift`.
  The terminal view had a role and an identifier but no name, so every
  terminal in a split window announced as "text area". And the project tab
  bar's `accessibilityRepresentation` replaced the tab with
  `Button(tab.name)`, discarding the agent badge — the amber marker that says
  an agent is blocked waiting for input. Quick Terminal had been announcing it
  correctly all along; the two surfaces had drifted.

## What changed

### Pane divider — a real `AXSplitter`

New `Pine/PaneDividerAccessibility.swift`. SwiftUI cannot express what this
control needs, so the semantics live on an `NSView` behind the drawn line —
the same shape `SidebarAccessibilityRow` already uses. It publishes
`AXSplitter`, the position as a locale-formatted percentage, the orientation
of the split, and increment/decrement wired to the pane tree. `hitTest`
returns `nil`, so the drag gesture keeps every mouse event it had.

Full Keyboard Access gets arrow keys along the split's own axis. The divider
joins the key view loop **only** when Full Keyboard Access is on: always
accepting focus would put a Tab stop between two panes of text for everyone
who never asked for one.

Adjustment is clamped to `0.1...0.9` — the bounds a drag is clamped to — and
returns `false` at either end, which is what makes VoiceOver announce that the
divider is already as far as it goes.

### Go-to-Definition quick pick — focusable, and reachable

Key handling moved off the backdrop onto a `.focusable()` container with
`@FocusState`, matching the pattern `AgentInboxView` and
`AgentAttentionOverlay` already use. Rows became one combined stop each, with
a button trait, the selected trait, a hint, an identifier and an accessibility
action that selects and opens. Mouse behaviour is untouched: single click
still selects, double click still opens. The backdrop is hidden from the tree.

### Status bar

Each git count now announces its kind, and the count sits in the **label**,
not in a value — see the findings below. The `·` separators are hidden.
Cursor, indentation and file size get a stable name plus a value, so a moving
cursor announces as a value change against a name that does not move. The
Problems glyph is hidden; the count text beside it was already the button's
name.

### Agent Inbox

The row publishes a rotor action named for what it will do to *that* row —
"Mark as Read" on an unread one, "Mark as Unread" on a read one — wired to the
same `toggleReviewed` the context menu calls.

### Terminal

One shared identity, `TerminalTabIdentityLabel.accessibilityLabel(for:)`, used
by the project tab bar, Quick Terminal and the terminal surface itself.
`QuickTerminalContentView.agentIdentityAccessibilityLabel` stays as its own
entry point and delegates, so the two surfaces cannot drift apart again.

The surface's name is supplied as a **closure**, read at query time, because
both halves of it move on their own: the shell renames the tab through OSC,
and agent detection attaches a session later. Anything pushed once would be
stale by the time VoiceOver read it.

## Two findings that shaped the fix

Both came from probing what the accessibility tree actually receives, and both
would have silently defeated the obvious implementation.

1. **macOS drops `.accessibilityValue` on an element whose bridged role is
   `AXUnknown`** — which is what a `Label` collapsed with
   `.accessibilityElement(children: .ignore)` becomes. Splitting the git
   summary into label "Modified" + value "3" reads back correctly in the view
   code and announces "Modified" to VoiceOver, with the number gone. The count
   is therefore in the label.

2. **`.accessibilityLabel` on a `Menu` does not reach the tree at all**, and
   `.accessibilityRepresentation` on a `Menu` destroys its `AXPress`. The line
   ending and encoding menus in the status bar are therefore left alone rather
   than "fixed" into unusable controls — see *Deferred*.

## Tests

Five new suites, plus `PineTests/AccessibilityTreeProbe.swift`, a shared
reader for the tree a hosted view actually publishes.

**On why the tests are shaped this way.** A SwiftUI accessibility modifier is
a request, not a guarantee — as both findings above show. And
`XCUIElement.label` answers from the model, so it agrees with the view code
whether or not anything reached VoiceOver. Every assertion in these suites
therefore reads the published tree through `accessibilityChildren()`, the
route VoiceOver takes, using the approach already documented in
`PineTests/RecoveryDialogEscapeSafetyTests.swift:1432-1460`. Where an element
is supposed to *do* something, the test performs the action through the tree
and requires the model to have changed: an action published with the right
name and no wiring is indistinguishable from the outside.

| Suite | Tests |
| --- | --- |
| `PaneDividerAccessibilityTests` | 10 |
| `StatusBarAccessibilityHostedTests` | 7 |
| `DefinitionQuickPickAccessibilityTests` | 6 |
| `TerminalAccessibilityIdentityTests` | 6 |
| `AgentInboxMarkReadAccessibilityTests` | 4 |

No UI tests added; shard balance unchanged (`check_ui_test_shards.py`:
delta=2, 41 classes / 239 tests).

### Mutation verification

Each row: the named piece of the fix was removed or inverted in the working
tree, the suite that is supposed to notice was run, and the tree was restored
and byte-compared against a pristine snapshot before the next row. All 25 kill
their suite.

| # | Mutation | Suite | Result |
| --- | --- | --- | --- |
| 1 | divider role `.splitter` → `.group` | PaneDivider | ✘ 1 issue |
| 2 | drop `setAccessibilityValue` | PaneDivider | ✘ 1 issue |
| 3 | `accessibilityPerformIncrement` returns `false` | PaneDivider | ✘ 3 issues |
| 4 | invert divider orientation | PaneDivider | ✘ 2 issues |
| 5 | drop the adjustment clamp | PaneDivider | ✘ 6 issues |
| 6 | `acceptsFirstResponder` hardcoded `false` | PaneDivider | ✘ 2 issues |
| 7 | swap arrow keys across the axes | PaneDivider | ✘ 10 issues |
| 8 | drop the git count's `.accessibilityLabel` | StatusBar | ✘ 2 issues |
| 9 | git count in `.accessibilityValue` instead of the label | StatusBar | ✘ 2 issues |
| 10 | "Added" count announced with the "Modified" wording | StatusBar | ✘ 1 issue |
| 11 | unhide the `·` separators | StatusBar | ✘ 1 issue |
| 12 | drop the cursor indicator's name | StatusBar | ✘ 1 issue |
| 13 | drop the cursor indicator's value | StatusBar | ✘ 1 issue |
| 14 | drop the file size indicator's name | StatusBar | ✘ 2 issues |
| 15 | drop the row's `.accessibilityElement(children: .combine)` | QuickPick | ✘ 2 issues |
| 16 | row announces the symbol without its location | QuickPick | ✘ 3 issues |
| 17 | drop the row's `.accessibilityAction` | QuickPick | ✘ 3 issues |
| 18 | drop the selected trait | QuickPick | ✘ 1 issue |
| 19 | publish the dismissal backdrop as a button | QuickPick | ✘ 1 issue |
| 20 | drop `.accessibilityActions` from the row | Inbox | ✘ 10 issues |
| 21 | action always named "Mark as Read" | Inbox | ✘ 7 issues |
| 22 | action published but wired to nothing | Inbox | ✘ 2 issues |
| 23 | drop the terminal surface's label provider | Terminal | ✘ 4 issues |
| 24 | freeze the surface label at construction | Terminal | ✘ 4 issues |
| 25 | tab representation back to `Button(tab.name)` | Terminal | ✘ 2 issues |

Row 14 is worth reading: on the first sweep it **survived**. Requiring a
non-empty label was not enough, because with `.accessibilityLabel` deleted
SwiftUI falls back to echoing the reading, so the element still had *a* label
— "2 KB" — and the test agreed with the defect. The assertion now requires a
name to be a name: letters, no digits, and not a copy of the value. That is
exactly the tautology this issue warned about, caught by the sweep rather than
by reading the test.

## Change to an existing test — `PineTests/AgentInboxTests.swift`

**This is somebody else's test and the edit is mine.** Calling it out here so
it is reviewed on purpose rather than found in the diff.

### What changed

`BlockingInboxProjectCanonicalizer.waitUntilEntered` polled for the recovery
path to reach canonicalization, bounded at `200 × 1 ms`. It is now
`5_000 × 1 ms`. Nothing else in that file changed, and the comment above it
records why.

### Why 200 ms was not a strict budget but an unreachable one

`recoverAgentTaskFromInbox` runs on the main actor. Swift Testing runs suites
in parallel by default, so anything else `@MainActor` that is scheduled at the
same time holds the actor and the poll simply never gets to observe `entered`
flip. The budget was therefore not measuring the code under test — it was
measuring how busy the machine happened to be.

Measured on this branch, hosting the Inbox in an `NSHostingView` and reading
its accessibility tree once:

```
COST host+read #0: 232.9 ms      (first host: includes one-time setup)
COST host+read #1:  82.0 ms
COST host+read #2:  79.9 ms
COST host+read #3:  78.9 ms
```

The new suite hosts four times, so it occupies the main actor for roughly
**473 ms in one suite** — more than twice the old budget. Even a *single*
hosted-Inbox test costs 80 ms of the 200, and the first one alone blows it.

That is the reason there is no fix available on my side. Trimming the suite to
one hosting still costs 233 ms; hosting a smaller fixture still costs tens of
milliseconds against a budget that has to cover an arbitrary neighbour. Any
future `@MainActor` suite anywhere in `PineTests` runs into the same wall, so
narrowing my suite would only postpone the failure onto whoever writes the
next one.

### Why 5 s, and why it is still a bounded wait

5 s is far above the real cost of the operation (the canonicalizer is reached
in well under a millisecond when the actor is free) and far above the
main-actor occupancy any single suite plausibly adds. It is a ceiling, not a
delay: the loop returns the moment `entered` is true, so a passing run is
exactly as fast as before.

The bound is kept deliberately. `waitUntilEntered` still returns `false` and
the test still fails if canonicalization is never reached, so a genuinely
stuck recovery is caught rather than hanging the suite. This is not "wait
longer until it passes" — the failure mode the assertion exists for is
unchanged, only the false one is removed.

### Not done here

The same shape exists elsewhere: several suites bound main-actor work with
short `elapsed < N` or fixed poll budgets that a parallel neighbour can blow —
including two more in this very file (`AgentInboxTests.swift:794` and `:986`).
That is systemic rather than about the Inbox, so it is filed as #1568 rather
than swept up here.

## Localization

Ten new keys, inserted into `Localizable.xcstrings` by targeted text insertion
— never `json.dump`. The diff is 600 lines, all additions, no existing byte
touched.

All nine locales are filled in and marked `translated`. **The translations are
mine and have not been reviewed by a native speaker** — flagging that
explicitly. The counted keys are phrased as a category plus a number
("Modified: 3", "Изменено: 3") so no locale needs plural agreement.

Existing `a11y.*` keys were left alone: they ship English in every locale,
which is #1529's scope, and touching them here would collide.

`docs/accessibility-release-checklist.md` gains manual steps for the divider,
the quick pick, the status bar and the terminal's agent state.

## Deferred, with reasons

- **Status bar line-ending and encoding menus.** SwiftUI drops
  `.accessibilityLabel` on `Menu` on macOS 26/27, and
  `.accessibilityRepresentation` removes the press. Naming them needs an
  AppKit representation of the whole control — a bigger change than this
  issue, and one that wants its own visual check. The menus keep the behaviour
  they had.
- **A visible Mark as Read button on every Inbox row**, and a main-menu item
  for it. Both are visual/behavioural changes rather than accessibility
  repairs; the rotor action closes the "mouse only" gap now.
- **Minimap, Problems panel severity, identifier hygiene, Increase Contrast /
  Reduce Transparency** — the remaining #1533 boxes, untouched here.

## Local test state

All five new suites green, and green alongside `AgentInboxTests`,
`QuickTerminalContentHostedTests`, `RecoveryDialogEscapeSafetyTests`,
`AccessibilityLocalizationMatrixTests`, `SplitPaneRoutingTests` and
`StatusBarInfoTests`. `swiftlint --strict` clean.

A full `PineTests` run on this machine also reports failures in
`TerminalPTYProcessTreeTests`, `WindowLifecycleTests`, `AsyncFormatOnSaveTests`,
`UserTaskRunnerTests`, `MultiProjectAgentLifecycleIntegrationTests` and
`LSPTransportTests`. Those are the process- and deadline-sensitive suites
`AGENTS.md` describes: `TerminalPTYProcessTreeTests` fails identically with
this branch stashed, and `WindowLifecycleTests` passes when run alone on this
branch. CI is the signal.

## Visual review

No pixels change. Every edit is accessibility metadata, one hidden decorative
glyph, and the quick pick's key handling moving to a focusable container —
which changes what the keyboard does, not what is drawn. Worth a keyboard
poke at the quick pick and a VoiceOver pass on the divider before merge.

## Overlap with the #1527/#1528/#1529/#1532 branch

Checked against `fix/accessibility-icon-labels-and-status` at its working tree,
both branches based on `e30b26c3`. A textual merge is not enough for
`Localizable.xcstrings` — two branches can merge cleanly and still both claim
the same key — so the catalogue was compared by **key set** and `Strings` by
**member name**, then a three-way merge was run on top.

### Semantic overlap: none

| Check | Result |
| --- | --- |
| Localization keys added by both | none (hers 14, mine 10, disjoint) |
| Existing keys modified by both | none (she modifies 19, I modify 0) |
| `Strings` members added by both | none (hers 16, mine 10, disjoint) |
| Members removed by either | none |

The two changes are complementary rather than colliding. She translates the 19
`a11y.*` keys that ship English in every locale (#1529) — including
`a11y.paneDivider.label` and `a11y.paneDivider.hint`, which this PR's new
`AXSplitter` announces but does not modify. Her translations land on strings my
divider speaks; nothing has to be reconciled.

One thing worth a decision, not a conflict: she translates
`a11y.gitStatus.modified` / `.added` / `.untracked` ("Modified", "Added",
"Untracked" — the sidebar's Differentiate Without Color labels), while I add
`a11y.statusBar.git.modified %lld` and siblings for the status bar, which need
the count in the same string. Two key families now carry the same vocabulary
for two different surfaces. That is deliberate on my side (see the `AXUnknown`
finding above — the count cannot live in a separate value), but if you would
rather they were unified later, that is a follow-up, not something to settle in
either PR.

### Textual conflicts: two, both mechanical

`git merge-file` on the three shared files:

| File | Conflicts |
| --- | --- |
| `Pine/Strings.swift` | 0 — clean |
| `Pine/StatusBarView.swift` | 1 |
| `Pine/Localizable.xcstrings` | 1 |

**`Pine/StatusBarView.swift`** — we independently made the same decision about
the Problems severity glyph. She adds a bare `.accessibilityHidden(true)`; I
add the same line with a comment above it. Resolution: keep either side's
version of that one line, drop the other. No behaviour to reconcile.

**`Pine/Localizable.xcstrings`** — my eight status-bar keys are inserted
directly after `a11y.statusBar.terminalToggle.hint`, and that entry is one she
rewrites for #1529, so the two edits land on the same lines. Resolution: keep
her rewritten entry and keep my inserted block after it. Both sides are pure
additions to disjoint keys; nothing is lost either way.

I left both as they are rather than moving my insertion anchor or dropping my
comment — resolving them is a two-line edit for whoever merges second, and
reshuffling my diff to dodge a trivial conflict would make the change harder to
read for no gain. Nothing of hers is rewritten here.

### Merge order

Either order works. Whoever goes second resolves the two conflicts above.

## Ready to merge

After review. Not merged by me.
