### PR TITLE
docs(claude): rename AGENTS.md to CLAUDE.md and scope it into rules and skills

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,93 @@
+---
+paths:
+  - "Pine/**/*.swift"
+---
+
+# Pine architecture
+
+How the app is put together. Loads when you open a file under `Pine/`.
+
+**Pattern:** MVVM with SwiftUI views backed by AppKit via `NSViewRepresentable`.
+
+**State management:** `ProjectManager` (@Observable) is the central state object managing file tree, editor tabs, terminal tabs, and git status. It owns `PaneManager` (split pane tree), `TabManager` (primary editor tabs), `TerminalManager` (terminal coordinator), and `WorkspaceManager` (file tree + git). It communicates with views via SwiftUI observation and with menu commands via NotificationCenter.
+
+**AppKit bridges:**
+- `CodeEditorView` — wraps NSScrollView + custom `GutterTextView` (NSTextView subclass) + `LineNumberView` for the code editor
+- `TerminalContentView` — wraps SwiftTerm's `LocalProcessTerminalView` (NSView) for the terminal
+
+**Text system stack:** NSTextStorage → NSLayoutManager → NSTextContainer → GutterTextView (shifts text right for line number gutter)
+
+**Split panes:** `PaneNode` is a recursive enum (`.leaf` or `.split`) forming a binary tree of editor/terminal panes. `PaneManager` (@MainActor @Observable) manages the tree, per-pane TabManagers (for editor leaves), and per-pane `TerminalPaneState` (for terminal leaves). `PaneTreeView` recursively renders the tree; `PaneLeafView` switches on `PaneContent` (.editor/.terminal) to render the appropriate content. `PaneDividerView` handles resize. Drag-and-drop between panes uses `TabDragInfo` with `contentType` field for type validation (editor tabs can only drop on editor panes, terminal tabs on terminal panes). `PaneSplitDropDelegate` detects drop zones (right/bottom/center) based on cursor position. `TabCloseHelper` provides shared close-with-confirmation dialogs used by both ContentView and PaneLeafView.
+
+**Sidebar file navigation:** Treat the left file tree as a Finder-style, keyboard-first surface, not as a mouse-only list. `SidebarTreeNavigation` owns one selection over the flattened visible rows: Up/Down move by row; Left collapses an expanded folder or selects its parent; Right expands a collapsed folder or selects its first child; Home/End and Page Up/Page Down navigate the visible tree; typing performs Unicode-aware prefix selection with repeated-character cycling. Selection, opening, and focus are distinct states. Space opens a transient preview and keeps focus in the sidebar; Return starts inline rename; Cmd+Return permanently opens the file and moves focus to the editor. A single file click previews, a double-click permanently opens, and a folder-row click toggles disclosure. Keyboard selection must preserve spatial orientation: while the selected row is visible, do not move the viewport; once it leaves the viewport, reveal it by the smallest necessary amount at the nearest edge. With `ScrollViewProxy`, call `scrollTo(id)` without an anchor or animation for routine navigation — never use `.center` there. Intentional reveal after create/duplicate may use `.center` and animation, but must become immediate under Reduce Motion. Unit tests must lock the minimal-vs-centered request policy; an XCUITest that only asserts `isSelected` does not verify scroll geometry. Before release, manually check a tall tree with single and held arrow presses, both viewport boundaries, type-to-select to an off-screen row, Home/End, Page Up/Page Down, create/duplicate centering, and Reduce Motion.
+
+**Terminal:** Uses [SwiftTerm](https://github.com/migueldeicaza/SwiftTerm) — a full VT100/xterm terminal emulator in pure Swift. Terminal tabs live inside the split pane tree as `.terminal` leaf panes — there is no separate bottom panel. `TerminalPaneState` (@Observable) manages per-pane terminal tabs (array of `TerminalTab`, active tab, search state). `TerminalManager` is a coordinator that routes Cmd+T and Cmd+\` to the appropriate terminal pane via `PaneManager`. When creating a new terminal pane, it wraps the entire editor tree in a vertical split (terminal at bottom, full width). `TerminalPaneTabBar` provides the tab bar with drag-and-drop, maximize/restore, and close buttons. `TerminalContainerView` (AppKit) handles SwiftTerm view lifecycle. Supports colors, cursor positioning, TUI apps (vim, htop), oh-my-zsh, and all standard terminal features.
+
+**Terminal hyperlinks:** two independent click paths, both on ⌘+click. (1) Implicit `path:line[:col]` references in any terminal cell are parsed by `TerminalOutputParser` (#949) — the `TerminalScrollInterceptor` overlay resolves them against the working directory, verifies the file exists, and posts `.openFileAtLine` to open it in the editor. (2) Explicit OSC 8 hyperlinks and implicit URLs are handled by SwiftTerm itself (`linkReporting = .implicit`, `linkHighlightMode = .hoverWithModifier` — hover-underline is built in) → `TerminalTabDelegate.requestOpenLink` → `TerminalLinkOpener` (#1114): `file://` (local host) reveals in Finder via `NSWorkspace.activateFileViewerSelecting` WITHOUT launching — safe even if the link points at a `.app`/`.command` bundle a hostile program sneaked into its output; `http(s)`/`mailto` open in the system handler; `file://` with a foreign host is ignored to avoid Finder network mounts. The `path:line` path runs first (the overlay consumes the event); OSC 8 is the fallback when no `file:line` reference is under the cursor.
+
+**Git integration:** `GitStatusProvider` runs `git status` and `git diff` to show file status indicators in the sidebar and diff markers (added/modified/deleted) in the editor gutter. Branch switching is available via clickable subtitle in the title bar (shows NSMenu with all branches) and via Cmd+Shift+B (opens `BranchSwitcherView` sheet with search). The subtitle click is implemented via AppKit (`BranchSubtitleClickHandler`) because SwiftUI's `toolbarTitleMenu` does not work on macOS 26 with Liquid Glass. Git blame display shows per-line commit info (hash, author, timestamp, message) alongside code; toggled via menu. `GitBlameInfo` holds the parsed blame data structures.
+
+**Syntax highlighting:** `SyntaxHighlighter` singleton loads JSON grammar files from `Pine/Grammars/` at startup. Each grammar defines regex rules with scopes (comment, string, keyword, etc.) and a priority system prevents nested matches (comments > strings > keywords). Highlighting runs asynchronously using generation tokens to discard stale results.
+
+**Minimap:** `MinimapView` renders a scaled-down (12%) document overview on the right edge of the editor showing syntax colors and git diff markers. Click or drag to scroll the editor proportionally. A viewport indicator rectangle shows the visible region. Toggle visibility via menu.
+
+**Code folding:** `FoldRangeCalculator` identifies foldable ranges by scanning matched bracket pairs (`{}`, `[]`, `()`). `FoldState` tracks which ranges are folded for the active tab using a sorted set for O(1) hidden-line lookups. Fold/unfold/toggle operations are available via menu and gutter clicks.
+
+**Adding menu commands:** Menu items are defined in `PineApp.swift` inside `CommandGroup`. They post notifications via `NotificationCenter.default.post(name:)`. Notification names are defined as static properties in `extension Notification.Name` (bottom of `PineApp.swift`). `ContentView` listens via `.onReceive()` inside `GitAndNotificationObserver` ViewModifier. Strings go in `Strings.swift`, icons in `MenuIcons.swift`, localization in `Localizable.xcstrings` (targeted text insertion, not json.dump).
+
+**Find & Replace:** Uses NSTextView's native find bar (`usesFindBar = true`) triggered via NotificationCenter. Notifications: `findInFile` (Cmd+F), `findAndReplace` (Cmd+Option+F), `findNext` (Cmd+G), `findPrevious` (Cmd+Shift+G), `useSelectionForFind` (Cmd+E). The find bar is presented by `GutterTextView`'s coordinator in response to menu commands.
+
+**Project-wide search:** `ProjectSearchProvider` performs async full-project text search with debounce, `.gitignore` support, binary file detection, and a 1 MB per-file limit. Results are grouped by file and displayed in `SearchResultsView` with match highlighting and case-sensitivity toggle.
+
+**Status bar:** `StatusBarInfo` computes cursor position (line:column, 1-based), line ending style (LF/CRLF), indentation style (spaces/tabs with width), and human-readable file size. These values are displayed in `StatusBarView` at the bottom of the editor.
+
+**Format on Save:** `FileFormatterRegistry` applies language-aware formatters when `EditorSettings.formatOnSave` is enabled. Pure-Swift formatters (e.g. `JSONFileFormatter`) run synchronously. External tool formatters (`ExternalFileFormatter`) delegate to CLI tools (terraform, tofu, shfmt, prettier) via stdin/stdout — `ExternalFileFormatter.format()` dispatches `processRunner.run()` to a background queue via `DispatchGroup` so the main-thread `precondition` in `RealProcessRunner` is satisfied. `ExternalToolResolver` discovers tools by searching PATH + well-known directories (`/opt/homebrew/bin`, `/usr/local/bin`). `HCLFileFormatter` resolves terraform (preferred) or tofu for `.tf`/`.tfvars`/`.hcl` files. When neither tool is found, the formatter becomes a no-op (`toolPath: nil`). The registry is injectable via `TabManager.fileFormatters` for testing with `MockProcessRunner`.
+
+**Smart list continuation:** `SmartListContinuation` auto-continues Markdown list bullets/numbers/tasks on Enter. Wired into `GutterTextView` key handling. Enabled by default via `EditorSettings.smartListContinuation`.
+
+**Auto-save:** Auto-save support is accessible via menu (menu icon defined in `MenuIcons.autoSave`, string in `Strings.menuAutoSave`).
+
+**File system watching:** `FileSystemWatcher` uses FSEvents to monitor a directory tree and fires a debounced callback on the main thread when changes occur. Generation tokens prevent stale callbacks from firing after `stop()` is called.
+
+**Async file tree:** `WorkspaceManager` loads the project file tree in two phases — a shallow pass renders immediately for responsiveness, followed by a full async load. Generation tokens prevent stale async results from overwriting newer ones.
+
+**Window & tab management:** Uses `WindowGroup(for: URL.self)` where URL identifies the project directory (not individual files). Each project gets one native macOS window with an internal editor tab bar (`EditorTabBar`). `ProjectRegistry` (owned by `AppDelegate`, shared with `PineApp` via computed property) deduplicates open projects — opening the same directory twice returns the same `ProjectManager`. A `Welcome` window (`WelcomeView`) shows on launch with a recent projects list and an Open Folder button. `FocusedProjectKey` passes the active `ProjectManager` to menu commands via `@FocusedValue`. On macOS 26, XCUITest and direct binary launches bypass LaunchServices, causing SwiftUI to skip window creation despite `.defaultLaunchBehavior(.presented)`. `AppDelegate.createWelcomeWindowViaAppKit()` uses `NSHostingController` as a fallback to guarantee the Welcome window appears.
+
+**Document lifecycle:** `TabManager` manages save operations — `saveTab(at:)` writes to disk with NSAlert on failure, `trySaveTab(at:)` throws without UI. `saveAllTabs()` / `trySaveAllTabs()` save all dirty tabs. `saveActiveTabAs(to:)` implements Save As — writes to new URL and updates tab in-place preserving identity. `duplicateActiveTab()` creates a copy with Finder-like naming ("file copy.ext", "file copy 2.ext"). Close/quit dialogs list unsaved files with `dirtyTabs` and use "Save All" button. Failed saves cancel close/quit.
+
+**Quick Open:** `QuickOpenProvider` builds a file index from the `FileNode` tree and performs fuzzy subsequence matching with scoring (filename exact/prefix/substring bonuses, recent files boost). `QuickOpenView` is a sheet overlay with live search, arrow key navigation, and file icons. Triggered via Cmd+P.
+
+**Symbol Navigator:** `SymbolNavigatorView` shows functions, classes, and structs in the current file with fuzzy search. Triggered via Cmd+R. Uses regex-based symbol extraction per language.
+
+**Markdown preview:** Renders markdown using [swift-markdown](https://github.com/swiftlang/swift-markdown). Three modes: source-only, rendered, and side-by-side. Toggled via Cmd+Shift+P. The rendered view converts Markdown AST to NSAttributedString for display in a native text view.
+
+**Session persistence:** `SessionState` (Codable struct) saves project path, open file paths, pane layout tree (PaneNode), per-pane terminal tab counts, and editor state to UserDefaults. `AppDelegate` triggers save on app termination for all open projects. `ContentView.restoreSessionIfNeeded()` restores tabs and pane layout on first load if the saved session matches the current project. Terminal pane positions are preserved; terminal processes are recreated (scrollback lost).
+
+## Key entry points
+
+- `PineApp.swift` — @main, AppDelegate, menu commands, `CloseDelegate`
+- `ContentView.swift` — NavigationSplitView: sidebar + PaneTreeView
+- `ProjectManager.swift` — Central state: pane manager, tab manager, terminal coordinator, git provider
+- `CodeEditorView.swift` — NSViewRepresentable editor (GutterTextView + LineNumberView)
+- `PaneManager.swift` / `PaneNode.swift` — Split pane tree (binary tree of editor/terminal leaves)
+- `TabManager.swift` — Editor tab lifecycle (open, close, save, saveAs, duplicate, dirty tracking)
+- `WorkspaceManager.swift` — Async file tree loading, git integration, file watching
+- `GitStatusProvider.swift` — Git status/diff parsing, branch listing and checkout
+- `SyntaxHighlighter.swift` — Grammar loading, regex compilation, async highlighting
+- `TerminalSession.swift` / `TerminalManager.swift` — SwiftTerm integration and terminal coordination
+- `SessionState.swift` — Codable session persistence via UserDefaults
+- `PineTests/` — Unit tests (180+ files, Swift Testing framework)
+- `PineUITests/` — XCUITest suite (30 files), base class `PineUITestCase`
+- `PinePerformanceTests/` — XCTest `measure {}` benchmarks; enabled in default scheme but excluded from CI (opt-in via `perf` label or `workflow_dispatch`)
+
+## Type and view conventions
+
+- Models are either structs (EditorTab) or classes depending on identity semantics. `FileNode` is a plain `nonisolated final class` (not @Observable) — it's a recursive tree data structure, not reactive state. `TerminalTab` is `@Observable` because it drives SwiftUI updates
+- Grammar files are JSON in `Pine/Grammars/` — add new languages by adding a new JSON file following the existing format
+- **Keyboard shortcuts** — menu commands flow through `@FocusedValue(\.projectManager)` to `TabManager`. Notable exceptions: Cmd+W is intercepted via `NSEvent.addLocalMonitorForEvents` in AppDelegate (closes active tab, not window); Cmd+\` focuses terminal pane or creates one; Cmd+T creates a new terminal tab in the last-used terminal pane or creates a full-width terminal pane at the bottom
+- Editor tabs use an internal SwiftUI tab bar (`EditorTabBar`), not native macOS window tabs
+- Project windows use `WindowGroup(for: URL.self)` where URL = project directory; `ProjectRegistry` prevents duplicate windows for the same project
+
+## macOS 26 SwiftUI limitation
+
+- **Known issue:** SwiftUI's `toolbarTitleMenu` does not work on macOS 26 with Liquid Glass — the title/subtitle area is not clickable. Branch switching uses an AppKit workaround (`BranchSubtitleClickHandler`) that attaches an `NSClickGestureRecognizer` to the subtitle `NSTextField` in the window view hierarchy.

--- a/.claude/rules/ci-release.md
+++ b/.claude/rules/ci-release.md
@@ -1,0 +1,39 @@
+---
+paths:
+  - ".github/**"
+  - "scripts/**"
+  - "release-please-config.json"
+  - ".release-please-manifest.json"
+  - "version.txt"
+  - "Package.resolved"
+---
+
+# Release, CI, and dependency maintenance
+
+- **Release Please** (`.github/workflows/release-please.yml`) automates versioning and changelog via [Conventional Commits](https://www.conventionalcommits.org/):
+  - On every push to `main`, Release Please creates/updates a Release PR with version bump in `version.txt` and auto-generated `CHANGELOG.md`
+  - When the Release PR is merged, Release Please creates a git tag (e.g. `v0.13.0`) which triggers the build workflow
+  - Config: `release-please-config.json`, manifest: `.release-please-manifest.json`
+  - Requires `RELEASE_PLEASE_TOKEN` secret (PAT with `contents: write` + `pull-requests: write`) — default `GITHUB_TOKEN` won't trigger downstream workflows
+- **Build workflow** (`.github/workflows/release.yml`) triggers on `v*` tags
+- Pipeline: build → code sign → notarize → create DMG → GitHub Release → update Homebrew Tap
+- Secrets: `CERTIFICATE_P12`, `CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_ID_PASSWORD`, `APPLE_TEAM_ID`, `TAP_GITHUB_TOKEN`, `RELEASE_PLEASE_TOKEN`
+- Homebrew: `brew tap batonogov/tap && brew install --cask pine-editor`
+- **CI pipeline** (`.github/workflows/ci.yml`): Lint → Build → Unit Tests (with code coverage) + 7 UI Test shards (parallel) + Flaky Test Summary. All UI tests always run (no conditional skip). Coverage threshold: 70% logic-only (SwiftUI view files excluded). Flaky tests auto-retry once and are reported separately. UI test shards must be balanced (±3 tests, currently 33-35 per shard); verify script checks all test classes are assigned to a shard
+- **Branch protection**: requires all checks to pass. Does NOT require the branch to be up-to-date with main, and does NOT use a merge queue — multiple PRs can be merged in parallel/sequence without re-running CI on each. GitHub recomputes mergeability after each merge, but stale branches merge cleanly (3-way merge handles shared files)
+- **Action pinning** — all third-party GitHub Actions are pinned by full commit SHA (not mutable tags) for supply-chain safety. To update: find the new version's commit SHA on GitHub (Tags → verify the commit), replace the SHA in the workflow file, and keep the trailing `# vX.Y.Z` comment on the exact release tag (a floating `# vX` comment hides drift once the moving tag advances)
+- **Dependency maintenance** — keep every pinned dependency within **N-1 of upstream** (one release behind latest stable); **never downgrade** an already-current pin. The new version/SHA must be a strict descendant of the one it replaces. Run `scripts/check-deps.sh` to list pinned-vs-latest before each pass. Scope:
+  - **GitHub Actions** (SHA-pinned across `.github/workflows/*.yml`): `actions/checkout`, `actions/cache`, `actions/upload-artifact`, `actions/download-artifact`, `actions/github-script`, `googleapis/release-please-action`. Bump by replacing the SHA and the trailing `# vX.Y.Z` comment. **Major-version jumps** — notably `upload-artifact`/`download-artifact` (whose v4 line changed artifact immutability) — must land in their own `chore(deps)` PR with a green CI run; do not bundle them into a feature PR.
+  - **SwiftLint** (`SWIFTLINT_VERSION` + `SWIFTLINT_SHA256` in `.github/workflows/ci.yml`): **exception to the N-1 rule above** — this pin tracks the version developers actually run (`brew install swiftlint`, currently 0.65.1) so CI and local lint agree; a lint pin one release behind local just means CI misses violations you already see. When bumping, diff `swiftlint --strict` output between the old and new version across the whole tree before merging, and move both fields together (the `sha256sum -c -` install step fails closed on a mismatch).
+  - **SPM packages** (`Package.resolved`): SwiftTerm, Sparkle, swift-markdown, swift-cmark, swift-argument-parser. Bump via Xcode → File → Packages → Update, then rebuild and run `PineTests` before merge. A bump that regresses behavior is reverted and filed as an issue, not pinned to an older release.
+- **Nightly performance** (`.github/workflows/nightly-perf.yml`) — runs performance tests nightly and on schedule, uploads `PerformanceResults.xcresult` artifact, detects regressions via `scripts/check_perf_regression.py`
+- **Nightly fuzz** (`.github/workflows/nightly-fuzz.yml`) — scheduled fuzz testing
+- **Screenshots** (`.github/workflows/screenshots.yml`) — regenerates GitHub/landing page screenshots in `assets/` on demand
+
+## Adding a dependency
+
+- **Dependency:** SwiftTerm added via Xcode SPM (File > Add Package Dependencies > `https://github.com/migueldeicaza/SwiftTerm.git`)
+
+## Utility scripts
+
+- **Utility scripts** — `scripts/` directory contains `normalize-xcstrings.sh` (called by pre-commit hook to unstage cosmetic xcstrings changes), `reset-cosmetic-xcstrings.sh` (reverts cosmetic-only xcstrings diffs), `test-normalize-xcstrings.sh` (tests for the normalizer), `update-screenshots.sh` (regenerates GitHub/landing page screenshots), `check-no-post-under-inout.py` (pre-commit + CI guard that blocks the exclusivity-abort reentrancy class), `tests/test-check-no-post-under-inout.sh` (tests for that guard), and `check-deps.sh` (read-only dependency audit: prints pinned-vs-latest for GitHub Actions, SwiftLint, and SPM packages — run before each dependency pass)

--- a/.claude/rules/concurrency.md
+++ b/.claude/rules/concurrency.md
@@ -1,0 +1,39 @@
+---
+paths:
+  - "Pine/**/*.swift"
+  - "PineTests/**/*.swift"
+---
+
+# Concurrency, debounce, and reentrancy
+
+`CLAUDE.md` carries the rules that must hold before you open a file. This is
+the detail behind them.
+
+Pine uses GCD for background work, bridged to async/await via `withCheckedContinuation` at API boundaries.
+
+**Threading rules:**
+- All UI updates on main thread (SwiftUI observation + `DispatchQueue.main.async`)
+- CPU-intensive work dispatched to background: syntax highlighting (`com.pine.syntax-highlight` serial queue), git operations (`DispatchQueue.global` with `DispatchGroup` for parallel branch/status/branches), project search (`TaskGroup` with sliding-window concurrency), file tree loading (`DispatchQueue.global`)
+- **Never block main thread** with file I/O, regex computation, or git process execution
+- Generation tokens (`HighlightGeneration`, `WorkspaceManager.loadGeneration`, `FileSystemWatcher.activeGeneration`) prevent stale async results from overwriting newer ones — always check generation before applying results
+- **Background work owns its autorelease pool** (#1509). A `DispatchQueue.global()` work item runs with no pool in place, so every autoreleased Foundation/AppKit temporary it produces is parked in libobjc's thread-wide fallback pool and stays alive until the worker thread is destroyed. `runOnBackground` (`Pine/Concurrency/BackgroundDispatch.swift`) wraps its body in `autoreleasepool` on both the success and the error path — prefer it over a raw `DispatchQueue.global().async`, and wrap the body yourself where a raw dispatch is unavoidable. Verify with `OBJC_DEBUG_MISSING_POOLS=YES`: "autoreleased with no pool in place" lines are the regression signal
+
+**Debounce values** (centralised in `UITimings.Debounce` / `UITimings.Render`):
+- Syntax highlight on edit: 100ms (`Debounce.edit`)
+- Syntax highlight on scroll: 50ms (`Debounce.scroll`)
+- Fold range recalculation: 150ms (`Debounce.foldRecalc`)
+- Project search: 300ms (`Debounce.projectSearch`)
+- File system watcher: 150ms (`Debounce.fileWatcher`, `WorkspaceManager.watcherDebounce`)
+- Config validator (yamllint / shellcheck / hadolint / terraform validate): 300ms (`Debounce.configValidation`, `ConfigValidator.debounceInterval`)
+- Minimap redraw: 25ms with trailing coalesce (`Render.minimapRedraw`)
+
+**Performance thresholds:**
+- Viewport-only highlighting: files > 50 000 characters (`viewportHighlightThreshold`; lowered from 100KB in #637)
+- Large file dialog (disable highlighting?): files > 1MB (`largeFileThreshold`)
+- Partial load (first 1MB only): files > 10MB (`hugeFileThreshold`)
+- Project search skips files > 1MB
+- Target: <4ms main thread work per scroll frame for 120Hz ProMotion
+
+**Reentrancy / exclusivity:**
+
+- **Reentrancy / exclusivity** — never post a `NotificationCenter` notification inside a function that holds an `inout` (e.g. `tabs: inout [EditorTab]`) exclusive access. `NotificationCenter.post` delivers observers synchronously on the main queue; an observer that writes the same store re-enters the live access and Swift aborts the process (`_swift_reportExclusivityConflict`, Pine #1066 and the #1047/#1051/#1056/#1058 family). Safe pattern: RETURN the payload (e.g. `SaveOutcome.reload` / `ReloadedTab`) and let the caller post AFTER the `inout` scope ends — see `TabExternalChangeDetector.reloadTab` and `TabPersistence.saveTabContent`. For `.onReceive` / `@objc` observers, defer `@State`/`@Observable` mutations to the next runloop via `DispatchQueue.main.async`. The `check-no-post-under-inout.py` guard enforces the `inout`-post sub-pattern at pre-commit and CI; if you legitimately defer a post inside an `inout` function, mark the line `// reentrancy-safe`

--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "Pine/Localizable.xcstrings"
+  - "Pine/Strings.swift"
+---
+
+# Localization
+
+- **Localizable.xcstrings** — never use `json.dump` or standard JSON serializers to write this file. Xcode uses non-standard formatting (`"key" : "value"` with a space before the colon). Reserializing the entire file creates thousands of lines of whitespace noise in diffs. Instead, insert new translations by reading the file as text and making targeted insertions preserving the existing format
+- **Localization** — 9 languages supported (en, de, es, fr, ja, ko, pt-BR, ru, zh-Hans). All user-facing strings go through `Localizable.xcstrings`. To add a new language: add the language key to the xcstrings dict with translations for every existing key

--- a/.claude/rules/lsp.md
+++ b/.claude/rules/lsp.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - "Pine/LSP/**"
+  - "PineTests/SourceKitLSP*"
+---
+
+# SourceKit-LSP integration
+
+- **SourceKit-LSP smoke (opt-in):** `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -skipPackagePluginValidation -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PineTests/SourceKitLSPIntegrationTests PINE_RUN_SOURCEKIT_LSP_SMOKE=1` — creates an isolated temporary Swift package and HOME/cache directories, locates `sourcekit-lsp` through the active Xcode toolchain, bounds every wait, captures server stderr on failure, and always terminates the child. The test is explicitly skipped unless opted in and the server is available

--- a/.claude/rules/marketing-surfaces.md
+++ b/.claude/rules/marketing-surfaces.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "README.md"
+  - "docs/**"
+  - "assets/**"
+---
+
+# Marketing surface synchronization
+
+Pine's public product description spans several surfaces that must stay consistent. Treat a change to positioning, a flagship user-facing capability, supported-language count, third-party dependencies, installation instructions, or minimum macOS/Xcode requirements as a documentation change too.
+
+- **Canonical surfaces:** update `README.md`, `docs/index.html`, its SEO/Open Graph/X metadata, and all 9 landing-page translations (`en`, `de`, `es`, `fr`, `ja`, `ko`, `pt-BR`, `ru`, `zh-Hans`) in the same PR when a claim changes. Do not update English alone.
+- **GitHub About:** keep the repository description, homepage, and topics aligned with the landing-page positioning. Verify with `gh repo view --json description,homepageUrl,repositoryTopics`; update through `gh repo edit` only when the task authorizes external repository metadata changes.
+- **Screenshots:** marketing screenshots live in `assets/` and are produced by `PineUITests/ScreenshotTests.swift` through `scripts/update-screenshots.sh`. Fixtures must use a stable, human-readable project name such as `Pine Demo`; never ship UUIDs, temporary paths, stale feature counts, or test-only wording in visible screenshot content.
+- **Avoid fragile claims:** prefer durable wording over hard-coded counts or dependency totals. When an exact number is useful (for example, supported syntax grammars), derive or verify it from the repository before publishing.
+- **Release check:** before opening a PR that changes any canonical surface, verify the latest-release CTA, Homebrew command, system requirements, external links, responsive layout, keyboard access, reduced-motion behavior, and screenshot lightbox. Keep GitHub Pages deployment on the existing `docs/` workflow; do not create a separate hosting target.

--- a/.claude/rules/snapshot-tests.md
+++ b/.claude/rules/snapshot-tests.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - "PineTests/SnapshotTests/**"
+---
+
+# Snapshot testing
+
+Pine uses a minimal zero-dependency visual snapshot harness for SwiftUI views. Reference PNGs live under `PineTests/SnapshotTests/__Snapshots__/`. No third-party packages, no pbxproj edits.
+
+- **Harness:** `PineTests/SnapshotTests/SnapshotHarness.swift` — renders a SwiftUI view via `NSHostingView` into an `NSBitmapImageRep` under a given `NSAppearance` (`.light` / `.dark`), encodes to PNG, and compares against the reference using a mean-absolute per-pixel RGBA diff normalized to `[0, 1]`. Default tolerance is `0.01` to absorb trivial anti-aliasing noise.
+- **Backing scale independence:** the bitmap is allocated explicitly at 1× the logical size (`pixelsWide == Int(size.width)`) so output is identical on Retina (2×) developer machines and on macOS CI runners' 1× virtual displays. Without this, baselines recorded on a Retina Mac differ in pixel dimensions from CI output and the diff short-circuits to `1.0` (dimension mismatch). The bitmap is also pre-filled with `NSColor.windowBackgroundColor` under the requested appearance so semi-transparent system colors (e.g. `.secondary` text in dark mode) composite onto a realistic backdrop instead of a transparent canvas.
+- **Writing a test:** import the harness (it lives in the `PineTests` target) and call `try assertSnapshot(of: MyView(), size: NSSize(width: W, height: H), appearance: .light, named: "MyView.light")`. Cover both `.light` and `.dark` for every view. Use local `Harness` wrapper views for SwiftUI bindings.
+- **Stability:** stub out any data source that can vary between machines (e.g. populate `ProjectRegistry.recentProjects` and `GitStatusProvider.branches` manually). Never snapshot a view that depends on real git state, real filesystem contents, or network.
+- **Running:** `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -skipPackagePluginValidation -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PineTests/WelcomeViewSnapshotTests` (one suite at a time).
+- **Updating snapshots:** run tests with `PINE_RECORD_SNAPSHOTS=1` in the test environment (set it via the Pine scheme's Test action, or pass as the final positional `KEY=VALUE` arg to `xcodebuild test`). In record mode the harness always overwrites the reference PNG and passes. Review the PNG diff in the PR before merging.
+- **First run:** if no reference exists the harness writes a baseline and fails the test so new baselines can never sneak in silently. A failing test also writes an `<name>.actual.png` alongside the reference for visual inspection.
+- **Current coverage:** 8 view suites / 32 reference PNGs — `WelcomeView`, `BranchSwitcherView`, `GoToLineView`, `NavigationOverlay` (GoToLine overlay via `CommandOverlayView`), `BreadcrumbPathBar`, `EditorTabItem`, `IndentGuidesYAML`, `StatusBarView` (each in light + dark; `BreadcrumbPathBar`, `EditorTabItem`, and `StatusBarView` also snapshot multiple states). Remaining scope from issue #796 (editor gutter, sidebar file tree, minimap, diagnostic popover, inline diff) is tracked as follow-ups — the tab bar is now partially covered via `EditorTabItem` snapshots.

--- a/.claude/rules/terminal.md
+++ b/.claude/rules/terminal.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - "Pine/Terminal/**"
+  - "Pine/QuickTerminal/**"
+  - "PineTests/Terminal*"
+  - "PineUITests/Terminal*"
+---
+
+# Terminal, renderer, and quick terminal
+
+- **Quick terminal:** a system-wide ⌃⌥Space hotkey (`Carbon RegisterEventHotKey`, no Accessibility permission required, works in the App Sandbox) toggles a floating drop-down terminal over any application (#1113). The session is keep-alive — scrollback survives toggles; Esc and ⌘W hide it. The working directory resolves to an open Pine project (current implementation picks `openProjects.keys.first` — Dictionary order, not the key window; key-window resolution is a follow-up), else the most-recent project, else `$HOME`. Disable with `--disable-quick-terminal` or `PINE_DISABLE_QUICK_TERMINAL` (used by UI tests). Agent detection (#950) does NOT cover the quick-terminal tab (it lives outside the pane tree) — a follow-up wires it in. A menu item, Settings UI (custom hotkey, screen edge, height), and per-pane quick terminals are follow-ups — v1 ships the hotkey + window only.
+
+- **Known issue:** Pine's terminal opts into SwiftTerm's Metal renderer (`setUseMetal(true)`) once the view lands in a window, replacing the layer-backed CoreGraphics raster with a GPU swapchain and eliminating the entire black-screen class (#64, #661, #871, #918, #923, #966, #1094, #1108). On failure (headless CI VM, old GPU, virtual display without a Metal device) it silently falls back to CoreGraphics. UI tests pass `--disable-metal` to pin CoreGraphics on macOS-26 virtual displays; production users can opt out with `--disable-metal` or `PINE_DISABLE_METAL`.
+
+- **Terminal rendering compatibility:** manually reproduce rendering bugs once through the default path (Metal when available; record any fallback-to-CoreGraphics log) and once after relaunching with `--disable-metal` or `PINE_DISABLE_METAL=1` to force CoreGraphics. Record the effective renderer, Mac model/chip, display configuration, and whether the result differs on macOS 26 versus the current macOS 27 beta

--- a/.claude/rules/ui-tests.md
+++ b/.claude/rules/ui-tests.md
@@ -1,0 +1,30 @@
+---
+paths:
+  - "PineUITests/**/*.swift"
+---
+
+# XCUITest limitations and launch configuration
+
+Every "known issue" below has already cost someone a debugging session.
+
+## Targets and shards
+
+- UI test target: `PineUITests` (XCTest/XCUITest) — 41 test classes across 42 files, base class `PineUITestCase`. CI runs 7 parallel shards (Terminal, Welcome & Session, Navigation, Editor Chrome, Files & Save, Search & Panes, Security & Layout)
+
+## Launch arguments and environment
+
+- Launch arguments for UI testing: `--reset-state` (clears persisted sessions), `--disable-agent-detection` (disables the `ps`-polling agent detector — avoids the macOS-26 fork/spawn hang #1060), `--disable-metal` (pins the terminal to SwiftTerm's CoreGraphics renderer — Metal may be unavailable on CI virtual displays #1108), `--disable-quick-terminal` (disables the global ⌃⌥Space hotkey so it does not grab key events on CI #1113), `-ApplePersistenceIgnoreState YES` (ignores macOS saved window state), `-AppleLanguages (en)`, `-AppleLocale en_US` (force English locale so menu item names are predictable)
+- Environment variable for UI testing: `PINE_OPEN_PROJECT=<path>` (opens project without file dialog — uses env var because macOS interprets bare paths in launch arguments as files to open)
+- **Known issue:** XCUITest launch arguments (`-key YES`) store values as strings in NSArgumentDomain. `UserDefaults.object(forKey:) as? Bool` returns nil for strings. To set boolean UserDefaults for UI tests, use `defaults write <bundle-id> <key> -bool YES` via `Process` in setUp, and `defaults delete` in tearDown
+
+## What XCUITest cannot do
+
+- **Known issue:** On macOS 26, `XCUIApplication.launch()` bypasses LaunchServices, so SwiftUI `.defaultLaunchBehavior(.presented)` does not create windows. The app includes an AppKit fallback (`createWelcomeWindowViaAppKit`) that activates after 0.5s if no windows appear.
+- **Known issue:** `GutterTextView` (NSTextView inside NSViewRepresentable) does not receive keyboard input from XCUITest's `typeText()`/`typeKey()`. UI tests that need to verify editor content changes should use alternative approaches (e.g., verifying menu item availability, checking tab state).
+- **Known issue:** XCUITest's `typeKey()` bypasses the app's `NSEvent.addLocalMonitorForEvents` — synthetic key events go through Accessibility APIs, not the app's event queue. Keyboard shortcuts handled via local event monitors (e.g., Cmd+W for tab closing, Cmd+Shift+B for branch switcher) cannot be reliably UI-tested with `typeKey()`. Use mouse clicks on UI elements instead.
+- **Known issue:** UI tests that use `Process()` to run shell commands (e.g., `git init`) need `DEVELOPER_DIR` set in the process environment, otherwise `xcrun` fails with "cannot be used within an App Sandbox".
+
+## Driving the UI
+
+- To interact with menu items in UI tests, use `app.menuBars.menuBarItems["File"].click()` then `app.menuItems["Item Name"].click()` with English names (locale is forced to `en`)
+- Accessibility identifiers defined in `Pine/AccessibilityIdentifiers.swift` — used by both app views and UI tests

--- a/.claude/skills/agent-swarm/SKILL.md
+++ b/.claude/skills/agent-swarm/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: agent-swarm
+description: Use when distributing a backlog or milestone across subagents in this repository — "распредели issues по агентам", "orchestrate this milestone", "run a swarm", or any handoff where one worker owns one issue in its own worktree. Carries the issue-by-issue authorization flow, the independent fresh-context review gate every candidate must clear before its first push, and the narrow rules governing who may merge.
+---
+
+# Maintainer-directed issue swarm
+
+These three sections used to sit in `CLAUDE.md`. They are a procedure rather
+than standing context, so they load when a swarm is actually being run.
+
+When the maintainer asks the parent agent to distribute a backlog across
+subagents, use this stricter issue-by-issue flow:
+
+1. **The issue is the unit of authorization.** Never start implementation
+   without an existing issue. One worker owns exactly one issue at a time in
+   one isolated worktree and short-lived branch. Do not mix opportunistic fixes
+   from another issue into its diff. If the maintainer names a required first
+   wave, schedule those issues before optional work.
+2. **Start from current `origin/main`.** Fetch before creating a worktree and
+   record the exact base SHA. When `main` advances, especially after a sibling
+   or release merge, preserve the complete local diff with
+   `git stash push --include-untracked -m <unique-issue-and-base>`, record and
+   verify the resulting stash commit OID, update the uncommitted branch only
+   with `git merge --ff-only origin/main`, and restore with
+   `git stash apply <OID>`. Never pop or drop the backup until the moved diff is
+   validated; never use `reset --hard`, forced checkout, or `clean`. Stop on a
+   non-fast-forward or conflict. Prove that merged commits occur exactly once,
+   re-review overlapping files, and rerun the affected tests after the move.
+3. **Review before spending CI.** Risky or cross-cutting work first reports a
+   design and test plan, then a production-diff checkpoint. Every
+   implementation, regardless of risk, reports the complete diff after local
+   verification and passes the independent review gate below before commit,
+   push, or PR. The parent/orchestrator requests polishing before expensive
+   macOS or UI runners test the candidate.
+4. **Keep concurrent Xcode work isolated.** Give every issue a unique
+   `-derivedDataPath` under `/private/tmp`; never share DerivedData between
+   workers. Record the exact macOS, Xcode, SDK version, commands, test counts,
+   and result-bundle path. A code failure gets diagnosed and reviewed before a
+   bounded retry; do not hide a failure with repeated blind reruns.
+5. **Verification is evidence, not a summary.** Always run `git diff --check`.
+   Run every applicable targeted check and state each non-applicable check with
+   a reason: SwiftLint for Swift/code changes, targeted tests for behavioral
+   changes, and the existing full pre-PR build for code PRs. Add broader suites,
+   UI tests, security/race tests, or renderer checks when the issue requires
+   them. Report unrelated failures separately, but never call a PR merge-ready
+   until every required GitHub check is green.
+6. **Publish in dependency order.** Only after the parent review clears may the
+   worker make a Conventional Commit. The parent then performs a final commit
+   review, pushes, opens the issue-linked PR, states the merge order, and watches
+   CI. A worker subagent never merges its own PR.
+7. **Merge authorization is narrow.** By default only the maintainer merges.
+   If the maintainer explicitly authorizes the parent/orchestrator to merge
+   working PRs, the authorization must identify the exact PR numbers and
+   current head SHAs; a batch is an immutable enumeration of those exact
+   `(PR number, head SHA)` pairs. Revalidate them immediately before merge.
+   Only non-release PRs that remain mergeable, have a clean review gate, and
+   have every required check green may merge. Red or pending PRs are never
+   merged. Release actions require separate, exact authorization covering each
+   requested operation: Release Please PR merge; tag create, update, delete,
+   or push; and release-workflow edit, dispatch, rerun, or cancellation. After
+   any authorized Release Please PR merge, regardless of actor, treat the
+   resulting release commit as the new mandatory base for all active issue
+   branches.
+
+## Independent review gate
+
+Every implementation must pass an independent, fresh-context review before
+its first push and before a PR is opened. This keeps expensive macOS and UI
+runners from testing a candidate that has not cleared adversarial review.
+Green CI remains necessary, but it does not replace that review.
+
+1. **Review the local candidate diff before push.** Once implementation and
+   regression tests are stable, review the complete local diff against its
+   intended base (`main...HEAD`, plus any staged or unstaged changes). Keep the
+   original worktree path as the single mutable copy, include
+   `git status --short`, and represent every untracked file explicitly with a
+   manifest plus a `git diff --no-index /dev/null <file>` patch (or an
+   equivalent content-complete artifact). Review and fix workers must use that
+   same worktree until commit. Run at least three read-only reviewer subagents
+   with distinct lenses: (a)
+   correctness and architecture, (b) concurrency, security, and lifecycle
+   races, and (c) tests, UX, localization, and OS compatibility. Reviewers
+   must read the issue acceptance criteria and must not edit files.
+2. **Demand actionable findings.** Each finding includes severity, exact
+   file/line references, a concrete failure sequence or reproduction, and the
+   smallest safe fix. A clean review explicitly lists the invariants checked;
+   a summary that merely restates the diff does not count.
+3. **Synthesize and verify.** The parent agent deduplicates findings, validates
+   them against the code, and adds a regression test before or with each fix.
+   All confirmed P0, P1, and P2 findings must be resolved before merge. Record
+   low-risk coverage gaps or P3 findings in the PR or a follow-up issue when
+   they are intentionally deferred.
+4. **Fix on the same local branch.** In the maintainer-directed flow, keep the
+   candidate uncommitted until review clears. If the candidate was already
+   committed under a different flow, add follow-up commits; never amend or
+   force-push. Repeat the independent review/fix loop until reviewers return no
+   unresolved P0-P2 findings, then rerun the relevant local checks.
+5. **Push and open the PR only after review clears.** Summarize reviewer
+   angles, findings, dispositions, and local verification in the PR body.
+   Run the full required CI once the PR exists. An agent with explicit merge
+   authorization must not invoke merge until the pre-push review gate remains
+   clean and every required CI check is green.
+6. **Recover visibly from a premature merge.** If review was skipped before
+   merge, or a post-merge review finds a P0-P2 defect, reopen the source issue,
+   create a short-lived follow-up branch from current `main`, add regression
+   tests and fixes, repeat review plus CI, and close the issue only after the
+   follow-up PR is green and merged.
+
+## Milestone orchestration with subagents
+
+For a milestone with multiple issues, the maintainer (or a parent agent) orchestrates implementation across subagents instead of doing all the work in one session. Used for parallelizable issues, large features, or when strict adversarial review is wanted. The full loop runs inside the agent; the maintainer merges by default, or may explicitly authorize the parent/orchestrator to merge under the narrow gate above.
+
+Flow:
+1. **Scope first.** Read every issue in the milestone end-to-end, identify shared files, and note dependencies (`blocked-by`, or an explicit "depends on #X" in the body). Order implementation and merge accordingly.
+2. **One issue = one worker = one candidate branch.** Delegate each issue to a worker subagent in an isolated worktree (`worktree: true`). Each worker creates its own local branch, implements the candidate, runs local verification, and reports the complete working diff for review without committing, pushing, or opening a PR. Pass each worker explicit permissions in the task and an `acceptance` contract with `verify` commands and `stopRules` (notably: never commit before review clears, never push, never open a PR, never merge, never force-push, never amend).
+3. **Respect cross-issue boundaries.** Tell each worker exactly which files/branches it may touch so sibling PRs stay mergeable (e.g. add a dedicated accumulator field per branch instead of repurposing a shared one). When an issue depends on siblings not yet merged, wait for them to land or have the parent create a separately reviewed integration base with a recorded SHA and exactly-once proof. Workers do not merge or cherry-pick sibling branches into an uncommitted candidate.
+4. **Strict review from fresh context before push.** Run fresh-context `reviewer` subagents with distinct angles against each complete local candidate diff. Reviewers are read-only — they must not edit.
+5. **Fix before opening the PR.** Synthesize reviewer findings and hand them to a fix-worker that uses the **existing local candidate branch** and working diff. Keep fixes uncommitted until the review gate is clean. Never amend, force-push, or open a new branch for fixes. Repeat the review/fix loop until reviewers return a clean verdict (typically ~2 rounds), then create the Conventional Commit.
+6. **Publish and verify after review.** Only now does the parent/orchestrator push each reviewed branch and open its PR. Confirm every PR is `MERGEABLE` and **fully green** — every required CI check passing, no exceptions. Pending checks must be explicitly noted. There is no "red but mergeable" state: branch protection blocks the merge button on any failing check, so a red PR is not ready regardless of why it failed. State the merge order.
+7. **Workers never publish or merge.** After review clears, the
+   parent/orchestrator opens and reports the PR. It merges only when the
+   maintainer has explicitly delegated that authority and all review,
+   dependency-order, and green-CI requirements above are satisfied; otherwise
+   the maintainer merges.
+
+Operational notes:
+- Worktree isolation requires a clean main tree — remove stray artifacts (e.g. a `reviews/` folder written by reviewers) before launching new worktree runs.
+- "needs attention" control signals from a finished run are stale noise; trust `gh pr checks` / `gh pr view` as ground truth.
+- Acceptance-gate / parse-report errors in the subagent harness do not mean the work failed — check the PR and CI; the code usually landed.

--- a/.claude/skills/macos27-crash-triage/SKILL.md
+++ b/.claude/skills/macos27-crash-triage/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: macos27-crash-triage
+description: Use when the PineTests host crashes, hangs, or segfaults on the macOS 27 beta (issue #1509) — reading .ips diagnostic reports, pinning the OS build, injecting objc/malloc diagnostics through a copied .xctestrun, or interpreting an objc_autoreleasePoolPop backtrace. Not for ordinary test failures.
+---
+
+# Diagnosing a test-host crash on the macOS 27 beta (#1509)
+
+- Trust `~/Library/Logs/DiagnosticReports/`, not the console log — the beta drops log lines badly. Reports rotate into `Retired/` and only about twenty are kept there, so **copy a report out the moment you see the crash**; the two incidents #1509 was opened on were already gone by the time it was triaged.
+- Record the OS **build**, not the marketing version: `sw_vers` → `BuildVersion`, matched against `osVersion.build` in the `.ips`. `/var/log/install.log` (`Previous System Version … Current System Version …`) says when the machine changed builds, which is the first thing to check before calling a crash reproducible or fixed.
+- Inject `objc`/malloc diagnostics by copying the generated `.xctestrun` and editing `TestConfigurations → TestTargets → EnvironmentVariables`, then `xcodebuild test-without-building -xctestrun <copy>`. Keep the copy **in the same directory as the original** — the file's `__TESTROOT__` placeholders resolve relative to it. Useful keys: `OBJC_DEBUG_POOL_ALLOCATION=YES` (halts on an out-of-order pool pop), `OBJC_DEBUG_MISSING_POOLS=YES`, `OBJC_DISABLE_AUTORELEASE_COALESCING=YES`, `MallocScribble=1`, `NSZombieEnabled=YES`.
+- For a crash in `objc_autoreleasePoolPop` → `AutoreleasePoolPage::releaseUntil` → `objc_release`, the registers `x22 = 0xa1a1a1a1`, `x23 = 0xf00ffffffffffff` and `x24 = 0xa3a3a3a3a3a3a3a3` are **not** evidence of anything — they are loop-invariant constants (pool-page magic, pointer mask, SCRIBBLE byte) materialised in `releaseUntil`'s prologue on every single pool pop. Read `x0`/`x21` (the object being released), the word at `[x0]` (its `isa`), and confirm `far == (isa & 0x7ffffffffff8) + 0x20`. Reaching `releaseUntil` at all means libobjc already validated the page magic, so the pool page itself was intact.
+
+## Before you blame the diff
+
+A local failure on this runtime is not a pass/fail signal — CI is. `CLAUDE.md`
+names the two standing failures that reproduce there regardless of the diff in
+the tree. Confirm a failure on an idle machine first.

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,12 @@ PineTests/SnapshotTests/__Snapshots__/*.actual.png
 LifecycleDiagnostics/
 
 # Agents
-.claude/
+# Ignore the whole directory except the instruction files, which are part of
+# the repository: rules load by path when Claude reads a matching file, skills
+# are invoked by name. Personal settings and worktrees stay ignored.
+.claude/*
+!.claude/rules/
+!.claude/skills/
 .pi/
 .pi-subagents/
 .pine/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# AGENTS.md
+# CLAUDE.md
 
 Guidance for AI coding agents (Claude Code, pi, and others) working in this repository.
 
@@ -252,7 +252,7 @@ How the maintainer works day-to-day. Documents intent and handoff conventions fo
 ### Working with AI agents
 - Typical handoff: **"реши issue #N"** (solve issue #N) — the agent reads the issue **and all its comments** in full, then plans, implements, writes tests, and opens a PR.
 - Agents may freely, without asking: edit code, run single-file typecheck, run unit tests, create branches, open PRs.
-- **Explicit confirmation required** for: merging a PR, and anything in the destructive-command list in `AGENTS.md` (deletions, force-pushes, infrastructure changes).
+- **Explicit confirmation required** for: merging a PR, and anything in the destructive-command list in this file (deletions, force-pushes, infrastructure changes).
 - Agents should run unit tests themselves — no need to ask first.
 
 ### Maintainer-directed issue swarm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Its mini
 - [SwiftTerm](https://github.com/migueldeicaza/SwiftTerm) — terminal emulator
 - [Sparkle](https://sparkle-project.org/Sparkle) — auto-updates
 - [swift-markdown](https://github.com/swiftlang/swift-markdown) — markdown preview rendering
+- No other third-party dependencies
 
 ## Build & Run
 
@@ -19,196 +20,38 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Its mini
 - Open `Pine.xcodeproj` in Xcode, build and run (Cmd+R)
 - CLI build: `xcodebuild -skipPackagePluginValidation -project Pine.xcodeproj -scheme Pine build` (requires `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`)
 - Type-check a single file (no sudo needed): `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -typecheck -target arm64-apple-macos26.0 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk <file.swift>`
-- **Dependency:** SwiftTerm added via Xcode SPM (File > Add Package Dependencies > `https://github.com/migueldeicaza/SwiftTerm.git`)
 - **Package plugins:** SwiftTerm 1.19+ uses the pinned `SwiftTermBuildInfoPlugin`. Non-interactive `xcodebuild` invocations must pass `-skipPackagePluginValidation`; keep this flag on CI, nightly, release, screenshot, and release-smoke build paths. Because the flag applies to every package plugin, continue pinning and reviewing all SPM revisions in `Package.resolved`
-- No other third-party dependencies
 - **Xcode project format:** Uses `PBXFileSystemSynchronizedRootGroup` (objectVersion 77) — new `.swift` files placed in `Pine/`, `PineTests/`, or `PineUITests/` are automatically picked up by Xcode. No manual `project.pbxproj` edits needed
 - **Git hooks:** Run once after cloning: `git config core.hooksPath .githooks && git config merge.ours.driver true`. Enables pre-commit hook that auto-unstages cosmetic-only changes to `Localizable.xcstrings` (Xcode build artifacts) and `ours` merge driver for xcstrings conflicts
 - **SwiftLint:** `brew install swiftlint` — runs as a build phase; config in `.swiftlint.yml`. CI pins SwiftLint 0.65.1 — the same version `brew install swiftlint` gives you locally, so a clean local run means a clean CI run (bump both `SWIFTLINT_VERSION` and `SWIFTLINT_SHA256` in `.github/workflows/ci.yml` together). Run `swiftlint` before every commit and fix all warnings/errors. If `swiftlint` crashes with `sourcekitdInProc` error, prefix with `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer`
+
+## Testing
+
 - **Unit Tests:** `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -skipPackagePluginValidation -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PineTests`
 - Run a single test class: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -skipPackagePluginValidation -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PineTests/GoToLineTests`
-- **SourceKit-LSP smoke (opt-in):** `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -skipPackagePluginValidation -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PineTests/SourceKitLSPIntegrationTests PINE_RUN_SOURCEKIT_LSP_SMOKE=1` — creates an isolated temporary Swift package and HOME/cache directories, locates `sourcekit-lsp` through the active Xcode toolchain, bounds every wait, captures server stderr on failure, and always terminates the child. The test is explicitly skipped unless opted in and the server is available
-- Unit test target: `PineTests` (Swift Testing framework) — 180+ test files covering git parsing, grammar models, file tree, syntax highlighting, find & replace, code folding, minimap, status bar, project search, external formatters, and more
 - **UI Tests:** `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -skipPackagePluginValidation -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PineUITests`
-- UI test target: `PineUITests` (XCTest/XCUITest) — 41 test classes across 42 files, base class `PineUITestCase`. CI runs 7 parallel shards (Terminal, Welcome & Session, Navigation, Editor Chrome, Files & Save, Search & Panes, Security & Layout)
-- Launch arguments for UI testing: `--reset-state` (clears persisted sessions), `--disable-agent-detection` (disables the `ps`-polling agent detector — avoids the macOS-26 fork/spawn hang #1060), `--disable-metal` (pins the terminal to SwiftTerm's CoreGraphics renderer — Metal may be unavailable on CI virtual displays #1108), `--disable-quick-terminal` (disables the global ⌃⌥Space hotkey so it does not grab key events on CI #1113), `-ApplePersistenceIgnoreState YES` (ignores macOS saved window state), `-AppleLanguages (en)`, `-AppleLocale en_US` (force English locale so menu item names are predictable)
-- Environment variable for UI testing: `PINE_OPEN_PROJECT=<path>` (opens project without file dialog — uses env var because macOS interprets bare paths in launch arguments as files to open)
 - **Performance Tests:** `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -skipPackagePluginValidation -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PinePerformanceTests` — XCTest `measure {}` benchmarks for FoldRange, SyntaxHighlighter, ProjectSearch, GitStatus. Enabled in default scheme but excluded from CI (opt-in via `perf` label on PR or `workflow_dispatch`)
-- **Known issue:** On macOS 26, `XCUIApplication.launch()` bypasses LaunchServices, so SwiftUI `.defaultLaunchBehavior(.presented)` does not create windows. The app includes an AppKit fallback (`createWelcomeWindowViaAppKit`) that activates after 0.5s if no windows appear.
-- **Known issue:** `GutterTextView` (NSTextView inside NSViewRepresentable) does not receive keyboard input from XCUITest's `typeText()`/`typeKey()`. UI tests that need to verify editor content changes should use alternative approaches (e.g., verifying menu item availability, checking tab state).
-- **Known issue:** XCUITest's `typeKey()` bypasses the app's `NSEvent.addLocalMonitorForEvents` — synthetic key events go through Accessibility APIs, not the app's event queue. Keyboard shortcuts handled via local event monitors (e.g., Cmd+W for tab closing, Cmd+Shift+B for branch switcher) cannot be reliably UI-tested with `typeKey()`. Use mouse clicks on UI elements instead.
-- **Known issue:** SwiftUI's `toolbarTitleMenu` does not work on macOS 26 with Liquid Glass — the title/subtitle area is not clickable. Branch switching uses an AppKit workaround (`BranchSubtitleClickHandler`) that attaches an `NSClickGestureRecognizer` to the subtitle `NSTextField` in the window view hierarchy.
-- **Known issue:** UI tests that use `Process()` to run shell commands (e.g., `git init`) need `DEVELOPER_DIR` set in the process environment, otherwise `xcrun` fails with "cannot be used within an App Sandbox".
-- **Quick terminal:** a system-wide ⌃⌥Space hotkey (`Carbon RegisterEventHotKey`, no Accessibility permission required, works in the App Sandbox) toggles a floating drop-down terminal over any application (#1113). The session is keep-alive — scrollback survives toggles; Esc and ⌘W hide it. The working directory resolves to an open Pine project (current implementation picks `openProjects.keys.first` — Dictionary order, not the key window; key-window resolution is a follow-up), else the most-recent project, else `$HOME`. Disable with `--disable-quick-terminal` or `PINE_DISABLE_QUICK_TERMINAL` (used by UI tests). Agent detection (#950) does NOT cover the quick-terminal tab (it lives outside the pane tree) — a follow-up wires it in. A menu item, Settings UI (custom hotkey, screen edge, height), and per-pane quick terminals are follow-ups — v1 ships the hotkey + window only.
-- **Known issue:** XCUITest launch arguments (`-key YES`) store values as strings in NSArgumentDomain. `UserDefaults.object(forKey:) as? Bool` returns nil for strings. To set boolean UserDefaults for UI tests, use `defaults write <bundle-id> <key> -bool YES` via `Process` in setUp, and `defaults delete` in tearDown
-- **Known issue:** Pine's terminal opts into SwiftTerm's Metal renderer (`setUseMetal(true)`) once the view lands in a window, replacing the layer-backed CoreGraphics raster with a GPU swapchain and eliminating the entire black-screen class (#64, #661, #871, #918, #923, #966, #1094, #1108). On failure (headless CI VM, old GPU, virtual display without a Metal device) it silently falls back to CoreGraphics. UI tests pass `--disable-metal` to pin CoreGraphics on macOS-26 virtual displays; production users can opt out with `--disable-metal` or `PINE_DISABLE_METAL`.
-- **Terminal rendering compatibility:** manually reproduce rendering bugs once through the default path (Metal when available; record any fallback-to-CoreGraphics log) and once after relaunching with `--disable-metal` or `PINE_DISABLE_METAL=1` to force CoreGraphics. Record the effective renderer, Mac model/chip, display configuration, and whether the result differs on macOS 26 versus the current macOS 27 beta
-- To interact with menu items in UI tests, use `app.menuBars.menuBarItems["File"].click()` then `app.menuItems["Item Name"].click()` with English names (locale is forced to `en`)
-- Accessibility identifiers defined in `Pine/AccessibilityIdentifiers.swift` — used by both app views and UI tests
+- Targets: `PineTests` (Swift Testing, 180+ files), `PineUITests` (XCUITest, 41 classes, base class `PineUITestCase`, 7 parallel CI shards), `PinePerformanceTests` (XCTest `measure {}`)
+- XCUITest limitations, snapshot-harness details, and the SourceKit-LSP smoke test load from `.claude/rules/` when you open the matching files
 
-## Architecture
+## Non-negotiables
 
-**Pattern:** MVVM with SwiftUI views backed by AppKit via `NSViewRepresentable`.
+These hold before you open any file. The reasoning behind each is in
+`.claude/rules/`, which loads when you touch the relevant code.
 
-**State management:** `ProjectManager` (@Observable) is the central state object managing file tree, editor tabs, terminal tabs, and git status. It owns `PaneManager` (split pane tree), `TabManager` (primary editor tabs), `TerminalManager` (terminal coordinator), and `WorkspaceManager` (file tree + git). It communicates with views via SwiftUI observation and with menu commands via NotificationCenter.
-
-**AppKit bridges:**
-- `CodeEditorView` — wraps NSScrollView + custom `GutterTextView` (NSTextView subclass) + `LineNumberView` for the code editor
-- `TerminalContentView` — wraps SwiftTerm's `LocalProcessTerminalView` (NSView) for the terminal
-
-**Text system stack:** NSTextStorage → NSLayoutManager → NSTextContainer → GutterTextView (shifts text right for line number gutter)
-
-**Split panes:** `PaneNode` is a recursive enum (`.leaf` or `.split`) forming a binary tree of editor/terminal panes. `PaneManager` (@MainActor @Observable) manages the tree, per-pane TabManagers (for editor leaves), and per-pane `TerminalPaneState` (for terminal leaves). `PaneTreeView` recursively renders the tree; `PaneLeafView` switches on `PaneContent` (.editor/.terminal) to render the appropriate content. `PaneDividerView` handles resize. Drag-and-drop between panes uses `TabDragInfo` with `contentType` field for type validation (editor tabs can only drop on editor panes, terminal tabs on terminal panes). `PaneSplitDropDelegate` detects drop zones (right/bottom/center) based on cursor position. `TabCloseHelper` provides shared close-with-confirmation dialogs used by both ContentView and PaneLeafView.
-
-**Sidebar file navigation:** Treat the left file tree as a Finder-style, keyboard-first surface, not as a mouse-only list. `SidebarTreeNavigation` owns one selection over the flattened visible rows: Up/Down move by row; Left collapses an expanded folder or selects its parent; Right expands a collapsed folder or selects its first child; Home/End and Page Up/Page Down navigate the visible tree; typing performs Unicode-aware prefix selection with repeated-character cycling. Selection, opening, and focus are distinct states. Space opens a transient preview and keeps focus in the sidebar; Return starts inline rename; Cmd+Return permanently opens the file and moves focus to the editor. A single file click previews, a double-click permanently opens, and a folder-row click toggles disclosure. Keyboard selection must preserve spatial orientation: while the selected row is visible, do not move the viewport; once it leaves the viewport, reveal it by the smallest necessary amount at the nearest edge. With `ScrollViewProxy`, call `scrollTo(id)` without an anchor or animation for routine navigation — never use `.center` there. Intentional reveal after create/duplicate may use `.center` and animation, but must become immediate under Reduce Motion. Unit tests must lock the minimal-vs-centered request policy; an XCUITest that only asserts `isSelected` does not verify scroll geometry. Before release, manually check a tall tree with single and held arrow presses, both viewport boundaries, type-to-select to an off-screen row, Home/End, Page Up/Page Down, create/duplicate centering, and Reduce Motion.
-
-**Terminal:** Uses [SwiftTerm](https://github.com/migueldeicaza/SwiftTerm) — a full VT100/xterm terminal emulator in pure Swift. Terminal tabs live inside the split pane tree as `.terminal` leaf panes — there is no separate bottom panel. `TerminalPaneState` (@Observable) manages per-pane terminal tabs (array of `TerminalTab`, active tab, search state). `TerminalManager` is a coordinator that routes Cmd+T and Cmd+\` to the appropriate terminal pane via `PaneManager`. When creating a new terminal pane, it wraps the entire editor tree in a vertical split (terminal at bottom, full width). `TerminalPaneTabBar` provides the tab bar with drag-and-drop, maximize/restore, and close buttons. `TerminalContainerView` (AppKit) handles SwiftTerm view lifecycle. Supports colors, cursor positioning, TUI apps (vim, htop), oh-my-zsh, and all standard terminal features.
-
-**Terminal hyperlinks:** two independent click paths, both on ⌘+click. (1) Implicit `path:line[:col]` references in any terminal cell are parsed by `TerminalOutputParser` (#949) — the `TerminalScrollInterceptor` overlay resolves them against the working directory, verifies the file exists, and posts `.openFileAtLine` to open it in the editor. (2) Explicit OSC 8 hyperlinks and implicit URLs are handled by SwiftTerm itself (`linkReporting = .implicit`, `linkHighlightMode = .hoverWithModifier` — hover-underline is built in) → `TerminalTabDelegate.requestOpenLink` → `TerminalLinkOpener` (#1114): `file://` (local host) reveals in Finder via `NSWorkspace.activateFileViewerSelecting` WITHOUT launching — safe even if the link points at a `.app`/`.command` bundle a hostile program sneaked into its output; `http(s)`/`mailto` open in the system handler; `file://` with a foreign host is ignored to avoid Finder network mounts. The `path:line` path runs first (the overlay consumes the event); OSC 8 is the fallback when no `file:line` reference is under the cursor.
-
-**Git integration:** `GitStatusProvider` runs `git status` and `git diff` to show file status indicators in the sidebar and diff markers (added/modified/deleted) in the editor gutter. Branch switching is available via clickable subtitle in the title bar (shows NSMenu with all branches) and via Cmd+Shift+B (opens `BranchSwitcherView` sheet with search). The subtitle click is implemented via AppKit (`BranchSubtitleClickHandler`) because SwiftUI's `toolbarTitleMenu` does not work on macOS 26 with Liquid Glass. Git blame display shows per-line commit info (hash, author, timestamp, message) alongside code; toggled via menu. `GitBlameInfo` holds the parsed blame data structures.
-
-**Syntax highlighting:** `SyntaxHighlighter` singleton loads JSON grammar files from `Pine/Grammars/` at startup. Each grammar defines regex rules with scopes (comment, string, keyword, etc.) and a priority system prevents nested matches (comments > strings > keywords). Highlighting runs asynchronously using generation tokens to discard stale results.
-
-**Minimap:** `MinimapView` renders a scaled-down (12%) document overview on the right edge of the editor showing syntax colors and git diff markers. Click or drag to scroll the editor proportionally. A viewport indicator rectangle shows the visible region. Toggle visibility via menu.
-
-**Code folding:** `FoldRangeCalculator` identifies foldable ranges by scanning matched bracket pairs (`{}`, `[]`, `()`). `FoldState` tracks which ranges are folded for the active tab using a sorted set for O(1) hidden-line lookups. Fold/unfold/toggle operations are available via menu and gutter clicks.
-
-**Adding menu commands:** Menu items are defined in `PineApp.swift` inside `CommandGroup`. They post notifications via `NotificationCenter.default.post(name:)`. Notification names are defined as static properties in `extension Notification.Name` (bottom of `PineApp.swift`). `ContentView` listens via `.onReceive()` inside `GitAndNotificationObserver` ViewModifier. Strings go in `Strings.swift`, icons in `MenuIcons.swift`, localization in `Localizable.xcstrings` (targeted text insertion, not json.dump).
-
-**Find & Replace:** Uses NSTextView's native find bar (`usesFindBar = true`) triggered via NotificationCenter. Notifications: `findInFile` (Cmd+F), `findAndReplace` (Cmd+Option+F), `findNext` (Cmd+G), `findPrevious` (Cmd+Shift+G), `useSelectionForFind` (Cmd+E). The find bar is presented by `GutterTextView`'s coordinator in response to menu commands.
-
-**Project-wide search:** `ProjectSearchProvider` performs async full-project text search with debounce, `.gitignore` support, binary file detection, and a 1 MB per-file limit. Results are grouped by file and displayed in `SearchResultsView` with match highlighting and case-sensitivity toggle.
-
-**Status bar:** `StatusBarInfo` computes cursor position (line:column, 1-based), line ending style (LF/CRLF), indentation style (spaces/tabs with width), and human-readable file size. These values are displayed in `StatusBarView` at the bottom of the editor.
-
-**Format on Save:** `FileFormatterRegistry` applies language-aware formatters when `EditorSettings.formatOnSave` is enabled. Pure-Swift formatters (e.g. `JSONFileFormatter`) run synchronously. External tool formatters (`ExternalFileFormatter`) delegate to CLI tools (terraform, tofu, shfmt, prettier) via stdin/stdout — `ExternalFileFormatter.format()` dispatches `processRunner.run()` to a background queue via `DispatchGroup` so the main-thread `precondition` in `RealProcessRunner` is satisfied. `ExternalToolResolver` discovers tools by searching PATH + well-known directories (`/opt/homebrew/bin`, `/usr/local/bin`). `HCLFileFormatter` resolves terraform (preferred) or tofu for `.tf`/`.tfvars`/`.hcl` files. When neither tool is found, the formatter becomes a no-op (`toolPath: nil`). The registry is injectable via `TabManager.fileFormatters` for testing with `MockProcessRunner`.
-
-**Smart list continuation:** `SmartListContinuation` auto-continues Markdown list bullets/numbers/tasks on Enter. Wired into `GutterTextView` key handling. Enabled by default via `EditorSettings.smartListContinuation`.
-
-**Auto-save:** Auto-save support is accessible via menu (menu icon defined in `MenuIcons.autoSave`, string in `Strings.menuAutoSave`).
-
-**File system watching:** `FileSystemWatcher` uses FSEvents to monitor a directory tree and fires a debounced callback on the main thread when changes occur. Generation tokens prevent stale callbacks from firing after `stop()` is called.
-
-**Async file tree:** `WorkspaceManager` loads the project file tree in two phases — a shallow pass renders immediately for responsiveness, followed by a full async load. Generation tokens prevent stale async results from overwriting newer ones.
-
-**Window & tab management:** Uses `WindowGroup(for: URL.self)` where URL identifies the project directory (not individual files). Each project gets one native macOS window with an internal editor tab bar (`EditorTabBar`). `ProjectRegistry` (owned by `AppDelegate`, shared with `PineApp` via computed property) deduplicates open projects — opening the same directory twice returns the same `ProjectManager`. A `Welcome` window (`WelcomeView`) shows on launch with a recent projects list and an Open Folder button. `FocusedProjectKey` passes the active `ProjectManager` to menu commands via `@FocusedValue`. On macOS 26, XCUITest and direct binary launches bypass LaunchServices, causing SwiftUI to skip window creation despite `.defaultLaunchBehavior(.presented)`. `AppDelegate.createWelcomeWindowViaAppKit()` uses `NSHostingController` as a fallback to guarantee the Welcome window appears.
-
-**Document lifecycle:** `TabManager` manages save operations — `saveTab(at:)` writes to disk with NSAlert on failure, `trySaveTab(at:)` throws without UI. `saveAllTabs()` / `trySaveAllTabs()` save all dirty tabs. `saveActiveTabAs(to:)` implements Save As — writes to new URL and updates tab in-place preserving identity. `duplicateActiveTab()` creates a copy with Finder-like naming ("file copy.ext", "file copy 2.ext"). Close/quit dialogs list unsaved files with `dirtyTabs` and use "Save All" button. Failed saves cancel close/quit.
-
-**Quick Open:** `QuickOpenProvider` builds a file index from the `FileNode` tree and performs fuzzy subsequence matching with scoring (filename exact/prefix/substring bonuses, recent files boost). `QuickOpenView` is a sheet overlay with live search, arrow key navigation, and file icons. Triggered via Cmd+P.
-
-**Symbol Navigator:** `SymbolNavigatorView` shows functions, classes, and structs in the current file with fuzzy search. Triggered via Cmd+R. Uses regex-based symbol extraction per language.
-
-**Markdown preview:** Renders markdown using [swift-markdown](https://github.com/swiftlang/swift-markdown). Three modes: source-only, rendered, and side-by-side. Toggled via Cmd+Shift+P. The rendered view converts Markdown AST to NSAttributedString for display in a native text view.
-
-**Session persistence:** `SessionState` (Codable struct) saves project path, open file paths, pane layout tree (PaneNode), per-pane terminal tab counts, and editor state to UserDefaults. `AppDelegate` triggers save on app termination for all open projects. `ContentView.restoreSessionIfNeeded()` restores tabs and pane layout on first load if the saved session matches the current project. Terminal pane positions are preserved; terminal processes are recreated (scrollback lost).
-
-## Key Entry Points
-
-- `PineApp.swift` — @main, AppDelegate, menu commands, `CloseDelegate`
-- `ContentView.swift` — NavigationSplitView: sidebar + PaneTreeView
-- `ProjectManager.swift` — Central state: pane manager, tab manager, terminal coordinator, git provider
-- `CodeEditorView.swift` — NSViewRepresentable editor (GutterTextView + LineNumberView)
-- `PaneManager.swift` / `PaneNode.swift` — Split pane tree (binary tree of editor/terminal leaves)
-- `TabManager.swift` — Editor tab lifecycle (open, close, save, saveAs, duplicate, dirty tracking)
-- `WorkspaceManager.swift` — Async file tree loading, git integration, file watching
-- `GitStatusProvider.swift` — Git status/diff parsing, branch listing and checkout
-- `SyntaxHighlighter.swift` — Grammar loading, regex compilation, async highlighting
-- `TerminalSession.swift` / `TerminalManager.swift` — SwiftTerm integration and terminal coordination
-- `SessionState.swift` — Codable session persistence via UserDefaults
-- `PineTests/` — Unit tests (180+ files, Swift Testing framework)
-- `PineUITests/` — XCUITest suite (30 files), base class `PineUITestCase`
-- `PinePerformanceTests/` — XCTest `measure {}` benchmarks; enabled in default scheme but excluded from CI (opt-in via `perf` label or `workflow_dispatch`)
-
-## Concurrency Model
-
-Pine uses GCD for background work, bridged to async/await via `withCheckedContinuation` at API boundaries.
-
-**Threading rules:**
-- All UI updates on main thread (SwiftUI observation + `DispatchQueue.main.async`)
-- CPU-intensive work dispatched to background: syntax highlighting (`com.pine.syntax-highlight` serial queue), git operations (`DispatchQueue.global` with `DispatchGroup` for parallel branch/status/branches), project search (`TaskGroup` with sliding-window concurrency), file tree loading (`DispatchQueue.global`)
-- **Never block main thread** with file I/O, regex computation, or git process execution
-- Generation tokens (`HighlightGeneration`, `WorkspaceManager.loadGeneration`, `FileSystemWatcher.activeGeneration`) prevent stale async results from overwriting newer ones — always check generation before applying results
-- **Background work owns its autorelease pool** (#1509). A `DispatchQueue.global()` work item runs with no pool in place, so every autoreleased Foundation/AppKit temporary it produces is parked in libobjc's thread-wide fallback pool and stays alive until the worker thread is destroyed. `runOnBackground` (`Pine/Concurrency/BackgroundDispatch.swift`) wraps its body in `autoreleasepool` on both the success and the error path — prefer it over a raw `DispatchQueue.global().async`, and wrap the body yourself where a raw dispatch is unavoidable. Verify with `OBJC_DEBUG_MISSING_POOLS=YES`: "autoreleased with no pool in place" lines are the regression signal
-
-**Debounce values** (centralised in `UITimings.Debounce` / `UITimings.Render`):
-- Syntax highlight on edit: 100ms (`Debounce.edit`)
-- Syntax highlight on scroll: 50ms (`Debounce.scroll`)
-- Fold range recalculation: 150ms (`Debounce.foldRecalc`)
-- Project search: 300ms (`Debounce.projectSearch`)
-- File system watcher: 150ms (`Debounce.fileWatcher`, `WorkspaceManager.watcherDebounce`)
-- Config validator (yamllint / shellcheck / hadolint / terraform validate): 300ms (`Debounce.configValidation`, `ConfigValidator.debounceInterval`)
-- Minimap redraw: 25ms with trailing coalesce (`Render.minimapRedraw`)
-
-**Performance thresholds:**
-- Viewport-only highlighting: files > 50 000 characters (`viewportHighlightThreshold`; lowered from 100KB in #637)
-- Large file dialog (disable highlighting?): files > 1MB (`largeFileThreshold`)
-- Partial load (first 1MB only): files > 10MB (`hugeFileThreshold`)
-- Project search skips files > 1MB
-- Target: <4ms main thread work per scroll frame for 120Hz ProMotion
-
-## Release & CI
-
-- **Release Please** (`.github/workflows/release-please.yml`) automates versioning and changelog via [Conventional Commits](https://www.conventionalcommits.org/):
-  - On every push to `main`, Release Please creates/updates a Release PR with version bump in `version.txt` and auto-generated `CHANGELOG.md`
-  - When the Release PR is merged, Release Please creates a git tag (e.g. `v0.13.0`) which triggers the build workflow
-  - Config: `release-please-config.json`, manifest: `.release-please-manifest.json`
-  - Requires `RELEASE_PLEASE_TOKEN` secret (PAT with `contents: write` + `pull-requests: write`) — default `GITHUB_TOKEN` won't trigger downstream workflows
-- **Build workflow** (`.github/workflows/release.yml`) triggers on `v*` tags
-- Pipeline: build → code sign → notarize → create DMG → GitHub Release → update Homebrew Tap
-- Secrets: `CERTIFICATE_P12`, `CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_ID_PASSWORD`, `APPLE_TEAM_ID`, `TAP_GITHUB_TOKEN`, `RELEASE_PLEASE_TOKEN`
-- Homebrew: `brew tap batonogov/tap && brew install --cask pine-editor`
-- **CI pipeline** (`.github/workflows/ci.yml`): Lint → Build → Unit Tests (with code coverage) + 7 UI Test shards (parallel) + Flaky Test Summary. All UI tests always run (no conditional skip). Coverage threshold: 70% logic-only (SwiftUI view files excluded). Flaky tests auto-retry once and are reported separately. UI test shards must be balanced (±3 tests, currently 33-35 per shard); verify script checks all test classes are assigned to a shard
-- **Branch protection**: requires all checks to pass. Does NOT require the branch to be up-to-date with main, and does NOT use a merge queue — multiple PRs can be merged in parallel/sequence without re-running CI on each. GitHub recomputes mergeability after each merge, but stale branches merge cleanly (3-way merge handles shared files)
-- **Action pinning** — all third-party GitHub Actions are pinned by full commit SHA (not mutable tags) for supply-chain safety. To update: find the new version's commit SHA on GitHub (Tags → verify the commit), replace the SHA in the workflow file, and keep the trailing `# vX.Y.Z` comment on the exact release tag (a floating `# vX` comment hides drift once the moving tag advances)
-- **Dependency maintenance** — keep every pinned dependency within **N-1 of upstream** (one release behind latest stable); **never downgrade** an already-current pin. The new version/SHA must be a strict descendant of the one it replaces. Run `scripts/check-deps.sh` to list pinned-vs-latest before each pass. Scope:
-  - **GitHub Actions** (SHA-pinned across `.github/workflows/*.yml`): `actions/checkout`, `actions/cache`, `actions/upload-artifact`, `actions/download-artifact`, `actions/github-script`, `googleapis/release-please-action`. Bump by replacing the SHA and the trailing `# vX.Y.Z` comment. **Major-version jumps** — notably `upload-artifact`/`download-artifact` (whose v4 line changed artifact immutability) — must land in their own `chore(deps)` PR with a green CI run; do not bundle them into a feature PR.
-  - **SwiftLint** (`SWIFTLINT_VERSION` + `SWIFTLINT_SHA256` in `.github/workflows/ci.yml`): **exception to the N-1 rule above** — this pin tracks the version developers actually run (`brew install swiftlint`, currently 0.65.1) so CI and local lint agree; a lint pin one release behind local just means CI misses violations you already see. When bumping, diff `swiftlint --strict` output between the old and new version across the whole tree before merging, and move both fields together (the `sha256sum -c -` install step fails closed on a mismatch).
-  - **SPM packages** (`Package.resolved`): SwiftTerm, Sparkle, swift-markdown, swift-cmark, swift-argument-parser. Bump via Xcode → File → Packages → Update, then rebuild and run `PineTests` before merge. A bump that regresses behavior is reverted and filed as an issue, not pinned to an older release.
-- **Nightly performance** (`.github/workflows/nightly-perf.yml`) — runs performance tests nightly and on schedule, uploads `PerformanceResults.xcresult` artifact, detects regressions via `scripts/check_perf_regression.py`
-- **Nightly fuzz** (`.github/workflows/nightly-fuzz.yml`) — scheduled fuzz testing
-- **Screenshots** (`.github/workflows/screenshots.yml`) — regenerates GitHub/landing page screenshots in `assets/` on demand
-
-## Marketing Surface Synchronization
-
-Pine's public product description spans several surfaces that must stay consistent. Treat a change to positioning, a flagship user-facing capability, supported-language count, third-party dependencies, installation instructions, or minimum macOS/Xcode requirements as a documentation change too.
-
-- **Canonical surfaces:** update `README.md`, `docs/index.html`, its SEO/Open Graph/X metadata, and all 9 landing-page translations (`en`, `de`, `es`, `fr`, `ja`, `ko`, `pt-BR`, `ru`, `zh-Hans`) in the same PR when a claim changes. Do not update English alone.
-- **GitHub About:** keep the repository description, homepage, and topics aligned with the landing-page positioning. Verify with `gh repo view --json description,homepageUrl,repositoryTopics`; update through `gh repo edit` only when the task authorizes external repository metadata changes.
-- **Screenshots:** marketing screenshots live in `assets/` and are produced by `PineUITests/ScreenshotTests.swift` through `scripts/update-screenshots.sh`. Fixtures must use a stable, human-readable project name such as `Pine Demo`; never ship UUIDs, temporary paths, stale feature counts, or test-only wording in visible screenshot content.
-- **Avoid fragile claims:** prefer durable wording over hard-coded counts or dependency totals. When an exact number is useful (for example, supported syntax grammars), derive or verify it from the repository before publishing.
-- **Release check:** before opening a PR that changes any canonical surface, verify the latest-release CTA, Homebrew command, system requirements, external links, responsive layout, keyboard access, reduced-motion behavior, and screenshot lightbox. Keep GitHub Pages deployment on the existing `docs/` workflow; do not create a separate hosting target.
+- **Never block the main thread** with file I/O, regex computation, or git process execution. Background work owns its autorelease pool — prefer `runOnBackground` (`Pine/Concurrency/BackgroundDispatch.swift`) over a raw `DispatchQueue.global().async` (#1509)
+- **Never post a `NotificationCenter` notification inside a function holding an `inout` access.** Observers are delivered synchronously; one that writes the same store re-enters the live access and Swift aborts the process (#1066). Return the payload and let the caller post after the scope ends. `scripts/check-no-post-under-inout.py` enforces this at pre-commit and in CI
+- **Never rewrite `Localizable.xcstrings` with `json.dump`** or any standard JSON serializer — Xcode's non-standard formatting turns the diff into thousands of lines of noise. Insert translations as targeted text edits
+- **Never merge a red PR.** Branch protection blocks it, and a green run is a prerequisite, not a judgment call
+- **Generation tokens** (`HighlightGeneration`, `WorkspaceManager.loadGeneration`, `FileSystemWatcher.activeGeneration`) guard every async result — check the token before applying one
 
 ## Conventions
 
-- Uses `@Observable` macro (Swift 5.9+), not ObservableObject/Published
-- Models are either structs (EditorTab) or classes depending on identity semantics. `FileNode` is a plain `nonisolated final class` (not @Observable) — it's a recursive tree data structure, not reactive state. `TerminalTab` is `@Observable` because it drives SwiftUI updates
-- Grammar files are JSON in `Pine/Grammars/` — add new languages by adding a new JSON file following the existing format
-- **Keyboard shortcuts** — menu commands flow through `@FocusedValue(\.projectManager)` to `TabManager`. Notable exceptions: Cmd+W is intercepted via `NSEvent.addLocalMonitorForEvents` in AppDelegate (closes active tab, not window); Cmd+\` focuses terminal pane or creates one; Cmd+T creates a new terminal tab in the last-used terminal pane or creates a full-width terminal pane at the bottom
-- UI uses semantic system colors (migrated from hardcoded dark theme values)
-- macOS 26 SDK renamed `NSColor(sRGBRed:)` → `NSColor(srgbRed:)` (lowercase)
-- Editor tabs use an internal SwiftUI tab bar (`EditorTabBar`), not native macOS window tabs
-- Project windows use `WindowGroup(for: URL.self)` where URL = project directory; `ProjectRegistry` prevents duplicate windows for the same project
 - **Conventional Commits** — all commit messages must follow the format: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `perf:`, `test:`. Use `feat!:` or `BREAKING CHANGE:` footer for breaking changes
 - **Test coverage** — every new feature or bug fix must include unit tests (and UI tests where applicable). Aim for comprehensive coverage: test public API, edge cases, error paths, boundary conditions, and integration between components. Cover the maximum number of cases — not just the happy path. Do not merge code without corresponding tests
-- **Localizable.xcstrings** — never use `json.dump` or standard JSON serializers to write this file. Xcode uses non-standard formatting (`"key" : "value"` with a space before the colon). Reserializing the entire file creates thousands of lines of whitespace noise in diffs. Instead, insert new translations by reading the file as text and making targeted insertions preserving the existing format
-- **Localization** — 9 languages supported (en, de, es, fr, ja, ko, pt-BR, ru, zh-Hans). All user-facing strings go through `Localizable.xcstrings`. To add a new language: add the language key to the xcstrings dict with translations for every existing key
-- **Utility scripts** — `scripts/` directory contains `normalize-xcstrings.sh` (called by pre-commit hook to unstage cosmetic xcstrings changes), `reset-cosmetic-xcstrings.sh` (reverts cosmetic-only xcstrings diffs), `test-normalize-xcstrings.sh` (tests for the normalizer), `update-screenshots.sh` (regenerates GitHub/landing page screenshots), `check-no-post-under-inout.py` (pre-commit + CI guard that blocks the exclusivity-abort reentrancy class), `tests/test-check-no-post-under-inout.sh` (tests for that guard), and `check-deps.sh` (read-only dependency audit: prints pinned-vs-latest for GitHub Actions, SwiftLint, and SPM packages — run before each dependency pass)
-- **Reentrancy / exclusivity** — never post a `NotificationCenter` notification inside a function that holds an `inout` (e.g. `tabs: inout [EditorTab]`) exclusive access. `NotificationCenter.post` delivers observers synchronously on the main queue; an observer that writes the same store re-enters the live access and Swift aborts the process (`_swift_reportExclusivityConflict`, Pine #1066 and the #1047/#1051/#1056/#1058 family). Safe pattern: RETURN the payload (e.g. `SaveOutcome.reload` / `ReloadedTab`) and let the caller post AFTER the `inout` scope ends — see `TabExternalChangeDetector.reloadTab` and `TabPersistence.saveTabContent`. For `.onReceive` / `@objc` observers, defer `@State`/`@Observable` mutations to the next runloop via `DispatchQueue.main.async`. The `check-no-post-under-inout.py` guard enforces the `inout`-post sub-pattern at pre-commit and CI; if you legitimately defer a post inside an `inout` function, mark the line `// reentrancy-safe`
-
-## Snapshot Testing
-
-Pine uses a minimal zero-dependency visual snapshot harness for SwiftUI views. Reference PNGs live under `PineTests/SnapshotTests/__Snapshots__/`. No third-party packages, no pbxproj edits.
-
-- **Harness:** `PineTests/SnapshotTests/SnapshotHarness.swift` — renders a SwiftUI view via `NSHostingView` into an `NSBitmapImageRep` under a given `NSAppearance` (`.light` / `.dark`), encodes to PNG, and compares against the reference using a mean-absolute per-pixel RGBA diff normalized to `[0, 1]`. Default tolerance is `0.01` to absorb trivial anti-aliasing noise.
-- **Backing scale independence:** the bitmap is allocated explicitly at 1× the logical size (`pixelsWide == Int(size.width)`) so output is identical on Retina (2×) developer machines and on macOS CI runners' 1× virtual displays. Without this, baselines recorded on a Retina Mac differ in pixel dimensions from CI output and the diff short-circuits to `1.0` (dimension mismatch). The bitmap is also pre-filled with `NSColor.windowBackgroundColor` under the requested appearance so semi-transparent system colors (e.g. `.secondary` text in dark mode) composite onto a realistic backdrop instead of a transparent canvas.
-- **Writing a test:** import the harness (it lives in the `PineTests` target) and call `try assertSnapshot(of: MyView(), size: NSSize(width: W, height: H), appearance: .light, named: "MyView.light")`. Cover both `.light` and `.dark` for every view. Use local `Harness` wrapper views for SwiftUI bindings.
-- **Stability:** stub out any data source that can vary between machines (e.g. populate `ProjectRegistry.recentProjects` and `GitStatusProvider.branches` manually). Never snapshot a view that depends on real git state, real filesystem contents, or network.
-- **Running:** `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -skipPackagePluginValidation -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PineTests/WelcomeViewSnapshotTests` (one suite at a time).
-- **Updating snapshots:** run tests with `PINE_RECORD_SNAPSHOTS=1` in the test environment (set it via the Pine scheme's Test action, or pass as the final positional `KEY=VALUE` arg to `xcodebuild test`). In record mode the harness always overwrites the reference PNG and passes. Review the PNG diff in the PR before merging.
-- **First run:** if no reference exists the harness writes a baseline and fails the test so new baselines can never sneak in silently. A failing test also writes an `<name>.actual.png` alongside the reference for visual inspection.
-- **Current coverage:** 8 view suites / 32 reference PNGs — `WelcomeView`, `BranchSwitcherView`, `GoToLineView`, `NavigationOverlay` (GoToLine overlay via `CommandOverlayView`), `BreadcrumbPathBar`, `EditorTabItem`, `IndentGuidesYAML`, `StatusBarView` (each in light + dark; `BreadcrumbPathBar`, `EditorTabItem`, and `StatusBarView` also snapshot multiple states). Remaining scope from issue #796 (editor gutter, sidebar file tree, minimap, diagnostic popover, inline diff) is tracked as follow-ups — the tab bar is now partially covered via `EditorTabItem` snapshots.
+- Uses `@Observable` macro (Swift 5.9+), not ObservableObject/Published
+- UI uses semantic system colors (migrated from hardcoded dark theme values)
+- macOS 26 SDK renamed `NSColor(sRGBRed:)` → `NSColor(srgbRed:)` (lowercase)
 
 ## GitHub Issues
 
@@ -224,17 +67,20 @@ When creating issues, always:
 How the maintainer works day-to-day. Documents intent and handoff conventions for contributors and AI agents.
 
 ### Prioritization
+
 - Work is driven by **milestones**. The next task is picked from the active milestone, prioritized by labels (`priority: high` first).
 - An issue is filed and assigned to a milestone **before** its branch is created or implementation begins (see `## GitHub Issues`). A PR may only be opened for an existing issue and must reference it.
 
 ### Branches & PRs
+
 - **One task = one short-lived branch**, named by type with no issue number: `feat/terminal-scroll`, `fix/gutter-bug`.
 - No long-lived feature branches. Nothing is committed directly to `main`.
 - PRs are **squash-merged** into `main` (one commit per PR).
 - The PR description states **when the branch is ready to merge** — do not merge before that.
-- **All CI checks must be green before a PR can be merged.** This is enforced by repository branch protection ("requires all checks to pass", see `## Release & CI`) — GitHub will refuse the merge button on any non-green PR. Red PRs are never merged. When CI fails due to flakiness or a runner/infrastructure issue that is provably not the diff's fault (e.g. an identical hang reproduces on a screenshots-only PR), the fix is to resolve the failure — rerun, mitigate the flakiness, or fix the code — until a fully green run exists. Do not hand-wave a red check as "not our fault" and call the PR mergeable; a green run is a hard prerequisite, not a judgment call.
+- **All CI checks must be green before a PR can be merged.** This is enforced by repository branch protection ("requires all checks to pass", see `.claude/rules/ci-release.md`) — GitHub will refuse the merge button on any non-green PR. Red PRs are never merged. When CI fails due to flakiness or a runner/infrastructure issue that is provably not the diff's fault (e.g. an identical hang reproduces on a screenshots-only PR), the fix is to resolve the failure — rerun, mitigate the flakiness, or fix the code — until a fully green run exists. Do not hand-wave a red check as "not our fault" and call the PR mergeable; a green run is a hard prerequisite, not a judgment call.
 
 ### Local development loop
+
 - Code is edited **inside Pine itself**, or via AI agents in the terminal.
 - Fast feedback loop: **single-file typecheck** (`swiftc -typecheck`, see `## Build & Run`) — not a full build on every change.
 - A full `xcodebuild build` is run **before opening a PR**.
@@ -243,140 +89,47 @@ How the maintainer works day-to-day. Documents intent and handoff conventions fo
 
 **Local runs on the macOS 27 beta are not a pass/fail signal** — CI is (#1509). Two known standing differences on that runtime, both unrelated to whatever diff is in the tree: `AgentInboxToolbarButtonSnapshotTests` fails all four cases because the baselines are recorded on the macOS 26 CI runner and the beta renders that view ~3% differently; and `ApplicationLifecycleProcessTests.quitCrashAndRelaunchJourney()` fails with `terminal-child-unavailable` when several agents run `xcodebuild` at once, because its wait for the spawned terminal child is bounded at 5s. Confirm a local failure on an idle machine before blaming a diff for it.
 
-**Diagnosing a test-host crash on the macOS 27 beta** (#1509):
-- Trust `~/Library/Logs/DiagnosticReports/`, not the console log — the beta drops log lines badly. Reports rotate into `Retired/` and only about twenty are kept there, so **copy a report out the moment you see the crash**; the two incidents #1509 was opened on were already gone by the time it was triaged.
-- Record the OS **build**, not the marketing version: `sw_vers` → `BuildVersion`, matched against `osVersion.build` in the `.ips`. `/var/log/install.log` (`Previous System Version … Current System Version …`) says when the machine changed builds, which is the first thing to check before calling a crash reproducible or fixed.
-- Inject `objc`/malloc diagnostics by copying the generated `.xctestrun` and editing `TestConfigurations → TestTargets → EnvironmentVariables`, then `xcodebuild test-without-building -xctestrun <copy>`. Keep the copy **in the same directory as the original** — the file's `__TESTROOT__` placeholders resolve relative to it. Useful keys: `OBJC_DEBUG_POOL_ALLOCATION=YES` (halts on an out-of-order pool pop), `OBJC_DEBUG_MISSING_POOLS=YES`, `OBJC_DISABLE_AUTORELEASE_COALESCING=YES`, `MallocScribble=1`, `NSZombieEnabled=YES`.
-- For a crash in `objc_autoreleasePoolPop` → `AutoreleasePoolPage::releaseUntil` → `objc_release`, the registers `x22 = 0xa1a1a1a1`, `x23 = 0xf00ffffffffffff` and `x24 = 0xa3a3a3a3a3a3a3a3` are **not** evidence of anything — they are loop-invariant constants (pool-page magic, pointer mask, SCRIBBLE byte) materialised in `releaseUntil`'s prologue on every single pool pop. Read `x0`/`x21` (the object being released), the word at `[x0]` (its `isa`), and confirm `far == (isa & 0x7ffffffffff8) + 0x20`. Reaching `releaseUntil` at all means libobjc already validated the page magic, so the pool page itself was intact.
+For the crash-report workflow on that runtime, invoke the `macos27-crash-triage` skill.
 
 ### Working with AI agents
+
 - Typical handoff: **"реши issue #N"** (solve issue #N) — the agent reads the issue **and all its comments** in full, then plans, implements, writes tests, and opens a PR.
 - Agents may freely, without asking: edit code, run single-file typecheck, run unit tests, create branches, open PRs.
 - **Explicit confirmation required** for: merging a PR, and anything in the destructive-command list in this file (deletions, force-pushes, infrastructure changes).
 - Agents should run unit tests themselves — no need to ask first.
-
-### Maintainer-directed issue swarm
-
-When the maintainer asks the parent agent to distribute a backlog across
-subagents, use this stricter issue-by-issue flow:
-
-1. **The issue is the unit of authorization.** Never start implementation
-   without an existing issue. One worker owns exactly one issue at a time in
-   one isolated worktree and short-lived branch. Do not mix opportunistic fixes
-   from another issue into its diff. If the maintainer names a required first
-   wave, schedule those issues before optional work.
-2. **Start from current `origin/main`.** Fetch before creating a worktree and
-   record the exact base SHA. When `main` advances, especially after a sibling
-   or release merge, preserve the complete local diff with
-   `git stash push --include-untracked -m <unique-issue-and-base>`, record and
-   verify the resulting stash commit OID, update the uncommitted branch only
-   with `git merge --ff-only origin/main`, and restore with
-   `git stash apply <OID>`. Never pop or drop the backup until the moved diff is
-   validated; never use `reset --hard`, forced checkout, or `clean`. Stop on a
-   non-fast-forward or conflict. Prove that merged commits occur exactly once,
-   re-review overlapping files, and rerun the affected tests after the move.
-3. **Review before spending CI.** Risky or cross-cutting work first reports a
-   design and test plan, then a production-diff checkpoint. Every
-   implementation, regardless of risk, reports the complete diff after local
-   verification and passes the independent review gate below before commit,
-   push, or PR. The parent/orchestrator requests polishing before expensive
-   macOS or UI runners test the candidate.
-4. **Keep concurrent Xcode work isolated.** Give every issue a unique
-   `-derivedDataPath` under `/private/tmp`; never share DerivedData between
-   workers. Record the exact macOS, Xcode, SDK version, commands, test counts,
-   and result-bundle path. A code failure gets diagnosed and reviewed before a
-   bounded retry; do not hide a failure with repeated blind reruns.
-5. **Verification is evidence, not a summary.** Always run `git diff --check`.
-   Run every applicable targeted check and state each non-applicable check with
-   a reason: SwiftLint for Swift/code changes, targeted tests for behavioral
-   changes, and the existing full pre-PR build for code PRs. Add broader suites,
-   UI tests, security/race tests, or renderer checks when the issue requires
-   them. Report unrelated failures separately, but never call a PR merge-ready
-   until every required GitHub check is green.
-6. **Publish in dependency order.** Only after the parent review clears may the
-   worker make a Conventional Commit. The parent then performs a final commit
-   review, pushes, opens the issue-linked PR, states the merge order, and watches
-   CI. A worker subagent never merges its own PR.
-7. **Merge authorization is narrow.** By default only the maintainer merges.
-   If the maintainer explicitly authorizes the parent/orchestrator to merge
-   working PRs, the authorization must identify the exact PR numbers and
-   current head SHAs; a batch is an immutable enumeration of those exact
-   `(PR number, head SHA)` pairs. Revalidate them immediately before merge.
-   Only non-release PRs that remain mergeable, have a clean review gate, and
-   have every required check green may merge. Red or pending PRs are never
-   merged. Release actions require separate, exact authorization covering each
-   requested operation: Release Please PR merge; tag create, update, delete,
-   or push; and release-workflow edit, dispatch, rerun, or cancellation. After
-   any authorized Release Please PR merge, regardless of actor, treat the
-   resulting release commit as the new mandatory base for all active issue
-   branches.
-
-### Independent review gate
-
-Every implementation must pass an independent, fresh-context review before
-its first push and before a PR is opened. This keeps expensive macOS and UI
-runners from testing a candidate that has not cleared adversarial review.
-Green CI remains necessary, but it does not replace that review.
-
-1. **Review the local candidate diff before push.** Once implementation and
-   regression tests are stable, review the complete local diff against its
-   intended base (`main...HEAD`, plus any staged or unstaged changes). Keep the
-   original worktree path as the single mutable copy, include
-   `git status --short`, and represent every untracked file explicitly with a
-   manifest plus a `git diff --no-index /dev/null <file>` patch (or an
-   equivalent content-complete artifact). Review and fix workers must use that
-   same worktree until commit. Run at least three read-only reviewer subagents
-   with distinct lenses: (a)
-   correctness and architecture, (b) concurrency, security, and lifecycle
-   races, and (c) tests, UX, localization, and OS compatibility. Reviewers
-   must read the issue acceptance criteria and must not edit files.
-2. **Demand actionable findings.** Each finding includes severity, exact
-   file/line references, a concrete failure sequence or reproduction, and the
-   smallest safe fix. A clean review explicitly lists the invariants checked;
-   a summary that merely restates the diff does not count.
-3. **Synthesize and verify.** The parent agent deduplicates findings, validates
-   them against the code, and adds a regression test before or with each fix.
-   All confirmed P0, P1, and P2 findings must be resolved before merge. Record
-   low-risk coverage gaps or P3 findings in the PR or a follow-up issue when
-   they are intentionally deferred.
-4. **Fix on the same local branch.** In the maintainer-directed flow, keep the
-   candidate uncommitted until review clears. If the candidate was already
-   committed under a different flow, add follow-up commits; never amend or
-   force-push. Repeat the independent review/fix loop until reviewers return no
-   unresolved P0-P2 findings, then rerun the relevant local checks.
-5. **Push and open the PR only after review clears.** Summarize reviewer
-   angles, findings, dispositions, and local verification in the PR body.
-   Run the full required CI once the PR exists. An agent with explicit merge
-   authorization must not invoke merge until the pre-push review gate remains
-   clean and every required CI check is green.
-6. **Recover visibly from a premature merge.** If review was skipped before
-   merge, or a post-merge review finds a P0-P2 defect, reopen the source issue,
-   create a short-lived follow-up branch from current `main`, add regression
-   tests and fixes, repeat review plus CI, and close the issue only after the
-   follow-up PR is green and merged.
-
-### Milestone orchestration with subagents
-
-For a milestone with multiple issues, the maintainer (or a parent agent) orchestrates implementation across subagents instead of doing all the work in one session. Used for parallelizable issues, large features, or when strict adversarial review is wanted. The full loop runs inside the agent; the maintainer merges by default, or may explicitly authorize the parent/orchestrator to merge under the narrow gate above.
-
-Flow:
-1. **Scope first.** Read every issue in the milestone end-to-end, identify shared files, and note dependencies (`blocked-by`, or an explicit "depends on #X" in the body). Order implementation and merge accordingly.
-2. **One issue = one worker = one candidate branch.** Delegate each issue to a worker subagent in an isolated worktree (`worktree: true`). Each worker creates its own local branch, implements the candidate, runs local verification, and reports the complete working diff for review without committing, pushing, or opening a PR. Pass each worker explicit permissions in the task and an `acceptance` contract with `verify` commands and `stopRules` (notably: never commit before review clears, never push, never open a PR, never merge, never force-push, never amend).
-3. **Respect cross-issue boundaries.** Tell each worker exactly which files/branches it may touch so sibling PRs stay mergeable (e.g. add a dedicated accumulator field per branch instead of repurposing a shared one). When an issue depends on siblings not yet merged, wait for them to land or have the parent create a separately reviewed integration base with a recorded SHA and exactly-once proof. Workers do not merge or cherry-pick sibling branches into an uncommitted candidate.
-4. **Strict review from fresh context before push.** Run fresh-context `reviewer` subagents with distinct angles against each complete local candidate diff. Reviewers are read-only — they must not edit.
-5. **Fix before opening the PR.** Synthesize reviewer findings and hand them to a fix-worker that uses the **existing local candidate branch** and working diff. Keep fixes uncommitted until the review gate is clean. Never amend, force-push, or open a new branch for fixes. Repeat the review/fix loop until reviewers return a clean verdict (typically ~2 rounds), then create the Conventional Commit.
-6. **Publish and verify after review.** Only now does the parent/orchestrator push each reviewed branch and open its PR. Confirm every PR is `MERGEABLE` and **fully green** — every required CI check passing, no exceptions. Pending checks must be explicitly noted. There is no "red but mergeable" state: branch protection blocks the merge button on any failing check, so a red PR is not ready regardless of why it failed. State the merge order.
-7. **Workers never publish or merge.** After review clears, the
-   parent/orchestrator opens and reports the PR. It merges only when the
-   maintainer has explicitly delegated that authority and all review,
-   dependency-order, and green-CI requirements above are satisfied; otherwise
-   the maintainer merges.
-
-Operational notes:
-- Worktree isolation requires a clean main tree — remove stray artifacts (e.g. a `reviews/` folder written by reviewers) before launching new worktree runs.
-- "needs attention" control signals from a finished run are stale noise; trust `gh pr checks` / `gh pr view` as ground truth.
-- Acceptance-gate / parse-report errors in the subagent harness do not mean the work failed — check the PR and CI; the code usually landed.
+- For a milestone or backlog distributed across subagents, invoke the `agent-swarm` skill — it carries the issue-by-issue authorization flow, the independent review gate, and the merge rules
 
 ### Releases
+
 - **No fixed cadence** — release when ready, by merging the Release Please PR.
-- Manual work before tagging is kept to a minimum; Release Please handles `version.txt` and `CHANGELOG.md` automatically (see `## Release & CI`).
+- Manual work before tagging is kept to a minimum; Release Please handles `version.txt` and `CHANGELOG.md` automatically (see `.claude/rules/ci-release.md`).
+
+## Where the rest of this guidance lives
+
+This file holds what applies before you open a file. Everything else is
+scoped so it enters context only when it is relevant.
+
+`.claude/rules/` — loaded automatically when a matching file is read:
+
+| Rule | Loads for | Covers |
+|---|---|---|
+| `architecture.md` | `Pine/**/*.swift` | Subsystem map, key entry points, type and view conventions |
+| `concurrency.md` | `Pine/**`, `PineTests/**` | Threading contract, debounce values, performance thresholds, reentrancy |
+| `terminal.md` | `Pine/Terminal/**`, `Pine/QuickTerminal/**` | Metal renderer and fallback, quick terminal, rendering-compatibility passes |
+| `ui-tests.md` | `PineUITests/**` | Launch arguments and every XCUITest limitation that has already cost a debugging session |
+| `snapshot-tests.md` | `PineTests/SnapshotTests/**` | Harness, backing-scale independence, recording baselines |
+| `lsp.md` | `Pine/LSP/**` | SourceKit-LSP smoke test |
+| `ci-release.md` | `.github/**`, `scripts/**` | Release Please, CI pipeline, action pinning, dependency maintenance |
+| `localization.md` | `Localizable.xcstrings`, `Strings.swift` | The xcstrings format rule and the nine shipped locales |
+| `marketing-surfaces.md` | `README.md`, `docs/**`, `assets/**` | Keeping the public product description consistent |
+
+`.claude/skills/` — invoked by name when the task calls for it:
+
+| Skill | Use when |
+|---|---|
+| `agent-swarm` | Distributing issues across subagents: authorization flow, review gate, merge rules |
+| `macos27-crash-triage` | The test host crashes or hangs on the macOS 27 beta (#1509) |
+
+Rules and skills are Claude Code mechanisms. Other agents working in this
+repository should treat `.claude/rules/` and `.claude/skills/` as ordinary
+markdown and read whichever file matches the work at hand.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,7 @@ Pine follows **MVVM** with SwiftUI views backed by AppKit via `NSViewRepresentab
 - **`SyntaxHighlighter`** loads JSON grammar files from `Pine/Grammars/` for syntax highlighting
 - Menu commands are defined in `PineApp.swift` and dispatched via `NotificationCenter`
 
-For more details, see the Architecture section in [CLAUDE.md](CLAUDE.md).
+For more details, see [`.claude/rules/architecture.md`](.claude/rules/architecture.md), and [CLAUDE.md](CLAUDE.md) for build, test, and workflow conventions.
 
 ## Making Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,7 @@ Pine follows **MVVM** with SwiftUI views backed by AppKit via `NSViewRepresentab
 - **`SyntaxHighlighter`** loads JSON grammar files from `Pine/Grammars/` for syntax highlighting
 - Menu commands are defined in `PineApp.swift` and dispatched via `NotificationCenter`
 
-For more details, see the Architecture section in [AGENTS.md](AGENTS.md).
+For more details, see the Architecture section in [CLAUDE.md](CLAUDE.md).
 
 ## Making Changes
 

--- a/Perf/README.md
+++ b/Perf/README.md
@@ -107,7 +107,7 @@ with a regression report.
 | **memory-pressure** | Open a 10MB+ file (`hugeFileThreshold` partial-load path)     | Allocations, `highlight.*`               |
 
 The target is **<4ms main-thread work per scroll frame** for 120Hz ProMotion
-(see CLAUDE.md → Concurrency Model).
+(see `.claude/rules/concurrency.md`).
 
 ---
 

--- a/Perf/README.md
+++ b/Perf/README.md
@@ -107,7 +107,7 @@ with a regression report.
 | **memory-pressure** | Open a 10MB+ file (`hugeFileThreshold` partial-load path)     | Allocations, `highlight.*`               |
 
 The target is **<4ms main-thread work per scroll frame** for 120Hz ProMotion
-(see AGENTS.md → Concurrency Model).
+(see CLAUDE.md → Concurrency Model).
 
 ---
 

--- a/Pine/Agent/AgentInboxPopoverCoordinator.swift
+++ b/Pine/Agent/AgentInboxPopoverCoordinator.swift
@@ -248,7 +248,7 @@ final class AgentInboxPopoverCoordinator: NSObject, NSPopoverDelegate,
         guard resolution.bindingIsPresented != nil else { return }
         // The SwiftUI half is not. `update` runs inside a live view update
         // pass, and writing `@State` there re-enters it — the mutation
-        // AGENTS.md requires observers to defer.
+        // CLAUDE.md requires observers to defer.
         NativeCommandDelivery.deferToNextMainRunLoop { [weak self] in
             self?.writeSettledUpdate()
         }

--- a/Pine/Agent/AgentInboxPopoverPresenter.swift
+++ b/Pine/Agent/AgentInboxPopoverPresenter.swift
@@ -80,7 +80,7 @@ final class AgentInboxPopoverRouter {
         let generation = deliveryGeneration
         // Anchors register from `viewDidMoveToWindow` and `updateNSView`.
         // Presenting synchronously there writes SwiftUI state inside a live
-        // update pass — the mutation AGENTS.md requires observers to defer —
+        // update pass — the mutation CLAUDE.md requires observers to defer —
         // and shows the popover before layout has given the anchor a non-zero
         // `bounds`, which would pin it to the window's origin.
         deliverQueuedRequest { [weak self, weak host] in

--- a/Pine/RecoveryManager.swift
+++ b/Pine/RecoveryManager.swift
@@ -193,7 +193,7 @@ final class RecoveryManager {
     /// re-runs on scene restoration and on closing and reopening the window:
     /// three 40 MB buffers left for later would otherwise block the main
     /// thread on ~120 MB of reading and decoding before the window draws,
-    /// every launch and every reopen, for a week (AGENTS.md: never block the
+    /// every launch and every reopen, for a week (CLAUDE.md: never block the
     /// main thread with file I/O).
     ///
     /// Only the listing moves. The decision about what is worth offering stays
@@ -496,7 +496,7 @@ final class RecoveryManager {
     /// to read one `Date` now scales with how much unrecovered work the user
     /// is holding, and a snapshot carries a whole unsaved buffer (Pine's own
     /// large-file threshold is 1MB, and nothing caps a snapshot at it).
-    /// `AGENTS.md` forbids blocking the main thread with file I/O. A file
+    /// `CLAUDE.md` forbids blocking the main thread with file I/O. A file
     /// whose modification date is inside the window can only be kept, so one
     /// `stat` settles it, and in steady state — where everything on disk is
     /// younger than the window — nothing is read at all. The date is read

--- a/PinePerformanceTests/XCTMetricPerformanceTests.swift
+++ b/PinePerformanceTests/XCTMetricPerformanceTests.swift
@@ -37,7 +37,7 @@ final class XCTMetricPerformanceTests: XCTestCase {
 
     /// Highlights a large file while tracking peak memory, which `measure {}`
     /// cannot capture on its own. Memory is the dimension that matters for the
-    /// huge-file path (see AGENTS.md → Performance thresholds).
+    /// huge-file path (see CLAUDE.md → Performance thresholds).
     func testHighlightMemoryMetric() {
         let highlighter = SyntaxHighlighter.shared
         registerSwiftGrammar(on: highlighter)

--- a/PinePerformanceTests/XCTMetricPerformanceTests.swift
+++ b/PinePerformanceTests/XCTMetricPerformanceTests.swift
@@ -37,7 +37,7 @@ final class XCTMetricPerformanceTests: XCTestCase {
 
     /// Highlights a large file while tracking peak memory, which `measure {}`
     /// cannot capture on its own. Memory is the dimension that matters for the
-    /// huge-file path (see CLAUDE.md → Performance thresholds).
+    /// huge-file path (see .claude/rules/concurrency.md → Performance thresholds).
     func testHighlightMemoryMetric() {
         let highlighter = SyntaxHighlighter.shared
         registerSwiftGrammar(on: highlighter)

--- a/PineTests/AgentInboxPopoverCoordinatorTests.swift
+++ b/PineTests/AgentInboxPopoverCoordinatorTests.swift
@@ -296,7 +296,7 @@ struct AgentInboxPopoverCoordinatorTests {
 
     /// `update` runs inside SwiftUI's live view update, so the `@State` write
     /// this resolution carries has to be deferred — the exact mutation
-    /// AGENTS.md requires observers to move off the pass.
+    /// CLAUDE.md requires observers to move off the pass.
     @Test("an update pass never writes the binding inside itself")
     func updateDefersItsBindingWrite() async throws {
         let fixture = try Fixture()

--- a/PineTests/RecoveryTerminationSweepTests.swift
+++ b/PineTests/RecoveryTerminationSweepTests.swift
@@ -501,7 +501,7 @@ struct RecoveryTerminationSweepTests {
         // The launch sweep runs on the main actor and a snapshot carries a
         // whole unsaved buffer, so it now settles a file by its modification
         // date whenever it can and only decodes what that leaves undecided —
-        // in steady state, nothing (AGENTS.md: never block the main thread
+        // in steady state, nothing (CLAUDE.md: never block the main thread
         // with file I/O). The fast path is observable exactly here: an entry
         // dated outside the window in a file written moments ago is kept.
         //
@@ -1009,7 +1009,7 @@ struct RecoveryTerminationSweepTests {
         // `staleEntryRetentionDays` after a "Later" and the scene `.task`
         // re-runs on restoration and on close/reopen, which would put three
         // 40 MB buffers in front of the window on every launch and every
-        // reopen for a week. AGENTS.md: never block the main thread with file
+        // reopen for a week. CLAUDE.md: never block the main thread with file
         // I/O.
         //
         // This test does not compile at all unless the listing is

--- a/PineTests/SettingsWindowMetricsTests.swift
+++ b/PineTests/SettingsWindowMetricsTests.swift
@@ -20,7 +20,7 @@ import Testing
 @Suite("Settings window metrics", .serialized)
 @MainActor
 struct SettingsWindowMetricsTests {
-    /// The nine shipped localizations, per `AGENTS.md`.
+    /// The nine shipped localizations, per `CLAUDE.md`.
     private static let shippedLocales = [
         "en", "de", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-Hans",
     ]

--- a/PineTests/SettingsWindowMetricsTests.swift
+++ b/PineTests/SettingsWindowMetricsTests.swift
@@ -20,7 +20,7 @@ import Testing
 @Suite("Settings window metrics", .serialized)
 @MainActor
 struct SettingsWindowMetricsTests {
-    /// The nine shipped localizations, per `CLAUDE.md`.
+    /// The nine shipped localizations, per `.claude/rules/localization.md`.
     private static let shippedLocales = [
         "en", "de", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-Hans",
     ]

--- a/PineUITests/SplitPaneRoutingUITests.swift
+++ b/PineUITests/SplitPaneRoutingUITests.swift
@@ -25,7 +25,7 @@
 //    2. The Go-to-Line overlay appears whenever any tab is active, so its
 //       presence does not prove routing — and cursor movement (the actual
 //       routing effect) is unverifiable via XCUITest due to the
-//       GutterTextView keyboard-input limitation (see AGENTS.md).
+//       GutterTextView keyboard-input limitation (see CLAUDE.md).
 //
 //  XCUITest cannot create editor-pane splits via drag-and-drop (SwiftUI's
 //  onDrag/onDrop relies on the macOS pasteboard system, which synthetic
@@ -265,7 +265,7 @@ final class SplitPaneRoutingUITests: PineUITestCase {
         // Ensure the secondary pane is focused by clicking its tab.
         editorTab("utils.swift").click()
 
-        // Trigger Go to Line via Edit menu (typeKey is unreliable per AGENTS.md).
+        // Trigger Go to Line via Edit menu (typeKey is unreliable per CLAUDE.md).
         clickMenuBarItem("Edit")
         let goToLineItem = app.menuItems["Go to Line"]
         XCTAssertTrue(

--- a/PineUITests/SplitPaneRoutingUITests.swift
+++ b/PineUITests/SplitPaneRoutingUITests.swift
@@ -25,7 +25,7 @@
 //    2. The Go-to-Line overlay appears whenever any tab is active, so its
 //       presence does not prove routing — and cursor movement (the actual
 //       routing effect) is unverifiable via XCUITest due to the
-//       GutterTextView keyboard-input limitation (see CLAUDE.md).
+//       GutterTextView keyboard-input limitation (see .claude/rules/ui-tests.md).
 //
 //  XCUITest cannot create editor-pane splits via drag-and-drop (SwiftUI's
 //  onDrag/onDrop relies on the macOS pasteboard system, which synthetic
@@ -265,7 +265,7 @@ final class SplitPaneRoutingUITests: PineUITestCase {
         // Ensure the secondary pane is focused by clicking its tab.
         editorTab("utils.swift").click()
 
-        // Trigger Go to Line via Edit menu (typeKey is unreliable per CLAUDE.md).
+        // Trigger Go to Line via Edit menu (typeKey is unreliable, see ui-tests.md).
         clickMenuBarItem("Edit")
         let goToLineItem = app.menuItems["Go to Line"]
         XCTAssertTrue(

--- a/PineUITests/TerminalTests.swift
+++ b/PineUITests/TerminalTests.swift
@@ -825,7 +825,7 @@ final class TerminalTests: PineUITestCase {
 
         // Click `+` — this is the exact path users hit per issue #918.
         // Cmd+T cannot be used because XCUITest's typeKey() bypasses the
-        // app's NSEvent.addLocalMonitorForEvents (see CLAUDE.md).
+        // app's NSEvent.addLocalMonitorForEvents (see .claude/rules/ui-tests.md).
         newTerminalButton.click()
 
         let tab2 = terminalTab("Terminal 2")

--- a/PineUITests/TerminalTests.swift
+++ b/PineUITests/TerminalTests.swift
@@ -825,7 +825,7 @@ final class TerminalTests: PineUITestCase {
 
         // Click `+` — this is the exact path users hit per issue #918.
         // Cmd+T cannot be used because XCUITest's typeKey() bypasses the
-        // app's NSEvent.addLocalMonitorForEvents (see AGENTS.md).
+        // app's NSEvent.addLocalMonitorForEvents (see CLAUDE.md).
         newTerminalButton.click()
 
         let tab2 = terminalTab("Terminal 2")

--- a/docs/accessibility-release-checklist.md
+++ b/docs/accessibility-release-checklist.md
@@ -4,7 +4,7 @@ Run this short manual pass for release candidates after the automated unit and
 `A11y & Localization` UI matrix is green. The matrix distributes all nine
 supported locales across four focused jobs, exercises a keyboard-only critical
 journey, and retains double-length/representative layout screenshots plus AX
-trees. Record the exact macOS and Xcode/SDK versions described in `AGENTS.md`,
+trees. Record the exact macOS and Xcode/SDK versions described in `CLAUDE.md`,
 plus the language, appearance, and accessibility settings used.
 
 ## Representative configurations

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -5,7 +5,7 @@
 # component so a dependency pass can see, at a glance, what has fallen behind
 # upstream. Read-only: makes no changes.
 #
-# Policy (see CLAUDE.md -> "Dependency maintenance"):
+# Policy (see .claude/rules/ci-release.md -> "Dependency maintenance"):
 #   - keep every pin within N-1 of upstream;
 #   - never downgrade an already-current pin;
 #   - the new version/SHA must be a strict descendant of the one it replaces.
@@ -69,4 +69,4 @@ else
 fi
 
 echo
-echo "Re-run before every dependency pass. See CLAUDE.md -> \"Dependency maintenance\"."
+echo "Re-run before every dependency pass. See .claude/rules/ci-release.md."

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -5,7 +5,7 @@
 # component so a dependency pass can see, at a glance, what has fallen behind
 # upstream. Read-only: makes no changes.
 #
-# Policy (see AGENTS.md -> "Dependency maintenance"):
+# Policy (see CLAUDE.md -> "Dependency maintenance"):
 #   - keep every pin within N-1 of upstream;
 #   - never downgrade an already-current pin;
 #   - the new version/SHA must be a strict descendant of the one it replaces.
@@ -69,4 +69,4 @@ else
 fi
 
 echo
-echo "Re-run before every dependency pass. See AGENTS.md -> \"Dependency maintenance\"."
+echo "Re-run before every dependency pass. See CLAUDE.md -> \"Dependency maintenance\"."


### PR DESCRIPTION
Two commits: the rename you did, and the size work on top of it.

---

## 1. `mv AGENTS.md CLAUDE.md` (`4cd0ce57`)

Git records it as `R AGENTS.md -> CLAUDE.md`; contents byte-identical except
the `# AGENTS.md` heading and a self-reference to "the destructive-command
list in `AGENTS.md`", now "in this file".

**18 references across 13 files** retargeted so they don't dangle:
CONTRIBUTING.md's architecture link, doc comments in seven Swift files, two
lines of `scripts/check-deps.sh` (one printed to the user),
`docs/accessibility-release-checklist.md`, `Perf/README.md`. `CHANGELOG.md`
keeps its history — including `#988`, "move CLAUDE.md to AGENTS.md", the same
file going the other way.

**Why this matters more than it looks.** Claude Code reads `CLAUDE.md`, not
`AGENTS.md` — so these 382 lines had never once loaded into a session. The
rename is what puts them in context for the first time.

## 2. Scoping the file by when it's needed (`1ded14da`)

56KB in every session, against a documented target of under 200 lines, because
a longer file costs context and measurably reduces adherence.

Split by **when** the guidance is needed, not by topic:

| Stays in `CLAUDE.md` | Moves to `.claude/rules/` | Becomes a skill |
|---|---|---|
| Build and test commands | Subsystem architecture | The subagent swarm flow |
| Workflow, issues, branches, PRs | XCUITest traps | macOS 27 crash triage |
| The five non-negotiable rules | Snapshot harness, CI, localization | |
| A map of where the rest lives | Concurrency detail, terminal renderer | |

Rules carry a `paths:` glob and load when Claude reads a matching file. The
two skills are procedures you invoke, not standing context — and `CLAUDE.md`
keeps a one-line pointer to each so neither can be forgotten.

**Result: 56KB → 13KB always-loaded. 135 lines, under the 200-line target.**

| | Lines | Bytes | Loads |
|---|---:|---:|---|
| `CLAUDE.md` | 135 | 12.9K | always |
| `rules/architecture.md` | 93 | 15.6K | `Pine/**/*.swift` |
| `rules/ci-release.md` | 39 | 5.4K | `.github/**`, `scripts/**` |
| `rules/concurrency.md` | 39 | 3.7K | `Pine/**`, `PineTests/**` |
| `rules/ui-tests.md` | 30 | 3.1K | `PineUITests/**` |
| `rules/snapshot-tests.md` | 17 | 3.2K | `PineTests/SnapshotTests/**` |
| `rules/terminal.md` | 15 | 2.0K | `Pine/Terminal/**`, `QuickTerminal/**` |
| `rules/marketing-surfaces.md` | 16 | 1.9K | `README.md`, `docs/**`, `assets/**` |
| `rules/localization.md` | 10 | 0.7K | `Localizable.xcstrings`, `Strings.swift` |
| `rules/lsp.md` | 9 | 0.7K | `Pine/LSP/**` |
| `skills/agent-swarm` | 129 | 10.8K | invoked by name |
| `skills/macos27-crash-triage` | 17 | 2.5K | invoked by name |

### How the content was moved

Extracted **by anchor, not retyped** — a script pulls each block by a unique
substring and asserts it matched exactly one line. That assert caught a real
ambiguity mid-run (`toolbarTitleMenu` appears in two sections) instead of
silently grabbing the wrong one.

Then a verification pass compares every non-heading line of the old file
against the new set. **Two lines don't appear verbatim, both intentionally:**

- The `PineTests` description that enumerated which subsystems its 180+ files
  cover — condensed, since that list is derivable from the test filenames.
  This is the only content actually dropped.
- `**Diagnosing a test-host crash on the macOS 27 beta** (#1509):` — became
  the skill's own `#` heading.

Everything else survives byte for byte.

### One thing that would have silently broken this

`.gitignore` ignored **all** of `.claude/`, so none of these files would have
reached the repository — the rules would have worked on my machine and nowhere
else. It now ignores the directory's *contents* while letting `rules/` and
`skills/` through. Verified: `settings.local.json`, `worktrees/`, `.DS_Store`
still ignored; the instruction files tracked.

## Verification

| Check | Result |
|---|---|
| Every non-heading line of the old file present in the new set | 2 intentional exceptions above, all else verbatim |
| YAML frontmatter on all 11 files | valid; 9 rules carry `paths`, 2 skills carry `name` + `description` |
| Dangling `## Section` links inside CLAUDE.md | none — two pointing at `## Release & CI` retargeted |
| `git check-ignore` on personal vs instruction files | correct on both sides |
| `swiftlint --strict` on all changed Swift files | clean |
| `bash -n` and a live run of `check-deps.sh` | clean, prints the new path |
| `xcodebuild build` | **could not run — see below** |

**The build could not be verified locally.** This machine's Xcode-beta lost its
Metal Toolchain (`cannot execute tool 'metal'`), and it fails identically on a
stashed clean tree with none of these changes, so it is the environment, not
the diff. The Swift changes here are comment text only and SwiftLint parsed
every one of them. CI on this PR is the real signal.

## Worth knowing

- `CLAUDE.md` still says confirmation is required for "anything in the
  destructive-command list in this file" — there is no such list, and there
  wasn't one in `AGENTS.md` either. Pre-existing; left alone rather than
  inventing a list inside a docs PR.
- `.claude/rules/architecture.md` is 93 lines and the largest single file. If
  it proves noisy when loaded, the natural next split is per-subsystem globs
  (`Pine/Git/**`, `Pine/Syntax/**`, `Pine/Tabs/**`). Not done here — it needs
  real use to know where the seams are.
- Rules and skills are Claude Code mechanisms. The file says so explicitly and
  tells other agents to read the directories as plain markdown.
