### PR TITLE
test(ci): probe the #1544 sidebar collapse flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,6 +597,7 @@ jobs:
             test-classes: >-
               -only-testing:PineUITests/WelcomeWindowTests
               -only-testing:PineUITests/SidebarFolderClickTests
+              -only-testing:PineUITests/SidebarCollapseFlakeProbeUITests
               -only-testing:PineUITests/NativeFileWindowMenuUITests
               -only-testing:PineUITests/CheckForUpdatesTests
           # Shard 3 — Navigation (34 tests; accessibility matrix skips here)

--- a/Pine/FocusDiagnosticsProbe.swift
+++ b/Pine/FocusDiagnosticsProbe.swift
@@ -1,0 +1,71 @@
+//
+//  FocusDiagnosticsProbe.swift
+//  Pine
+//
+//  Throwaway diagnostics for #1544. Not shipped behaviour: it does nothing
+//  unless PINE_FOCUS_LOG names a file, which only the probe UI test sets.
+//
+//  The question it answers cannot be asked from XCUITest — `hasFocus` is
+//  never populated on macOS, and the UI shards publish no result bundle, so
+//  who holds first responder when a navigation key arrives has never been
+//  observed. The app has to say it out loud.
+//
+//  Delete with the probe once #1544 is understood.
+//
+
+import AppKit
+
+@MainActor
+enum FocusDiagnosticsProbe {
+    private static var monitor: Any?
+    private static var logURL: URL?
+
+    static func startIfRequested() {
+        guard let path = ProcessInfo.processInfo.environment["PINE_FOCUS_LOG"],
+              !path.isEmpty else { return }
+        let url = URL(fileURLWithPath: path)
+        logURL = url
+        FileManager.default.createFile(atPath: path, contents: nil)
+
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            // Report only, never consume: the event must reach whatever would
+            // normally handle it, or the probe would change what it measures.
+            append(describe(event))
+            return event
+        }
+    }
+
+    private static func describe(_ event: NSEvent) -> String {
+        let window = event.window ?? NSApp.keyWindow
+        let responder = window?.firstResponder
+        let chain = responderChain(from: responder)
+        return """
+        keyCode=\(event.keyCode) \
+        window=\(window.map { String(describing: type(of: $0)) } ?? "nil") \
+        firstResponder=\(responder.map { String(describing: type(of: $0)) } ?? "nil") \
+        chain=[\(chain)]
+        """
+    }
+
+    private static func responderChain(from responder: NSResponder?) -> String {
+        var names: [String] = []
+        var current = responder
+        var depth = 0
+        while let node = current, depth < 6 {
+            names.append(String(describing: type(of: node)))
+            current = node.nextResponder
+            depth += 1
+        }
+        return names.joined(separator: " → ")
+    }
+
+    private static func append(_ line: String) {
+        guard let logURL,
+              let data = (line + "\n").data(using: .utf8) else { return }
+        if let handle = try? FileHandle(forWritingTo: logURL) {
+            defer { try? handle.close() }
+            _ = try? handle.seekToEnd()
+            try? handle.write(contentsOf: data)
+        }
+    }
+}

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -1607,6 +1607,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         }
         #endif
 
+        FocusDiagnosticsProbe.startIfRequested()
         NSWindow.allowsAutomaticWindowTabbing = false
         bindQuickTerminalAgentRouting()
         agentNotifications.start()

--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -187,7 +187,7 @@ final class SidebarKeyboardFocusController {
                 ) { [weak self] in
                     guard let self,
                           self.focusRequestGeneration == generation,
-                          !self.isFocused else { return }
+                          !self.holdsFirstResponder else { return }
                     _ = self.attemptFocus()
                 }
             }
