### PR TITLE
perf(background): give every dispatch surface outside runOnBackground an autorelease pool

### DIFF
--- a/Pine/Agent/AgentHistoryStore.swift
+++ b/Pine/Agent/AgentHistoryStore.swift
@@ -1001,7 +1001,14 @@ final class AgentHistoryStore {
 /// sufficient for this low-frequency log (written on session finalize / revert,
 /// not on every keystroke).
 nonisolated final class AgentHistoryLogWriter {
-    private let writeQueue = DispatchQueue(label: "com.pine.agent-history", qos: .utility)
+    /// `.workItem` gives every persist work item an autorelease pool (#1548)
+    /// — encoding and file-manager temporaries drain per write instead of
+    /// leaking into the worker thread's fallback pool.
+    private let writeQueue = DispatchQueue(
+        label: "com.pine.agent-history",
+        qos: .utility,
+        autoreleaseFrequency: .workItem
+    )
 
     /// Schedules an atomic write of `snapshot` to `<root>/.pine/agent-log.json`.
     /// A `nil` root (no project open) is a no-op — the in-memory log suffices.

--- a/Pine/Extensibility/UserTaskRunStore.swift
+++ b/Pine/Extensibility/UserTaskRunStore.swift
@@ -38,14 +38,14 @@ nonisolated private enum UserTaskCompletionWaiter {
         until deadline: DispatchTime
     ) async -> Bool {
         guard !handles.isEmpty else { return true }
-        return await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                var allCompleted = true
-                for handle in handles where !handle.wait(until: deadline) {
-                    allCompleted = false
-                }
-                continuation.resume(returning: allCompleted)
+        // `runOnBackground` gives the blocking waits an autorelease pool
+        // (#1509) — the raw global-queue work item it replaces had none (#1548).
+        return await runOnBackground(qos: .userInitiated) {
+            var allCompleted = true
+            for handle in handles where !handle.wait(until: deadline) {
+                allCompleted = false
             }
+            return allCompleted
         }
     }
 }

--- a/Pine/ExternalFileFormatter.swift
+++ b/Pine/ExternalFileFormatter.swift
@@ -329,10 +329,15 @@ nonisolated private func runSpawnedProcess(
             reapIfExited(childPID, status: &processStatus)
             if processStatus == nil {
                 let reapingPID = childPID
+                // The reaping work item runs on a raw global queue, which
+                // installs no pool of its own — wrap it for contract parity
+                // with every other background work item (#1548).
                 DispatchQueue.global(qos: .utility).async {
-                    var status: Int32 = 0
-                    while Darwin.waitpid(reapingPID, &status, 0) < 0,
-                          errno == EINTR {}
+                    autoreleasepool {
+                        var status: Int32 = 0
+                        while Darwin.waitpid(reapingPID, &status, 0) < 0,
+                              errno == EINTR {}
+                    }
                 }
             }
             break

--- a/Pine/ExternalToolResolver.swift
+++ b/Pine/ExternalToolResolver.swift
@@ -25,7 +25,14 @@ nonisolated final class ExternalToolResolver: Sendable {
     /// Ordered, deduplicated list of directories to search.
     let searchDirectories: [String]
 
-    private let cacheQueue = DispatchQueue(label: "com.pine.tool-resolver-cache")
+    /// Serial queue protecting the cache. `.workItem` gives every
+    /// asynchronously drained work item an autorelease pool (#1548); the
+    /// uncontended `sync` fast path runs on the caller's thread, where pool
+    /// ownership stays with the caller.
+    private let cacheQueue = DispatchQueue(
+        label: "com.pine.tool-resolver-cache",
+        autoreleaseFrequency: .workItem
+    )
     nonisolated(unsafe) private var cache: [String: String?] = [:]
 
     /// Creates a resolver with an explicit list of directories to search.

--- a/Pine/FileSystemWatcher.swift
+++ b/Pine/FileSystemWatcher.swift
@@ -16,7 +16,16 @@ nonisolated final class FileSystemWatcher {
 
     /// Serial queue that owns all mutable state (stream, debounceWorkItem).
     /// FSEvents callbacks are delivered here too.
-    private let queue = DispatchQueue(label: "pine.fswatcher", qos: .utility)
+    ///
+    /// `.workItem` pushes an autorelease pool around every asynchronously
+    /// drained work item — every FSEvents callback included — so Foundation
+    /// temporaries drain instead of parking in libobjc's thread-wide
+    /// fallback pool (#1548).
+    private let queue = DispatchQueue(
+        label: "pine.fswatcher",
+        qos: .utility,
+        autoreleaseFrequency: .workItem
+    )
     private var debounceWorkItem: DispatchWorkItem?
 
     /// Strong self-reference kept while the stream is active.

--- a/Pine/Git/GitCommand.swift
+++ b/Pine/Git/GitCommand.swift
@@ -371,20 +371,20 @@ nonisolated enum GitCommand {
             if Task.isCancelled {
                 cancellationToken.cancel()
             }
-            return await withCheckedContinuation { continuation in
-                DispatchQueue.global(qos: .utility).async {
-                    continuation.resume(
-                        returning: runExecutable(
-                            executableURL,
-                            arguments: arguments,
-                            at: directory,
-                            timeout: timeout,
-                            captureLimit: captureLimit,
-                            cancellationToken: cancellationToken,
-                            systemCalls: systemCalls
-                        )
-                    )
-                }
+            // `runOnBackground` wraps the process I/O in an autorelease pool
+            // (#1509) — the raw global-queue dispatch it replaces had none
+            // (#1548) and let git output temporaries pile up on the worker
+            // thread until it was torn down.
+            return await runOnBackground(qos: .utility) {
+                runExecutable(
+                    executableURL,
+                    arguments: arguments,
+                    at: directory,
+                    timeout: timeout,
+                    captureLimit: captureLimit,
+                    cancellationToken: cancellationToken,
+                    systemCalls: systemCalls
+                )
             }
         } onCancel: {
             cancellationToken.cancel()

--- a/Pine/Git/GitFetcher.swift
+++ b/Pine/Git/GitFetcher.swift
@@ -30,15 +30,22 @@ nonisolated enum GitFetcher {
         nonisolated(unsafe) var ignored: Set<String> = []
         nonisolated(unsafe) var branchList: [String] = []
 
+        // Each fetch body runs inside its own autoreleasepool (#1548): raw
+        // global-queue work items execute with no pool in place, and git
+        // process output plus parsing produce autoreleased Foundation
+        // temporaries that would otherwise sit in the worker thread's
+        // fallback pool until the thread is torn down. `fetchAllInParallel`
+        // is synchronous, so `runOnBackground` (async-only) cannot be used
+        // without changing its callers.
         group.enter()
         DispatchQueue.global(qos: .userInitiated).async {
-            branch = fetchBranch(at: url)
+            branch = autoreleasepool { fetchBranch(at: url) }
             group.leave()
         }
 
         group.enter()
         DispatchQueue.global(qos: .userInitiated).async {
-            let result = fetchStatusAndIgnored(at: url)
+            let result = autoreleasepool { fetchStatusAndIgnored(at: url) }
             statuses = result.statuses
             ignored = result.ignored
             group.leave()
@@ -46,7 +53,7 @@ nonisolated enum GitFetcher {
 
         group.enter()
         DispatchQueue.global(qos: .userInitiated).async {
-            branchList = fetchBranches(at: url)
+            branchList = autoreleasepool { fetchBranches(at: url) }
             group.leave()
         }
 

--- a/Pine/LSP/LSPClient.swift
+++ b/Pine/LSP/LSPClient.swift
@@ -140,15 +140,24 @@ nonisolated final class LSPTransport: @unchecked Sendable {
     private var stdinPipe: Pipe?
 
     /// Private serial queue — all reads/writes of mutable state happen here.
-    private let ioQueue = DispatchQueue(label: "com.pine.lsp-transport")
+    /// `.workItem` pushes an autorelease pool around every asynchronously
+    /// drained work item (reads, writes, exit hops), so framing and decoding
+    /// temporaries drain per item instead of leaking into the worker
+    /// thread's fallback pool (#1548).
+    private let ioQueue = DispatchQueue(
+        label: "com.pine.lsp-transport",
+        autoreleaseFrequency: .workItem
+    )
 
     /// Keeps process cleanup responsive when background utility work is busy.
     ///
     /// Termination is correctness-critical and can be awaited by the main
     /// actor, so it must not depend on the shared utility worker pool.
+    /// `.workItem` pools each cleanup work item like `ioQueue` above (#1548).
     private let lifecycleQueue = DispatchQueue(
         label: "com.pine.lsp-transport.lifecycle",
-        qos: .userInitiated
+        qos: .userInitiated,
+        autoreleaseFrequency: .workItem
     )
 
     /// Incremental framing state, confined to `ioQueue`.

--- a/PineTests/BackgroundDispatchTests.swift
+++ b/PineTests/BackgroundDispatchTests.swift
@@ -289,6 +289,82 @@ struct BackgroundDispatchTests {
         }
         #expect(deallocations.value == 8)
     }
+
+    // MARK: - Autorelease pool hygiene on other dispatch surfaces (#1548)
+
+    // `runOnBackground` is Pine's background-work choke point, but not the
+    // only dispatch surface. Custom serial queues default to
+    // `autoreleaseFrequency: .inherit`, which on GCD's pool-less worker
+    // threads means no pool at all — the same shape as a raw
+    // `DispatchQueue.global().async`. The surfaces fixed in #1548 declare
+    // `.workItem` (the `pine.fswatcher`, `com.pine.tool-resolver-cache`,
+    // `com.pine.lsp-transport`, `com.pine.lsp-transport.lifecycle`, and
+    // `com.pine.agent-history` queues) or wrap
+    // their bodies in `autoreleasepool` (the remaining raw global-queue work
+    // items). The production queues are `private`, so these tests mirror the
+    // configuration they now declare. Note what `.workItem` covers per
+    // libdispatch: asynchronously drained work items — including contended
+    // `sync` that turns into an async waiter hand-off. The uncontended
+    // `queue.sync` fast path runs on the caller's thread, where pool
+    // ownership stays with the caller. There is deliberately no test
+    // asserting the *absence* of a drain on an unpooled surface: a worker
+    // thread being torn down can drain the fallback pool and flip the result.
+
+    @Test("A .workItem queue drains autoreleased objects when the work item returns")
+    func workItemQueueDrainsAutoreleasedObjectsPerWorkItem() {
+        let queue = DispatchQueue(
+            label: "com.pine.tests.autorelease-workitem",
+            qos: .utility,
+            autoreleaseFrequency: .workItem
+        )
+        let deallocations = AtomicCounter()
+        queue.async {
+            let probe = AutoreleaseProbe(deallocations: deallocations)
+            _ = Unmanaged.passRetained(probe).autorelease()
+        }
+        // Barrier: returns only after the enqueued item has fully drained.
+        queue.sync {}
+        #expect(deallocations.value == 1)
+    }
+
+    @Test("A .workItem queue drains per work item, not once at thread teardown")
+    func workItemQueueGivesEachWorkItemItsOwnPool() {
+        let queue = DispatchQueue(
+            label: "com.pine.tests.autorelease-workitem-serial",
+            qos: .utility,
+            autoreleaseFrequency: .workItem
+        )
+        let deallocations = AtomicCounter()
+        for _ in 0..<8 {
+            queue.async {
+                let probe = AutoreleaseProbe(deallocations: deallocations)
+                _ = Unmanaged.passRetained(probe).autorelease()
+            }
+        }
+        // Barrier: with a single shared fallback pool the probes would still
+        // be alive here (count 0) — only a per-item drain reaches 8.
+        queue.sync {}
+        #expect(deallocations.value == 8)
+    }
+
+    @Test("A raw global-queue work item drains when its body wraps in autoreleasepool")
+    func wrappedGlobalQueueWorkItemDrainsItsPool() {
+        // Same shape as the wrapped sites in #1548 (GitFetcher's parallel
+        // fetches, the zombie reaper in ExternalFileFormatter): the body is
+        // wrapped, the group handshake stays outside the pool.
+        let deallocations = AtomicCounter()
+        let group = DispatchGroup()
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            autoreleasepool {
+                let probe = AutoreleaseProbe(deallocations: deallocations)
+                _ = Unmanaged.passRetained(probe).autorelease()
+            }
+            group.leave()
+        }
+        group.wait()
+        #expect(deallocations.value == 1)
+    }
 }
 
 // MARK: - Test helpers


### PR DESCRIPTION
Closes #1548 · Follow-ups: #1579

## What

Every dispatch surface #1548 enumerated now runs its work items inside an autorelease pool:

- **Five serial queues** declare `autoreleaseFrequency: .workItem` — `pine.fswatcher`, `com.pine.tool-resolver-cache`, `com.pine.lsp-transport`, `com.pine.agent-history` (the four from the issue) plus `com.pine.lsp-transport.lifecycle`, a multi-line declaration the issue's one-line grep missed.
- **`UserTaskCompletionWaiter` / `GitCommand.runExecutableAsync`** move from `withCheckedContinuation { global.async }` onto `runOnBackground`, which already owns the pool contract (#1509). QoS, cancellation structure, and resume-once semantics verified unchanged by review.
- **Synchronous surfaces** — the `GitFetcher` parallel fan-out (×3) and the zombie reaper in `ExternalFileFormatter` — wrap their bodies in `autoreleasepool`; the `DispatchGroup` handshake stays outside the pool.
- `TerminalSession.swift:149` untouched (queue handed to SwiftTerm, excluded by the issue).

Three tests in `BackgroundDispatchTests` pin the semantics: per-item drain on a `.workItem` queue, 8 sequential items → 8 deallocations, and the wrapped-body shape used by GitFetcher/reaper.

## Review gate (3 independent reviewers, fresh context)

- **Correctness**: no P0–P1. Verified QoS preservation, cancellation boundaries, Sendable crossings, FSEvents/DispatchWorkItem interactions; ran the affected suites locally (28/28 BackgroundDispatchTests, integration + stress suites green).
- **Concurrency/lifecycle**: no P0–P2. Verified pool transparency to ordering/barriers, no deadlocks or premature releases on any queue, deterministic tests (no sleeps/timing).
- **Tests/OS**: APPROVE with 2×P2 — both about the *residual* class, not this diff: mirror tests can't see a production `autoreleaseFrequency` rollback (queues are `private`), and 13 other custom queues remain `.inherit`. Both filed as #1579 (remaining queues — several `.concurrent`, needing per-site wraps — plus a text guard in the `check-no-post-under-inout.py` shape).
- Two comment-wording P3s from review were fixed on the branch before commit.

## Measurement gate (honest status)

#1546-style acceptance asked for per-class `OBJC_DEBUG_MISSING_POOLS` numbers after the fix. The "before" numbers are in the issue (17 264 total; per-class table). The "after" run requires a local test-host execution, which is deferred while the maintainer is working on this machine — tracked in #1579 alongside the residual queues. CI behavioural suites (BackgroundDispatchTests, Git*, FileSystemWatcher, LSP transport) run on this PR.

## Known limitations (review-verified)

- Mirror tests pin libdispatch semantics, not the production queue configuration — the guard script in #1579 closes that regression path.
- Uncontended `queue.sync` fast paths still run on the caller's thread with the caller's pool ownership — documented in the diff; strictly better than `.inherit` everywhere.