### PR TITLE
fix(ci): tolerate sub-second mtime skew in validator self-test

### DIFF
--- a/scripts/tests/test-validate-test-results.sh
+++ b/scripts/tests/test-validate-test-results.sh
@@ -134,7 +134,12 @@ run_validator() {
 }
 
 fresh_bundle="$TEST_ROOT/fresh.xcresult"
-start_time="$(date +%s)"
+# GNU date +%s rounds to the nearest second, so it can report a whole second
+# slightly ahead of the bundle mtime set milliseconds later, tripping the
+# freshness check this suite exercises. Bias the synthetic start one second
+# into the past; the stale-bundle case pins start_time 3600s ahead and keeps
+# failing closed (#1576).
+start_time="$(( $(date +%s) - 1 ))"
 mkdir "$fresh_bundle"
 
 run_validator 0 "successful run reports every result category" \


### PR DESCRIPTION
Closes #1576

## What

The `Tests for unit-test result validation` step inside the SwiftLint job intermittently fails: GNU `date +%s` rounds to the nearest second, so the synthetic bundle's mtime can land a fraction of a second *behind* the captured `start_time`, and the validator's fail-closed freshness check rejects the run. Seen on #1575 (run [32975885982](https://github.com/batonogov/pine/actions/runs/32975885982/job/98200391623)); the PR diff was blameless.

The fix biases the self-test's synthetic start one second into the past. Every consumer of `start_time` in the suite:

- fresh-bundle cases — margin grows by 1 s, still passing;
- stale-bundle case — pins `future_start="$((start_time + 3600))"`, still ~an hour ahead of the bundle mtime, still failing closed;
- explicit-summary and GitHub-summary cases — unaffected (fresh bundle).

Production CI jobs are not exposed to the race: they capture `TEST_STARTED_AT` before `xcodebuild` and the result bundle is created minutes later.

## Testing

- `bash -n` syntax check locally.
- Self-test suite itself runs in CI on this PR (SwiftLint job).
- No Swift code touched; no unit/UI test surface changes.