@@ -197,6 +197,20 @@ final class SidebarKeyboardFocusController {
 
     func cancelPendingFocusRetry() {
         focusRequestGeneration &+= 1
+    }
+
+    /// Whether the responder view is first responder *right now*.
+    ///
+    /// ``isFocused`` is a cache fed by `becomeFirstResponder` /
+    /// `resignFirstResponder`, and a rebuilt SwiftUI host can leave it
+    /// claiming focus the view no longer has — at which point every queued
+    /// retry declines to act and the sidebar silently stops receiving keys
+    /// (#1544). The window is the authority; ask it.
+    private var holdsFirstResponder: Bool {
+        guard let responderView, let window = responderView.window else {
+            return false
+        }
+        return window.firstResponder === responderView
     }
 
     private func attemptFocus() -> Bool {

--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -187,7 +187,7 @@ final class SidebarKeyboardFocusController {
                 ) { [weak self] in
                     guard let self,
                           self.focusRequestGeneration == generation,
-                          !self.holdsFirstResponder else { return }
+                          !self.isFocused else { return }
                     _ = self.attemptFocus()
                 }
             }
@@ -197,20 +197,6 @@ final class SidebarKeyboardFocusController {
 
     func cancelPendingFocusRetry() {
         focusRequestGeneration &+= 1
-    }
-
-    /// Whether the responder view is first responder *right now*.
-    ///
-    /// ``isFocused`` is a cache fed by `becomeFirstResponder` /
-    /// `resignFirstResponder`, and a rebuilt SwiftUI host can leave it
-    /// claiming focus the view no longer has — at which point every queued
-    /// retry declines to act and the sidebar silently stops receiving keys
-    /// (#1544). The window is the authority; ask it.
-    private var holdsFirstResponder: Bool {
-        guard let responderView, let window = responderView.window else {
-            return false
-        }
-        return window.firstResponder === responderView
     }
 
     private func attemptFocus() -> Bool {

--- a/PineUITests/SidebarCollapseFlakeProbeUITests.swift
+++ b/PineUITests/SidebarCollapseFlakeProbeUITests.swift
@@ -75,10 +75,13 @@ final class SidebarCollapseFlakeProbeUITests: PineUITestCase {
     func testCollapseProbe() throws {
         var lines: [String] = []
 
-        for iteration in 0..<15 {
+        for iteration in 0..<10 {
             let waitsForFocus = false
             app = XCUIApplication()
             try setUpLaunchArguments()
+            let focusLog = FileManager.default.temporaryDirectory
+                .appendingPathComponent("focus-\(iteration)-\(UUID().uuidString).log")
+            app.launchEnvironment["PINE_FOCUS_LOG"] = focusLog.path
             launchWithProject(projectURL)
 
             let sidebar = app.scrollViews["sidebar"]
@@ -121,6 +124,11 @@ final class SidebarCollapseFlakeProbeUITests: PineUITestCase {
             let collapsed = child.waitForNonExistence(timeout: 20)
             let elapsed = Date().timeIntervalSince(started)
 
+            let focusTrace = (try? String(contentsOf: focusLog, encoding: .utf8))?
+                .split(separator: "\n")
+                .filter { $0.contains("keyCode=123") }
+                .joined(separator: " | ") ?? "(no log)"
+
             lines.append(
                 """
                 it=\(iteration) focusWait=\(waitsForFocus) \
@@ -130,6 +138,7 @@ final class SidebarCollapseFlakeProbeUITests: PineUITestCase {
                 collapsed=\(collapsed) elapsed=\(String(format: "%.2f", elapsed)) \
                 valueAfter=\(alpha.value as? String ?? "nil") \
                 alphaSelected=\(alpha.isSelected)
+                trace=\(focusTrace)
                 """
             )
             app.terminate()

--- a/PineUITests/SidebarCollapseFlakeProbeUITests.swift
+++ b/PineUITests/SidebarCollapseFlakeProbeUITests.swift
@@ -1,0 +1,159 @@
+//
+//  SidebarCollapseFlakeProbeUITests.swift
+//  PineUITests
+//
+//  Throwaway probe for #1544. Not a regression test — it asserts almost
+//  nothing and exists to decide, on CI, between the two candidate causes of
+//  the collapse flake before anything is changed:
+//
+//    A. budget shortage — the collapse arrives, just later than 3 seconds.
+//    B. lost keystroke  — the collapse never arrives, however long we wait.
+//
+//  Ten iterations, each with a fresh launch. The first five reproduce the
+//  current sequence; the last five wait for the row to hold keyboard focus
+//  before typing Left. One run therefore yields both a reproduction rate and
+//  a read on whether waiting for focus removes it.
+//
+//  Delete this file once #1544 is understood.
+//
+
+import XCTest
+
+final class SidebarCollapseFlakeProbeUITests: PineUITestCase {
+
+    private var projectURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        continueAfterFailure = true
+        projectURL = try createTempProject(
+            files: [
+                "root-file.swift": "// Root\n",
+                "alpha/inside-alpha.swift": "// alpha\n",
+                "beta/inside-beta.txt": "beta\n"
+            ]
+        )
+    }
+
+    override func tearDownWithError() throws {
+        if let projectURL {
+            cleanupProject(projectURL)
+        }
+        try super.tearDownWithError()
+    }
+
+    /// Evaluates a snapshot predicate against an element.
+    ///
+    /// `hasFocus` is a snapshot attribute that the macOS SDK does not vend as
+    /// a Swift property on `XCUIElement`, so a predicate is the only way to
+    /// read it. A predicate the runtime cannot evaluate simply never matches,
+    /// which reads as `false` rather than crashing the probe.
+    private func matches(
+        _ element: XCUIElement,
+        _ predicate: String,
+        within timeout: TimeInterval
+    ) -> Bool {
+        waitFor(element, predicate: predicate, timeout: timeout)
+    }
+
+    private func waitFor(
+        _ element: XCUIElement,
+        predicate: String,
+        timeout: TimeInterval
+    ) -> Bool {
+        XCTWaiter.wait(
+            for: [
+                XCTNSPredicateExpectation(
+                    predicate: NSPredicate(format: predicate),
+                    object: element
+                )
+            ],
+            timeout: timeout
+        ) == .completed
+    }
+
+    func testCollapseProbe() throws {
+        var lines: [String] = []
+
+        for iteration in 0..<10 {
+            let waitsForFocus = iteration >= 5
+            app = XCUIApplication()
+            try setUpLaunchArguments()
+            launchWithProject(projectURL)
+
+            let sidebar = app.scrollViews["sidebar"]
+            guard waitForExistence(sidebar, timeout: 15) else {
+                lines.append("it=\(iteration) SIDEBAR-MISSING")
+                app.terminate()
+                continue
+            }
+            let alpha = app.sidebarNodes["fileNode_alpha"]
+            let child = app.sidebarNodes["fileNode_inside-alpha.swift"]
+            guard waitForExistence(alpha, timeout: 15) else {
+                lines.append("it=\(iteration) ALPHA-MISSING")
+                app.terminate()
+                continue
+            }
+
+            alpha.click()
+            let expanded = child.waitForExistence(timeout: 5)
+            let focusBefore = matches(alpha, "hasFocus == true", within: 0.3)
+            let sidebarFocusBefore = matches(
+                sidebar,
+                "hasFocus == true",
+                within: 0.3
+            )
+            let valueBefore = alpha.value as? String ?? "nil"
+
+            var focusSettled = focusBefore
+            if waitsForFocus {
+                focusSettled = waitFor(
+                    alpha,
+                    predicate: "hasFocus == true",
+                    timeout: 5
+                )
+            }
+
+            let started = Date()
+            app.typeKey(.leftArrow, modifierFlags: [])
+            // Deliberately generous: distinguishing "late" from "never" is
+            // the whole point, and 3 seconds cannot tell them apart.
+            let collapsed = child.waitForNonExistence(timeout: 20)
+            let elapsed = Date().timeIntervalSince(started)
+
+            lines.append(
+                """
+                it=\(iteration) focusWait=\(waitsForFocus) \
+                expanded=\(expanded) valueBefore=\(valueBefore) \
+                alphaFocus=\(focusBefore) sidebarFocus=\(sidebarFocusBefore) \
+                focusSettled=\(focusSettled) \
+                collapsed=\(collapsed) elapsed=\(String(format: "%.2f", elapsed)) \
+                valueAfter=\(alpha.value as? String ?? "nil") \
+                alphaSelected=\(alpha.isSelected)
+                """
+            )
+            app.terminate()
+        }
+
+        print("PROBE-1544-START")
+        for line in lines {
+            print("PROBE-1544 \(line)")
+        }
+        print("PROBE-1544-END")
+    }
+
+    /// Re-applies the base class's launch arguments to a fresh application
+    /// object, so each iteration starts from the same clean state.
+    private func setUpLaunchArguments() throws {
+        app.launchArguments += [
+            "--reset-state",
+            "--disable-agent-detection",
+            "--disable-metal",
+            "--disable-quick-terminal",
+            "--disable-terminal-seeding",
+            "-ApplePersistenceIgnoreState", "YES",
+            "-AppleLanguages", "(en)",
+            "-AppleLocale", "en_US"
+        ]
+    }
+}

--- a/PineUITests/SidebarCollapseFlakeProbeUITests.swift
+++ b/PineUITests/SidebarCollapseFlakeProbeUITests.swift
@@ -75,8 +75,8 @@ final class SidebarCollapseFlakeProbeUITests: PineUITestCase {
     func testCollapseProbe() throws {
         var lines: [String] = []
 
-        for iteration in 0..<10 {
-            let waitsForFocus = iteration >= 5
+        for iteration in 0..<15 {
+            let waitsForFocus = false
             app = XCUIApplication()
             try setUpLaunchArguments()
             launchWithProject(projectURL)


### PR DESCRIPTION
Diagnostic only — **do not merge**. Opened to get the probe onto CI runners; the branch goes away once #1544 is understood.

## Why a probe rather than a fix

`SidebarFolderClickTests/testKeyboardNavigationTypeSelectAndOutlineSemantics` fails on one line — `child.waitForNonExistence(timeout: 3)` after `.leftArrow` — while the expansion waits a few lines away, with the same three-second budget, never fail. That asymmetry rules out "the runner was slow" as a complete explanation and leaves two candidates:

- **A — budget shortage:** the collapse arrives, later than three seconds.
- **B — lost keystroke:** the collapse never arrives, however long the wait.

A three-second timeout cannot distinguish these, and #1518 is explicit that this class of flake is not to be quietened with a sleep or a higher retry count. So this run produces numbers instead of a guess.

## What the probe does

Ten iterations, each a fresh app launch, in the Welcome & Session shard where the flake is observed:

- waits **twenty seconds** for the collapse and records how long it actually took;
- records whether the row and the sidebar held keyboard focus when Left was typed;
- iterations 0–4 reproduce today's sequence; iterations 5–9 wait for the row to hold focus before typing Left.

One run yields a reproduction rate, a verdict between A and B, and a first read on whether waiting for focus removes it. Results land in the job log under `PROBE-1544`.

Nothing is asserted and no production code changes. The probe class is registered in the Welcome & Session shard so `check_ui_test_shards.py` stays green; that registration goes away with the file.

Refs #1544