### PR TITLE
fix(accessibility): name the icon-only controls VoiceOver announced as buttons

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -106,8 +106,12 @@ struct ContentView: View {
                         }
                     } label: {
                         Image(systemName: "folder.badge.plus")
+                            .accessibilityHidden(true)
                     }
                     .help(Strings.openFolderTooltip)
+                    // A help tag maps to AXHelp, not AXTitle, so this button
+                    // reached VoiceOver as an unnamed one (#1527).
+                    .accessibilityLabel(Strings.openFolderTooltip)
                     .accessibilityIdentifier(
                         AccessibilityID.openFolderToolbarButton
                     )

--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -434,6 +434,7 @@ struct EditorTabBar: View {
                 .menuIndicator(.hidden)
                 .fixedSize()
                 .frame(width: 24, height: 30)
+                .accessibilityLabel(Strings.a11yEditorTabOverflowLabel)
                 .accessibilityIdentifier(AccessibilityID.editorTabOverflowMenu)
             }
 

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -23442,6 +23442,66 @@
         }
       }
     },
+    "a11y.editorTab.overflow.label": {
+      "comment" : "Accessibility label for the editor tab bar's overflow menu, which lists tabs that do not fit.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weitere Tabs"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "More tabs"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más pestañas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autres onglets"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "その他のタブ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기타 탭"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mais abas"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Другие вкладки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更多标签页"
+          }
+        }
+      }
+    },
     "a11y.editorTab.preview.value": {
       "comment": "VoiceOver value identifying a replaceable transient preview tab.",
       "extractionState": "manual",

--- a/Pine/StatusBarView.swift
+++ b/Pine/StatusBarView.swift
@@ -85,8 +85,15 @@ struct StatusBarView: View {
                     Image(systemName: waitingCount > 0 ? "bell.badge.fill" : "bell")
                         .font(.system(size: LayoutMetrics.captionFontSize))
                         .foregroundStyle(waitingCount > 0 ? .orange : .secondary)
+                        .accessibilityHidden(true)
                 }
                 .buttonStyle(.plain)
+                // The badge is the whole signal, and it is drawn only. How
+                // many agents are waiting has to be said, not shown (#1527).
+                .accessibilityLabel(Strings.agentAttentionTitle)
+                .accessibilityValue(
+                    Strings.agentInboxToolbarAttentionCount(waitingCount)
+                )
                 .accessibilityIdentifier(AccessibilityID.agentAttentionBell)
             }
 

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -3033,6 +3033,13 @@ enum Strings {
     static let a11yPaneDividerHint: String =
         String(localized: "a11y.paneDivider.hint", defaultValue: "Drag to resize the panes")
 
+    // Editor tab bar
+    static let a11yEditorTabOverflowLabel: String =
+        String(
+            localized: "a11y.editorTab.overflow.label",
+            defaultValue: "More tabs"
+        )
+
     // Minimap
     static let a11yMinimapLabel: String =
         String(localized: "a11y.minimap.label", defaultValue: "Minimap")

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -423,10 +423,13 @@ struct TerminalPaneTabBar: View {
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundStyle(.secondary)
                     .frame(width: 24, height: 24)
+                    .accessibilityHidden(true)
             }
             .buttonStyle(.plain)
             .padding(.trailing, 4)
             .help(Strings.hideTerminal)
+            .accessibilityLabel(Strings.a11yCloseTerminalLabel)
+            .accessibilityHint(Strings.a11yCloseTerminalHint)
             .accessibilityIdentifier(AccessibilityID.hideTerminalButton)
         }
         .frame(height: LayoutMetrics.tabBarHeight)

--- a/Pine/TerminalSearchBar.swift
+++ b/Pine/TerminalSearchBar.swift
@@ -59,6 +59,11 @@ struct TerminalSearchBar: View {
             }
             .buttonStyle(.borderless)
             .help(Strings.terminalSearchCaseSensitiveTooltip)
