### PR TITLE
fix(tests): stop test runs writing into the production UserDefaults domain

### DIFF
--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -364,7 +364,7 @@ final class ProjectManager {
     /// fallback used by project-level commands while no editor pane exists.
     let primaryTabManager = TabManager()
     let searchProvider = ProjectSearchProvider()
-    let quickOpenProvider = QuickOpenProvider()
+    let quickOpenProvider: QuickOpenProvider
     let progress = ProgressTracker()
     let contextFileWriter: ContextFileWriter
     /// Language Server Protocol manager — owns per-language server processes
@@ -1686,6 +1686,7 @@ final class ProjectManager {
             ContextPresentationIdentity(epoch: 1)
     ) {
         self.sessionDefaults = sessionDefaults
+        self.quickOpenProvider = QuickOpenProvider(defaults: sessionDefaults)
         self.workspace = WorkspaceManager(
             filesystemValidationSeam: workspaceFilesystemValidationSeam
         )

--- a/Pine/QuickOpenProvider.swift
+++ b/Pine/QuickOpenProvider.swift
@@ -37,6 +37,14 @@ final class QuickOpenProvider {
     /// The original (unresolved) root path prefix for computing relative paths.
     private var originalRootPrefix: String = ""
 
+    /// Store for recent files. Injectable so tests can point it at a scoped
+    /// suite instead of the production domain (#1554).
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
     // MARK: - Indexing
 
     /// Maximum recursion depth when traversing the file tree for indexing.
@@ -250,13 +258,13 @@ final class QuickOpenProvider {
     private func loadRecentFiles() -> [String] {
         guard let root = indexedRoot else { return [] }
         let key = Self.recentFilesKey + "." + root.path
-        return UserDefaults.standard.stringArray(forKey: key) ?? []
+        return defaults.stringArray(forKey: key) ?? []
     }
 
     private func saveRecentFiles(_ files: [String]) {
         guard let root = indexedRoot else { return }
         let key = Self.recentFilesKey + "." + root.path
-        UserDefaults.standard.set(files, forKey: key)
+        defaults.set(files, forKey: key)
     }
 
     // MARK: - Helpers

--- a/PineTests/MultiPaneIntegrationTests.swift
+++ b/PineTests/MultiPaneIntegrationTests.swift
@@ -178,12 +178,14 @@ struct MultiPaneIntegrationTests {
 
     @Test func saveSession_includesTabsFromAllPanes() throws {
         let (dir, files) = try makeTempProject()
+        let suiteName = "PineTests.MultiPaneSession.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer {
+            defaults.removePersistentDomain(forName: suiteName)
             cleanup(dir)
-            SessionState.clear(for: dir)
         }
 
-        let pm = ProjectManager()
+        let pm = ProjectManager(sessionDefaults: defaults)
         pm.workspace.loadDirectory(url: dir)
 
         let firstPaneID = pm.paneManager.activePaneID
@@ -198,7 +200,7 @@ struct MultiPaneIntegrationTests {
 
         pm.saveSession()
 
-        let session = SessionState.load(for: dir)
+        let session = SessionState.load(for: dir, defaults: defaults)
         #expect(session != nil)
         let savedPaths = session?.openFilePaths ?? []
         #expect(savedPaths.count == 3)

--- a/PineTests/ProductionDefaultsIsolationTests.swift
+++ b/PineTests/ProductionDefaultsIsolationTests.swift
@@ -100,16 +100,16 @@ struct ProductionDefaultsIsolationTests {
         #expect(SessionState.load(for: canonical, defaults: defaults)?.openFilePaths == [file.path])
     }
 
-    @Test("removePersistentDomain fully wipes a scoped suite")
-    func scopedSuiteTearDownRemovesDomain() throws {
-        let suiteName = "PineTests.Isolation.Wipe.\(UUID().uuidString)"
+    @Test("writes to a scoped suite stay invisible to the production domain")
+    func scopedSuiteWritesAreInvisibleToProduction() throws {
+        let suiteName = "PineTests.Isolation.Visibility.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defaults.set(["leak"], forKey: "probe")
-        #expect(defaults.stringArray(forKey: "probe") == ["leak"])
+        defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        defaults.removePersistentDomain(forName: suiteName)
+        let probeKey = "PineTests.Isolation.VisibilityProbe"
+        defaults.set(["scoped"], forKey: probeKey)
 
-        let reopened = try #require(UserDefaults(suiteName: suiteName))
-        #expect(reopened.dictionaryRepresentation().isEmpty)
+        #expect(defaults.stringArray(forKey: probeKey) == ["scoped"])
+        #expect(UserDefaults.standard.stringArray(forKey: probeKey) == nil)
     }
 }

--- a/PineTests/ProductionDefaultsIsolationTests.swift
+++ b/PineTests/ProductionDefaultsIsolationTests.swift
@@ -1,0 +1,115 @@
+//
+//  ProductionDefaultsIsolationTests.swift
+//  PineTests
+//
+//  Regression guard for #1554: production types that accept an injected
+//  `UserDefaults` must keep every write inside the injected suite. A call
+//  site that lets the `.standard` default slip through leaks throwaway test
+//  fixtures into the developer's real preference domain — the exact defect
+//  that accumulated 618 dead keys on the maintainer's machine.
+//
+//  Leak detection keys off the fixture's temporary path: both `sessionState:`
+//  and `quickOpen.recentFiles.` keys embed the project root path, so a leaked
+//  write is always visible as a key containing that path. Filtering by the
+//  path keeps the guard immune to unrelated AppKit keys appearing in
+//  `.standard` while the suite runs.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Production Defaults Isolation")
+@MainActor
+struct ProductionDefaultsIsolationTests {
+
+    private func makeFixtureProject() throws -> (dir: URL, file: URL) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineTests-Isolation-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("main.swift")
+        try "let value = 1".write(to: file, atomically: true, encoding: .utf8)
+        return (dir, file)
+    }
+
+    /// Production-domain keys that embed the given path — i.e. leaked writes.
+    private func leakedProductionKeys(containing path: String) -> Set<String> {
+        Set(
+            UserDefaults.standard.dictionaryRepresentation().keys
+                .filter { $0.contains(path) }
+        )
+    }
+
+    @Test("ProjectManager.saveSession stays inside the injected sessionDefaults suite")
+    func projectManagerSaveSessionStaysScoped() throws {
+        let (dir, file) = try makeFixtureProject()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let suiteName = "PineTests.Isolation.PMSession.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let pm = ProjectManager(sessionDefaults: defaults)
+        pm.workspace.loadDirectory(url: dir)
+        pm.primaryTabManager.openTab(url: file)
+        pm.saveSession()
+
+        let canonical = dir.resolvingSymlinksInPath()
+        #expect(leakedProductionKeys(containing: canonical.path).isEmpty)
+        #expect(leakedProductionKeys(containing: dir.path).isEmpty)
+        // The session itself must be present in the injected suite.
+        #expect(SessionState.load(for: canonical, defaults: defaults) != nil)
+    }
+
+    @Test("QuickOpenProvider recents stay inside the injected suite")
+    func quickOpenRecentsStayScoped() throws {
+        let (dir, file) = try makeFixtureProject()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let suiteName = "PineTests.Isolation.QuickOpen.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let root = FileNode(url: dir, projectRoot: dir)
+        let provider = QuickOpenProvider(defaults: defaults)
+        provider.buildIndex(from: [root], rootURL: dir)
+
+        provider.recordOpened(url: file)
+        _ = provider.search(query: "")
+
+        #expect(leakedProductionKeys(containing: dir.resolvingSymlinksInPath().path).isEmpty)
+        // The recents list must be readable back from the injected suite.
+        let results = provider.search(query: "")
+        #expect(results.map(\.fileName) == ["main.swift"])
+    }
+
+    @Test("SessionState.save with an injected suite stays out of the production domain")
+    func sessionStateSaveStaysScoped() throws {
+        let (dir, file) = try makeFixtureProject()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let suiteName = "PineTests.Isolation.SessionState.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        SessionState.save(projectURL: dir, openFileURLs: [file], defaults: defaults)
+
+        let canonical = dir.resolvingSymlinksInPath()
+        #expect(leakedProductionKeys(containing: canonical.path).isEmpty)
+        #expect(SessionState.load(for: canonical, defaults: defaults)?.openFilePaths == [file.path])
+    }
+
+    @Test("removePersistentDomain fully wipes a scoped suite")
+    func scopedSuiteTearDownRemovesDomain() throws {
+        let suiteName = "PineTests.Isolation.Wipe.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.set(["leak"], forKey: "probe")
+        #expect(defaults.stringArray(forKey: "probe") == ["leak"])
+
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let reopened = try #require(UserDefaults(suiteName: suiteName))
+        #expect(reopened.dictionaryRepresentation().isEmpty)
+    }
+}

--- a/PineTests/ProjectManagerInteractionSessionSaveTests.swift
+++ b/PineTests/ProjectManagerInteractionSessionSaveTests.swift
@@ -16,8 +16,10 @@ struct InteractionSessionSaveTests {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("PineSessionSave-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let suiteName = "PineTests.InteractionSessionSave.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer {
-            SessionState.clear(for: root)
+            defaults.removePersistentDomain(forName: suiteName)
             try? FileManager.default.removeItem(at: root)
         }
         let firstURL = root.appendingPathComponent("first.swift")
@@ -25,7 +27,7 @@ struct InteractionSessionSaveTests {
         try Data("let first = 1\n".utf8).write(to: firstURL)
         try Data("let second = 2\n".utf8).write(to: secondURL)
 
-        let projectManager = ProjectManager()
+        let projectManager = ProjectManager(sessionDefaults: defaults)
         projectManager.workspace.loadDirectory(url: root)
         let firstPane = projectManager.paneManager.activePaneID
         let firstManager = try #require(
@@ -62,7 +64,7 @@ struct InteractionSessionSaveTests {
         projectManager.saveSession()
 
         let session = try #require(
-            SessionState.load(for: root.resolvingSymlinksInPath())
+            SessionState.load(for: root.resolvingSymlinksInPath(), defaults: defaults)
         )
         #expect(session.activePaneID == secondPane.id.uuidString)
         #expect(session.paneActiveEditorPaths == [

--- a/PineTests/ProjectManagerSessionTests.swift
+++ b/PineTests/ProjectManagerSessionTests.swift
@@ -30,13 +30,25 @@ struct ProjectManagerSessionTests {
         try? FileManager.default.removeItem(at: url)
     }
 
+    private let suiteName = "PineTests.ProjectManagerSession.\(UUID().uuidString)"
+
+    private func makeDefaults() throws -> UserDefaults {
+        try #require(UserDefaults(suiteName: suiteName))
+    }
+
+    private func cleanupDefaults() {
+        UserDefaults().removePersistentDomain(forName: suiteName)
+    }
+
     // MARK: - saveSession basics
 
     @Test func saveSessionPersistsOpenTabs() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
-        let pm = ProjectManager()
+        let pm = ProjectManager(sessionDefaults: defaults)
         pm.workspace.loadDirectory(url: dir)
 
         pm.primaryTabManager.openTab(url: files[0])
@@ -44,7 +56,7 @@ struct ProjectManagerSessionTests {
         pm.saveSession()
 
         let canonical = dir.resolvingSymlinksInPath()
-        let session = SessionState.load(for: canonical)
+        let session = SessionState.load(for: canonical, defaults: defaults)
         #expect(session != nil)
         #expect(session?.existingFileURLs.count == 2)
         #expect(session?.existingFileURLs.contains(files[0]) == true)
@@ -54,8 +66,10 @@ struct ProjectManagerSessionTests {
     @Test func saveSessionPersistsActiveTab() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
-        let pm = ProjectManager()
+        let pm = ProjectManager(sessionDefaults: defaults)
         pm.workspace.loadDirectory(url: dir)
 
         pm.primaryTabManager.openTab(url: files[0])
@@ -64,13 +78,15 @@ struct ProjectManagerSessionTests {
         pm.saveSession()
 
         let canonical = dir.resolvingSymlinksInPath()
-        let session = SessionState.load(for: canonical)
+        let session = SessionState.load(for: canonical, defaults: defaults)
         #expect(session?.activeFileURL == files[1])
     }
 
     @Test func saveSessionFiltersFilesOutsideProject() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
         // Create a file outside the project
         let outsideDir = FileManager.default.temporaryDirectory
@@ -80,7 +96,7 @@ struct ProjectManagerSessionTests {
         let outsideFile = outsideDir.appendingPathComponent("external.swift")
         try "external".write(to: outsideFile, atomically: true, encoding: .utf8)
 
-        let pm = ProjectManager()
+        let pm = ProjectManager(sessionDefaults: defaults)
         pm.workspace.loadDirectory(url: dir)
 
         pm.primaryTabManager.openTab(url: files[0])
@@ -88,7 +104,7 @@ struct ProjectManagerSessionTests {
         pm.saveSession()
 
         let canonical = dir.resolvingSymlinksInPath()
-        let session = SessionState.load(for: canonical)
+        let session = SessionState.load(for: canonical, defaults: defaults)
         #expect(session?.existingFileURLs.count == 1)
         #expect(session?.existingFileURLs.first == files[0])
     }
@@ -96,22 +112,26 @@ struct ProjectManagerSessionTests {
     @Test func saveSessionNoOpWithoutRootURL() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
-        let pm = ProjectManager()
+        let pm = ProjectManager(sessionDefaults: defaults)
         // Do NOT call loadDirectory — rootURL stays nil
         pm.primaryTabManager.openTab(url: files[0])
         pm.saveSession()
 
         let canonical = dir.resolvingSymlinksInPath()
-        let session = SessionState.load(for: canonical)
+        let session = SessionState.load(for: canonical, defaults: defaults)
         #expect(session == nil)
     }
 
     @Test func saveSessionOverwritesPreviousSession() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
-        let pm = ProjectManager()
+        let pm = ProjectManager(sessionDefaults: defaults)
         pm.workspace.loadDirectory(url: dir)
 
         // First save with 2 tabs
@@ -124,7 +144,7 @@ struct ProjectManagerSessionTests {
         pm.saveSession()
 
         let canonical = dir.resolvingSymlinksInPath()
-        let session = SessionState.load(for: canonical)
+        let session = SessionState.load(for: canonical, defaults: defaults)
         #expect(session?.existingFileURLs.count == 3)
     }
 
@@ -133,9 +153,11 @@ struct ProjectManagerSessionTests {
     @Test func fullLifecycleOpenSaveRestore() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
         // Phase 1: open tabs and save
-        let pm1 = ProjectManager()
+        let pm1 = ProjectManager(sessionDefaults: defaults)
         pm1.workspace.loadDirectory(url: dir)
         pm1.primaryTabManager.openTab(url: files[0])
         pm1.primaryTabManager.openTab(url: files[1])
@@ -147,11 +169,11 @@ struct ProjectManagerSessionTests {
         pm1.saveSession()
 
         // Phase 2: simulate reopen — new PM, load session, restore tabs
-        let pm2 = ProjectManager()
+        let pm2 = ProjectManager(sessionDefaults: defaults)
         pm2.workspace.loadDirectory(url: dir)
 
         let canonical = dir.resolvingSymlinksInPath()
-        let session = try #require(SessionState.load(for: canonical))
+        let session = try #require(SessionState.load(for: canonical, defaults: defaults))
 
         for url in session.existingFileURLs {
             pm2.primaryTabManager.openTab(url: url)
@@ -172,6 +194,8 @@ struct ProjectManagerSessionTests {
     @Test func saveSessionFiltersActiveFileOutsideProject() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
         let outsideDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("PineTests-outside-\(UUID().uuidString)")
@@ -180,7 +204,7 @@ struct ProjectManagerSessionTests {
         let outsideFile = outsideDir.appendingPathComponent("external.swift")
         try "external".write(to: outsideFile, atomically: true, encoding: .utf8)
 
-        let pm = ProjectManager()
+        let pm = ProjectManager(sessionDefaults: defaults)
         pm.workspace.loadDirectory(url: dir)
 
         pm.primaryTabManager.openTab(url: files[0])
@@ -189,7 +213,7 @@ struct ProjectManagerSessionTests {
         pm.saveSession()
 
         let canonical = dir.resolvingSymlinksInPath()
-        let session = SessionState.load(for: canonical)
+        let session = SessionState.load(for: canonical, defaults: defaults)
         // Active file outside project root should be cleared
         #expect(session?.activeFilePath == nil)
     }
@@ -197,6 +221,8 @@ struct ProjectManagerSessionTests {
     @Test func saveSessionFiltersPreviewModesOutsideProject() throws {
         let (dir, _) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
         let outsideDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("PineTests-outside-\(UUID().uuidString)")
@@ -208,7 +234,7 @@ struct ProjectManagerSessionTests {
         try "# Inside".write(to: insideMd, atomically: true, encoding: .utf8)
         try "# Outside".write(to: outsideMd, atomically: true, encoding: .utf8)
 
-        let pm = ProjectManager()
+        let pm = ProjectManager(sessionDefaults: defaults)
         pm.workspace.loadDirectory(url: dir)
 
         pm.primaryTabManager.openTab(url: insideMd)
@@ -220,7 +246,7 @@ struct ProjectManagerSessionTests {
         pm.saveSession()
 
         let canonical = dir.resolvingSymlinksInPath()
-        let session = SessionState.load(for: canonical)
+        let session = SessionState.load(for: canonical, defaults: defaults)
         // Only inside markdown should have preview mode persisted
         #expect(session?.previewModes?.count == 1)
         #expect(session?.previewModes?[insideMd.path] == "split")
@@ -230,6 +256,8 @@ struct ProjectManagerSessionTests {
     @Test func saveSessionFiltersHighlightingDisabledOutsideProject() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
         let outsideDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("PineTests-outside-\(UUID().uuidString)")
@@ -238,7 +266,7 @@ struct ProjectManagerSessionTests {
         let outsideFile = outsideDir.appendingPathComponent("big.swift")
         try "big".write(to: outsideFile, atomically: true, encoding: .utf8)
 
-        let pm = ProjectManager()
+        let pm = ProjectManager(sessionDefaults: defaults)
         pm.workspace.loadDirectory(url: dir)
 
         pm.primaryTabManager.openTab(url: files[0])
@@ -249,7 +277,7 @@ struct ProjectManagerSessionTests {
         pm.saveSession()
 
         let canonical = dir.resolvingSymlinksInPath()
-        let session = SessionState.load(for: canonical)
+        let session = SessionState.load(for: canonical, defaults: defaults)
         // Only inside file should be persisted
         #expect(session?.highlightingDisabledPaths?.count == 1)
         #expect(session?.highlightingDisabledPaths?.first == files[0].path)
@@ -258,8 +286,10 @@ struct ProjectManagerSessionTests {
     @Test func saveSessionPersistsHighlightingDisabled() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
-        let pm = ProjectManager()
+        let pm = ProjectManager(sessionDefaults: defaults)
         pm.workspace.loadDirectory(url: dir)
 
         pm.primaryTabManager.openTab(url: files[0])
@@ -269,13 +299,13 @@ struct ProjectManagerSessionTests {
         pm.saveSession()
 
         let canonical = dir.resolvingSymlinksInPath()
-        let session = try #require(SessionState.load(for: canonical))
+        let session = try #require(SessionState.load(for: canonical, defaults: defaults))
 
         #expect(session.highlightingDisabledPaths?.count == 1)
         #expect(session.highlightingDisabledPaths?.first == files[1].path)
 
         // Phase 2: restore — use overload that skips alert
-        let pm2 = ProjectManager()
+        let pm2 = ProjectManager(sessionDefaults: defaults)
         pm2.workspace.loadDirectory(url: dir)
         let disabledSet = Set(session.highlightingDisabledPaths ?? [])
         for url in session.existingFileURLs {
@@ -289,8 +319,10 @@ struct ProjectManagerSessionTests {
     @Test func sessionSurvivedWindowClose() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
-        let registry = ProjectRegistry()
+        let registry = ProjectRegistry(defaults: defaults)
         let pm = try #require(registry.projectManager(for: dir))
 
         pm.primaryTabManager.openTab(url: files[0])
@@ -302,13 +334,13 @@ struct ProjectManagerSessionTests {
         registry.closeProject(dir)
 
         // Session must still be loadable after close (PR #98 fix)
-        let session = SessionState.load(for: canonical)
+        let session = SessionState.load(for: canonical, defaults: defaults)
         #expect(session != nil)
         #expect(session?.existingFileURLs.count == 2)
 
         // Simulate reopen from Welcome
         let pm2 = try #require(registry.projectManager(for: dir))
-        let restoredSession = try #require(SessionState.load(for: canonical))
+        let restoredSession = try #require(SessionState.load(for: canonical, defaults: defaults))
         for url in restoredSession.existingFileURLs {
             pm2.primaryTabManager.openTab(url: url)
         }
@@ -324,9 +356,11 @@ struct ProjectManagerSessionTests {
     @Test func roundTrip_emptyEditorNextToTerminal_isPrunedAfterRestore() throws {
         let (dir, _) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
         // Phase 1: build "empty editor + terminal" layout and save the session.
-        let pm1 = ProjectManager()
+        let pm1 = ProjectManager(sessionDefaults: defaults)
         pm1.workspace.loadDirectory(url: dir)
         let editorPaneID = pm1.paneManager.activePaneID
         _ = pm1.paneManager.createTerminalPane(
@@ -340,11 +374,11 @@ struct ProjectManagerSessionTests {
         // Phase 2: reload session into a fresh ProjectManager and apply the
         // same restore steps that ContentView+Helpers.restoreSessionIfNeeded
         // performs (restoreLayout → populate → pruneEmptyEditorLeaves).
-        let pm2 = ProjectManager()
+        let pm2 = ProjectManager(sessionDefaults: defaults)
         pm2.workspace.loadDirectory(url: dir)
 
         let canonical = dir.resolvingSymlinksInPath()
-        let session = try #require(SessionState.load(for: canonical))
+        let session = try #require(SessionState.load(for: canonical, defaults: defaults))
         let layoutData = try #require(session.paneLayoutData)
         let restoredNode = try #require(try? JSONDecoder().decode(PaneNode.self, from: layoutData))
         pm2.paneManager.restoreLayout(

--- a/PineTests/QuickOpenProviderTests.swift
+++ b/PineTests/QuickOpenProviderTests.swift
@@ -31,9 +31,21 @@ struct QuickOpenProviderTests {
         try? FileManager.default.removeItem(at: dir)
     }
 
-    private func buildProvider(dir: URL) -> QuickOpenProvider {
+    private let suiteName = "PineTests.QuickOpenProvider.\(UUID().uuidString)"
+
+    private func makeDefaults() throws -> UserDefaults {
+        try #require(UserDefaults(suiteName: suiteName))
+    }
+
+    private func cleanupDefaults() {
+        UserDefaults().removePersistentDomain(forName: suiteName)
+    }
+
+    /// Tests that record or read recent files must pass a scoped suite so
+    /// they never touch the production defaults domain (#1554).
+    private func buildProvider(dir: URL, defaults: UserDefaults = .standard) -> QuickOpenProvider {
         let root = FileNode(url: dir, projectRoot: dir)
-        let provider = QuickOpenProvider()
+        let provider = QuickOpenProvider(defaults: defaults)
         provider.buildIndex(from: [root], rootURL: dir)
         return provider
     }
@@ -223,8 +235,10 @@ struct QuickOpenProviderTests {
     func searchEmptyQuery() throws {
         let dir = try createTestProject(files: ["main.swift": ""])
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
-        let provider = buildProvider(dir: dir)
+        let provider = buildProvider(dir: dir, defaults: defaults)
         let results = provider.search(query: "")
         // No recent files recorded yet
         #expect(results.isEmpty)
@@ -311,8 +325,10 @@ struct QuickOpenProviderTests {
             "frequent.swift": ""
         ])
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
-        let provider = buildProvider(dir: dir)
+        let provider = buildProvider(dir: dir, defaults: defaults)
 
         // Record frequent.swift as recently opened
         let frequentURL = dir.appendingPathComponent("frequent.swift")
@@ -332,8 +348,10 @@ struct QuickOpenProviderTests {
             "c.swift": ""
         ])
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
-        let provider = buildProvider(dir: dir)
+        let provider = buildProvider(dir: dir, defaults: defaults)
         let urlA = dir.appendingPathComponent("a.swift")
         let urlC = dir.appendingPathComponent("c.swift")
         provider.recordOpened(url: urlA)

--- a/PineTests/SessionRestoreHighlightTests.swift
+++ b/PineTests/SessionRestoreHighlightTests.swift
@@ -35,14 +35,26 @@ struct SessionRestoreHighlightTests {
         try? FileManager.default.removeItem(at: url)
     }
 
+    private let suiteName = "PineTests.SessionRestoreHighlight.\(UUID().uuidString)"
+
+    private func makeDefaults() throws -> UserDefaults {
+        try #require(UserDefaults(suiteName: suiteName))
+    }
+
+    private func cleanupDefaults() {
+        UserDefaults().removePersistentDomain(forName: suiteName)
+    }
+
     // MARK: - Active tab after session restore
 
     @Test func restoredSessionHasActiveTab() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
         // Phase 1: save session with 3 tabs, middle one active
-        let pm1 = ProjectManager()
+        let pm1 = ProjectManager(sessionDefaults: defaults)
         pm1.workspace.loadDirectory(url: dir)
         for file in files { pm1.primaryTabManager.openTab(url: file) }
         if let middleTab = pm1.primaryTabManager.tab(for: files[1]) {
@@ -51,10 +63,10 @@ struct SessionRestoreHighlightTests {
         pm1.saveSession()
 
         // Phase 2: restore into fresh TabManager
-        let pm2 = ProjectManager()
+        let pm2 = ProjectManager(sessionDefaults: defaults)
         pm2.workspace.loadDirectory(url: dir)
         let canonical = dir.resolvingSymlinksInPath()
-        let session = try #require(SessionState.load(for: canonical))
+        let session = try #require(SessionState.load(for: canonical, defaults: defaults))
 
         let disabledSet = Set(session.existingHighlightingDisabledPaths ?? [])
         for url in session.existingFileURLs {
@@ -75,18 +87,20 @@ struct SessionRestoreHighlightTests {
     @Test func restoredSingleTabIsActive() throws {
         let (dir, files) = try makeTempProject(fileCount: 1)
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
         // Save with one tab
-        let pm1 = ProjectManager()
+        let pm1 = ProjectManager(sessionDefaults: defaults)
         pm1.workspace.loadDirectory(url: dir)
         pm1.primaryTabManager.openTab(url: files[0])
         pm1.saveSession()
 
         // Restore
-        let pm2 = ProjectManager()
+        let pm2 = ProjectManager(sessionDefaults: defaults)
         pm2.workspace.loadDirectory(url: dir)
         let canonical = dir.resolvingSymlinksInPath()
-        let session = try #require(SessionState.load(for: canonical))
+        let session = try #require(SessionState.load(for: canonical, defaults: defaults))
 
         for url in session.existingFileURLs {
             pm2.primaryTabManager.openTab(url: url)
@@ -105,19 +119,21 @@ struct SessionRestoreHighlightTests {
     @Test func restoredLastTabAsActiveDoesNotChangeID() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
         // Save with last tab active (which is the default after opening)
-        let pm1 = ProjectManager()
+        let pm1 = ProjectManager(sessionDefaults: defaults)
         pm1.workspace.loadDirectory(url: dir)
         for file in files { pm1.primaryTabManager.openTab(url: file) }
         // Last tab (files[2]) is already active — don't explicitly set it
         pm1.saveSession()
 
         // Restore
-        let pm2 = ProjectManager()
+        let pm2 = ProjectManager(sessionDefaults: defaults)
         pm2.workspace.loadDirectory(url: dir)
         let canonical = dir.resolvingSymlinksInPath()
-        let session = try #require(SessionState.load(for: canonical))
+        let session = try #require(SessionState.load(for: canonical, defaults: defaults))
 
         for url in session.existingFileURLs {
             pm2.primaryTabManager.openTab(url: url)
@@ -141,6 +157,8 @@ struct SessionRestoreHighlightTests {
     @Test func restoredTabsHaveContentForHighlighting() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
         // Write distinct content to each file
         for (i, file) in files.enumerated() {
@@ -148,15 +166,15 @@ struct SessionRestoreHighlightTests {
         }
 
         // Save and restore
-        let pm1 = ProjectManager()
+        let pm1 = ProjectManager(sessionDefaults: defaults)
         pm1.workspace.loadDirectory(url: dir)
         for file in files { pm1.primaryTabManager.openTab(url: file) }
         pm1.saveSession()
 
-        let pm2 = ProjectManager()
+        let pm2 = ProjectManager(sessionDefaults: defaults)
         pm2.workspace.loadDirectory(url: dir)
         let canonical = dir.resolvingSymlinksInPath()
-        let session = try #require(SessionState.load(for: canonical))
+        let session = try #require(SessionState.load(for: canonical, defaults: defaults))
 
         let disabledSet = Set(session.existingHighlightingDisabledPaths ?? [])
         for url in session.existingFileURLs {
@@ -176,6 +194,8 @@ struct SessionRestoreHighlightTests {
             .appendingPathComponent("PineTests-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
         let swiftFile = dir.appendingPathComponent("main.swift")
         let jsFile = dir.appendingPathComponent("app.js")
@@ -184,7 +204,7 @@ struct SessionRestoreHighlightTests {
         try "const x = 1".write(to: jsFile, atomically: true, encoding: .utf8)
         try "x = 1".write(to: pyFile, atomically: true, encoding: .utf8)
 
-        let pm = ProjectManager()
+        let pm = ProjectManager(sessionDefaults: defaults)
         pm.workspace.loadDirectory(url: dir)
 
         for url in [swiftFile, jsFile, pyFile] {
@@ -193,10 +213,10 @@ struct SessionRestoreHighlightTests {
         pm.saveSession()
 
         // Restore
-        let pm2 = ProjectManager()
+        let pm2 = ProjectManager(sessionDefaults: defaults)
         pm2.workspace.loadDirectory(url: dir)
         let canonical = dir.resolvingSymlinksInPath()
-        let session = try #require(SessionState.load(for: canonical))
+        let session = try #require(SessionState.load(for: canonical, defaults: defaults))
 
         for url in session.existingFileURLs {
             pm2.primaryTabManager.openTab(url: url)
@@ -212,17 +232,19 @@ struct SessionRestoreHighlightTests {
     @Test func restoredTabsSyntaxHighlightingNotDisabledByDefault() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
-        let pm = ProjectManager()
+        let pm = ProjectManager(sessionDefaults: defaults)
         pm.workspace.loadDirectory(url: dir)
         for file in files { pm.primaryTabManager.openTab(url: file) }
         pm.saveSession()
 
         // Restore
-        let pm2 = ProjectManager()
+        let pm2 = ProjectManager(sessionDefaults: defaults)
         pm2.workspace.loadDirectory(url: dir)
         let canonical = dir.resolvingSymlinksInPath()
-        let session = try #require(SessionState.load(for: canonical))
+        let session = try #require(SessionState.load(for: canonical, defaults: defaults))
 
         let disabledSet = Set(session.existingHighlightingDisabledPaths ?? [])
         for url in session.existingFileURLs {
@@ -239,19 +261,21 @@ struct SessionRestoreHighlightTests {
     @Test func restoredTabPreservesHighlightingDisabled() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
         // Save with one tab having highlighting disabled
-        let pm = ProjectManager()
+        let pm = ProjectManager(sessionDefaults: defaults)
         pm.workspace.loadDirectory(url: dir)
         for file in files { pm.primaryTabManager.openTab(url: file) }
         pm.primaryTabManager.tabs[1].syntaxHighlightingDisabled = true
         pm.saveSession()
 
         // Restore
-        let pm2 = ProjectManager()
+        let pm2 = ProjectManager(sessionDefaults: defaults)
         pm2.workspace.loadDirectory(url: dir)
         let canonical = dir.resolvingSymlinksInPath()
-        let session = try #require(SessionState.load(for: canonical))
+        let session = try #require(SessionState.load(for: canonical, defaults: defaults))
 
         let disabledSet = Set(session.existingHighlightingDisabledPaths ?? [])
         for url in session.existingFileURLs {
@@ -266,17 +290,19 @@ struct SessionRestoreHighlightTests {
     @Test func restoreEmptySessionDoesNotSetActiveTab() throws {
         let (dir, _) = try makeTempProject(fileCount: 0)
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
         // Save empty session
-        let pm = ProjectManager()
+        let pm = ProjectManager(sessionDefaults: defaults)
         pm.workspace.loadDirectory(url: dir)
         pm.saveSession()
 
         // Restore
-        let pm2 = ProjectManager()
+        let pm2 = ProjectManager(sessionDefaults: defaults)
         pm2.workspace.loadDirectory(url: dir)
         let canonical = dir.resolvingSymlinksInPath()
-        let session = SessionState.load(for: canonical)
+        let session = SessionState.load(for: canonical, defaults: defaults)
 
         // Session exists but has no files
         if let session {
@@ -293,9 +319,11 @@ struct SessionRestoreHighlightTests {
     @Test func deletedFilesSkippedDuringRestore() throws {
         let (dir, files) = try makeTempProject()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
         // Save session
-        let pm = ProjectManager()
+        let pm = ProjectManager(sessionDefaults: defaults)
         pm.workspace.loadDirectory(url: dir)
         for file in files { pm.primaryTabManager.openTab(url: file) }
         if let middleTab = pm.primaryTabManager.tab(for: files[1]) {
@@ -307,10 +335,10 @@ struct SessionRestoreHighlightTests {
         try FileManager.default.removeItem(at: files[1])
 
         // Restore
-        let pm2 = ProjectManager()
+        let pm2 = ProjectManager(sessionDefaults: defaults)
         pm2.workspace.loadDirectory(url: dir)
         let canonical = dir.resolvingSymlinksInPath()
-        let session = try #require(SessionState.load(for: canonical))
+        let session = try #require(SessionState.load(for: canonical, defaults: defaults))
 
         let disabledSet = Set(session.existingHighlightingDisabledPaths ?? [])
         for url in session.existingFileURLs {

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -12,10 +12,15 @@ import Testing
 @Suite("Window Lifecycle Tests", .serialized)
 @MainActor
 struct WindowLifecycleTests {
-    private func makeRegistry() -> ProjectRegistry {
-        ProjectRegistry(agentTasks: AgentTaskRegistry(
-            persistence: WindowLifecycleAgentTaskStore()
-        ))
+    /// Tests that persist sessions must pass a scoped suite; the `.standard`
+    /// default is only for tests that write no defaults at all (#1554).
+    private func makeRegistry(defaults: UserDefaults = .standard) -> ProjectRegistry {
+        ProjectRegistry(
+            defaults: defaults,
+            agentTasks: AgentTaskRegistry(
+                persistence: WindowLifecycleAgentTaskStore()
+            )
+        )
     }
 
     private func settle() async {
@@ -41,6 +46,16 @@ struct WindowLifecycleTests {
         try? FileManager.default.removeItem(at: url)
     }
 
+    private let suiteName = "PineTests.WindowLifecycle.\(UUID().uuidString)"
+
+    private func makeDefaults() throws -> UserDefaults {
+        try #require(UserDefaults(suiteName: suiteName))
+    }
+
+    private func cleanupDefaults() {
+        UserDefaults().removePersistentDomain(forName: suiteName)
+    }
+
     private func updateContent(
         _ content: String,
         in project: ProjectManager
@@ -54,8 +69,10 @@ struct WindowLifecycleTests {
     @Test func closingLastProjectTriggersShowWelcome() throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
-        let registry = makeRegistry()
+        let registry = makeRegistry(defaults: defaults)
         _ = registry.projectManager(for: dir)
 
         let delegate = AppDelegate()
@@ -77,8 +94,10 @@ struct WindowLifecycleTests {
         let dir1 = try makeTempDirectory()
         let dir2 = try makeTempDirectory()
         defer { cleanup(dir1); cleanup(dir2) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
-        let registry = makeRegistry()
+        let registry = makeRegistry(defaults: defaults)
         _ = registry.projectManager(for: dir1)
         _ = registry.projectManager(for: dir2)
 
@@ -101,8 +120,10 @@ struct WindowLifecycleTests {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
-        let registry = makeRegistry()
+        let registry = makeRegistry(defaults: defaults)
         let pm = try #require(registry.projectManager(for: dir))
         pm.primaryTabManager.openTab(url: file)
 
@@ -115,7 +136,7 @@ struct WindowLifecycleTests {
         #expect(registry.backgroundProjects.contains(canonical))
 
         // But session was saved BEFORE close — it must be loadable
-        let session = SessionState.load(for: canonical)
+        let session = SessionState.load(for: canonical, defaults: defaults)
         #expect(session != nil)
         #expect(session?.existingFileURLs.count == 1)
         #expect(session?.existingFileURLs.first == file)
@@ -127,11 +148,13 @@ struct WindowLifecycleTests {
         let dir1 = try makeTempDirectory()
         let dir2 = try makeTempDirectory()
         defer { cleanup(dir1); cleanup(dir2) }
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults() }
 
         let file1 = try makeTempFile(in: dir1, name: "a.swift")
         let file2 = try makeTempFile(in: dir2, name: "b.swift")
 
-        let registry = makeRegistry()
+        let registry = makeRegistry(defaults: defaults)
         let pm1 = try #require(registry.projectManager(for: dir1))
         let pm2 = try #require(registry.projectManager(for: dir2))
         pm1.primaryTabManager.openTab(url: file1)
@@ -144,8 +167,8 @@ struct WindowLifecycleTests {
         delegate.applicationWillTerminate(Notification(name: NSApplication.willTerminateNotification))
 
         // Both sessions saved
-        let session1 = SessionState.load(for: dir1.resolvingSymlinksInPath())
-        let session2 = SessionState.load(for: dir2.resolvingSymlinksInPath())
+        let session1 = SessionState.load(for: dir1.resolvingSymlinksInPath(), defaults: defaults)
+        let session2 = SessionState.load(for: dir2.resolvingSymlinksInPath(), defaults: defaults)
         #expect(session1?.existingFileURLs.count == 1)
         #expect(session2?.existingFileURLs.count == 1)
     }


### PR DESCRIPTION
Closes #1554

## What

Closes the dangerous half of #1554 — unit-test runs leaking keys into the production `io.github.batonogov.pine` domain (618 dead keys measured on the maintainer's machine: 440 `sessionState:` + 178 `quickOpen.recentFiles.`).

### Production code

- `QuickOpenProvider` gains `init(defaults: UserDefaults = .standard)`; `loadRecentFiles`/`saveRecentFiles` stop touching `UserDefaults.standard` directly.
- `ProjectManager` now builds its `quickOpenProvider` from the injected `sessionDefaults`, so a test-scoped suite covers both session and recents writes.

### Tests

Every suite that persists a session now passes a scoped, torn-down suite:

- `SessionRestoreHighlightTests`, `ProjectManagerSessionTests`, `MultiPaneIntegrationTests`, `ProjectManagerInteractionSessionSaveTests` — `ProjectManager(sessionDefaults:)` + `SessionState.load/clear(defaults:)`.
- `WindowLifecycleTests` — `makeRegistry(defaults:)`; the four tests whose close/terminate paths save sessions are isolated.
- `QuickOpenProviderTests` — `buildProvider(dir:defaults:)`; the three recents tests are isolated.

### Guard

New `ProductionDefaultsIsolationTests` (#1554 §4): if any write leaks, the leaked key necessarily embeds the fixture's unique temp path, so the guard asserts `.standard` contains no such key after `saveSession` / `recordOpened` / `SessionState.save` against a scoped suite — plus a teardown test that `removePersistentDomain` fully wipes a suite. Filtering by fixture path keeps it immune to unrelated AppKit keys appearing in `.standard` mid-run.

## Explicitly out of scope (follow-ups)

- The 7703 orphaned scoped-suite plists (`removePersistentDomain` missing after crashes) — separate cleanup.
- UI tests writing ordinary app keys for XCUITest containers under the production bundle id — needs launch-argument work.
- One-off cleanup guidance for existing machines (#1554 §5).

## Testing

- `swiftc -parse` + `swiftlint` clean on all touched files (local suite runs deferred — CI is the signal).
- Full unit suite runs in CI on this PR.