### PR TITLE
fix(tests): record .newAgent in the advertised-shortcut table

### DIFF
--- a/PineTests/MenuShortcutOverrideTests.swift
+++ b/PineTests/MenuShortcutOverrideTests.swift
@@ -41,6 +41,12 @@ struct MenuShortcutOverrideTests {
     /// cannot render: `MenuKeyboardShortcut` returns `nil`, the item loses
     /// its key equivalent, and nothing else in the app notices. This table is
     /// the independent record of what each item is supposed to show.
+    ///
+    /// Commands added *after* #1539 have no "before" to transcribe — they are
+    /// born reading `effectiveChord(for:)`. They still belong here: the table
+    /// is asserted to cover every command with a built-in chord, so a new
+    /// rebindable command cannot arrive without a record of what its menu
+    /// item shows. `.newAgent` (#1566) is the first of those.
     static var advertisedShortcuts: [UserCommand: AdvertisedShortcut] {
         [
             // File
@@ -94,6 +100,7 @@ struct MenuShortcutOverrideTests {
             ),
             .revealFileInFinder: AdvertisedShortcut("r", [.command, .shift]),
             .showAgentInbox: AdvertisedShortcut("i", [.command, .shift]),
+            .newAgent: AdvertisedShortcut("a", [.command, .shift]),
             // Git
             .showBranchSwitcher: AdvertisedShortcut("b", [.command, .shift]),
             // Terminal


### PR DESCRIPTION
Fixes #1570. Unblocks the release PR #1488.

## The failure

```
✘ Test "the table covers exactly the commands that own a built-in chord"
   PineTests/MenuShortcutOverrideTests.swift:147:9
   Expectation failed: Set(Self.advertisedShortcuts.keys) == withBuiltInChords
```

`advertisedShortcuts` is asserted to hold **exactly** the commands where
`UserCommand.defaultChord != nil`. #1565 wrote that table against the 46
rebindable commands on its branch; #1566 added `.newAgent` with a default
chord of `cmd+shift+a` as the 47th. Both merged at `2026-08-25T16:09`, touch
disjoint files, and neither branch ever saw the other — so both were green
individually and `main` came out red on one missing dictionary entry.

## The change

One entry, in the View section beside the Agent Inbox's `cmd+shift+i` that
`UserCommand+Palette.swift:424` names as the reason `.newAgent` took
`cmd+shift+a`:

```swift
.newAgent: AdvertisedShortcut("a", [.command, .shift]),
```

Plus a paragraph on the table's doc comment. It currently describes itself as
a transcription of the `.keyboardShortcut(…)` literals the menu carried
*before* #1539, which is silent about commands added after the override layer
landed — exactly the case that just broke. The new paragraph says those
commands belong in the table too, and why.

## Verification

Local, `Xcode-beta` (macOS 27 beta — CI is the pass/fail signal per AGENTS.md,
these are a sanity check):

| Check | Result |
|---|---|
| `PineTests/MenuShortcutOverrideTests` before the fix | 1 of 5 failed — reproduced |
| `PineTests/MenuShortcutOverrideTests` after | 5 of 5 passed |
| `PineTests/MenuHardcodedShortcutGuardTests` | 4 of 4 passed |
| `PineTests/AgentLaunchCommandTests` | 23 of 23 passed |
| `swiftlint lint --strict` on the changed file | clean (0.65.1, same as CI) |
| `xcodebuild build` | BUILD SUCCEEDED |

## Not in scope

The `cmd+shift+a` chord choice itself, which is fine, and the non-standard
chords tracked in #1564.

Worth deciding separately: two PRs merged minutes apart can red-line `main`
with no signal, because `CI` does not run on pushes to `main` (last run there
is from 2026-08-03) and GitHub does not re-check an open PR when a sibling
merges. Requiring branches to be up to date before merge, or running `CI` on
`main`, would have surfaced this at merge time instead of at the release PR.
Noted in #1570; not addressed here.