+            .accessibilityLabel(Strings.terminalSearchCaseSensitiveTooltip)
+            // A toggle has to say which way it is set, or VoiceOver
+            // announces the same thing on and off. The selected trait is the
+            // native way to say it and needs no string of its own (#1527).
+            .accessibilityAddTraits(caseSensitive ? [.isSelected] : [])
             .accessibilityIdentifier(AccessibilityID.terminalSearchCaseSensitive)
 
             Divider().frame(height: 16)
@@ -66,19 +71,23 @@ struct TerminalSearchBar: View {
             Button(action: onPrevious) {
                 Image(systemName: "chevron.up")
                     .imageScale(.small)
+                    .accessibilityHidden(true)
             }
             .buttonStyle(.borderless)
             .disabled(matchCount == 0)
             .help(Strings.terminalSearchPreviousTooltip)
+            .accessibilityLabel(Strings.terminalSearchPreviousTooltip)
             .accessibilityIdentifier(AccessibilityID.terminalSearchPrevious)
 
             Button(action: onNext) {
                 Image(systemName: "chevron.down")
                     .imageScale(.small)
+                    .accessibilityHidden(true)
             }
             .buttonStyle(.borderless)
             .disabled(matchCount == 0)
             .help(Strings.terminalSearchNextTooltip)
+            .accessibilityLabel(Strings.terminalSearchNextTooltip)
             .accessibilityIdentifier(AccessibilityID.terminalSearchNext)
 
             Divider().frame(height: 16)
@@ -86,8 +95,10 @@ struct TerminalSearchBar: View {
             Button(action: onDismiss) {
                 Image(systemName: "xmark")
                     .imageScale(.small)
+                    .accessibilityHidden(true)
             }
             .buttonStyle(.borderless)
+            .accessibilityLabel(Strings.terminalSearchCloseTooltip)
             .help(Strings.terminalSearchCloseTooltip)
             .accessibilityIdentifier(AccessibilityID.terminalSearchClose)
         }

--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -145,8 +145,13 @@ struct WelcomeView: View {
                             isSearchVisible.toggle()
                         } label: {
                             Image(systemName: "magnifyingglass")
+                                .accessibilityHidden(true)
                         }
                         .buttonStyle(.borderless)
+                        .accessibilityLabel(Strings.welcomeSearchPlaceholder)
+                        .accessibilityAddTraits(
+                            isSearchVisible ? [.isSelected] : []
+                        )
                         .accessibilityIdentifier(AccessibilityID.welcomeSearchToggle)
                     }
                 }

--- a/PineTests/IconOnlyControlLabelGuardTests.swift
+++ b/PineTests/IconOnlyControlLabelGuardTests.swift
@@ -1,0 +1,77 @@
+//
+//  IconOnlyControlLabelGuardTests.swift
+//  PineTests
+//
+//  The guard half of #1527. Labelling the nine controls found by hand fixes
+//  those nine; it does nothing about the tenth, added next month. So the
+//  invariant is stated over the source: a control that carries an
+//  accessibility identifier is a control someone reaches, and it must also
+//  carry a name.
+//
+
+import Foundation
+import Testing
+
+@Suite("Icon-only controls carry an accessibility label")
+struct IconOnlyControlLabelGuardTests {
+
+    /// Files whose interactive chrome reached VoiceOver unnamed (#1527).
+    nonisolated static let auditedFiles = [
+        "ContentView.swift",
+        "TerminalSearchBar.swift",
+        "StatusBarView.swift",
+        "EditorTabBar.swift",
+        "TerminalPaneTabBar.swift",
+        "WelcomeView.swift"
+    ]
+
+    private static func sourceDirectory() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // PineTests
+            .deletingLastPathComponent()   // repository root
+            .appendingPathComponent("Pine")
+    }
+
+    /// An icon-only control that carries an identifier but no name.
+    ///
+    /// Scoped to controls whose entire content is an SF Symbol, which is what
+    /// #1527 is about: a text button already names itself, and a container
+    /// names itself through its children. Deliberately textual — the point is
+    /// to fail on a source pattern before anyone has to run VoiceOver, the
+    /// same way `MenuHardcodedShortcutGuard` states its rule over the source.
+    @Test(arguments: auditedFiles)
+    func identifiedControlsAreNamed(_ fileName: String) throws {
+        let url = Self.sourceDirectory().appendingPathComponent(fileName)
+        let source = try String(contentsOf: url, encoding: .utf8)
+        let lines = source.split(separator: "\n", omittingEmptySubsequences: false)
+
+        var unnamed: [Int] = []
+        for (index, line) in lines.enumerated()
+        where line.contains(".accessibilityIdentifier(") {
+            let start = max(0, index - 12)
+            let end = min(lines.count - 1, index + 6)
+            let window = lines[start...end].joined(separator: "\n")
+
+            // Only icon-only controls are in scope.
+            guard window.contains("Image(systemName:") else { continue }
+            let namesItself = window.contains(".accessibilityLabel(")
+                || window.contains(".accessibilityElement(children: .contain)")
+                || window.contains(".accessibilityRepresentation")
+                || window.contains("Text(")
+                || window.contains("Label(")
+            if !namesItself {
+                unnamed.append(index + 1)
+            }
+        }
+
+        #expect(
+            unnamed.isEmpty,
+            """
+            \(fileName): controls carry an accessibility identifier but no \
+            name, at line(s) \(unnamed.map(String.init).joined(separator: ", ")). \
+            A help tag is AXHelp, not AXTitle — VoiceOver announces these as \
+            unnamed buttons (#1527).
+            """
+        )
+    }
+}


### PR DESCRIPTION
Closes #1527. Ready to merge once CI is green.

Nine controls made of nothing but an SF Symbol reached VoiceOver as unnamed buttons. Several carried `.help(...)` — that is AXHelp, not AXTitle, so a tooltip named nothing.

## What changed

| Control | Label |
|---|---|
| Toolbar Open Folder | `sidebar.openFolderTooltip` |
| Terminal search: Match Case | tooltip + native `.isSelected` trait |
| Terminal search: previous / next / close | their existing tooltips |
| Agent attention bell | `agentAttention.title` + waiting count as value |
| Editor tab overflow menu | new `a11y.editorTab.overflow.label` |
| Terminal pane close | `a11y.terminal.close.label` + hint |
| Welcome search toggle | `welcome.searchPlaceholder` + `.isSelected` |

Decorative symbols inside labelled controls are hidden, so each control speaks once.

## Three things worth a reviewer's attention

**Almost no new strings.** Eight of the nine labels reuse wording that already exists and is already translated into all eight non-English locales. Only the tab overflow menu had no existing phrasing; that one entry was inserted in all nine locales by targeted text edit, never by reserializing the catalog.

**Two of #1529's "dead" accessors are now alive.** `a11yCloseTerminalLabel` and `a11yCloseTerminalHint` were written for this exact button and never connected. This is why the stack order matters: #1529 would otherwise delete strings that #1527 and #1532 are about to need. Verified on current main — 15 accessors still unreferenced, 19 `a11y.*` keys still English in every locale.

**The bell says how many.** Its badge is the entire signal and it is drawn only, so the count is exposed as the accessibility value through the existing pluralized `agentInboxToolbarAttentionCount`. Toggles use the native selected trait instead of a hand-written on/off string.

## Guard

`IconOnlyControlLabelGuardTests` states the rule over the source: an icon-only control carrying an accessibility identifier must also carry a name. Labelling these nine does nothing about the tenth, added next month.

The first version of the guard was broader and flagged six more sites; five were text buttons and containers that name themselves, so it is scoped to controls whose whole content is an SF Symbol. The sixth was real but out of scope: `EditorTabBar`'s `Button("Close")` is a hardcoded English literal in a shipped control. Left for #1536, which owns untranslated surfaces.

## Verification

- `build-for-testing` clean.
- 24 tests across `IconOnlyControlLabelGuardTests`, `LocalizationCatalogCompletenessTests`, `AccessibilityLocalizationMatrixTests`, `StatusBarAccessibilityHostedTests`, `PaneDividerAccessibilityTests` pass.
- VoiceOver itself was not driven: XCUITest cannot launch the app on this machine (no automation rights), so the announcements are asserted through the catalog and the guard, not heard. Worth a manual pass before the release.