### PR TITLE
fix(terminal): route Cmd+G / Shift+Cmd+G to a visible terminal search

### DIFF
--- a/Pine/CodeEditorView+Coordinator.swift
+++ b/Pine/CodeEditorView+Coordinator.swift
@@ -1014,12 +1014,12 @@ extension CodeEditorView {
         }
 
         @objc func handleFindNext(_ notification: Notification) {
-            guard shouldHandleCommand(notification) else { return }
+            guard shouldHandleCommand(notification), canStepFind() else { return }
             handleFindNext()
         }
 
         @objc func handleFindPrevious(_ notification: Notification) {
-            guard shouldHandleCommand(notification) else { return }
+            guard shouldHandleCommand(notification), canStepFind() else { return }
             handleFindPrevious()
         }
 
@@ -1033,6 +1033,14 @@ extension CodeEditorView {
         func handleFindNext() { performFindAction(.nextMatch) }
         func handleFindPrevious() { performFindAction(.previousMatch) }
         func handleUseSelectionForFind() { performFindAction(.setSearchString) }
+
+        /// Whether the editor's find bar may take a ⌘G / ⇧⌘G step (#1551).
+        /// Find stepping is window-routed: while `FindStepTargetPolicy`
+        /// resolves it to a visible terminal search bar, the editor must
+        /// yield so the command is not double-stepped. Internal for testability.
+        func canStepFind() -> Bool {
+            parent.canHandleFindStepping?() ?? true
+        }
 
         // MARK: - Send to Terminal (issue #311)
 

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -41,6 +41,11 @@ struct CodeEditorView: NSViewRepresentable {
     /// AppKit bridge. Multiple editor panes share one key NSWindow, so window
     /// focus alone cannot identify the intended coordinator.
     var canHandleCommands: (() -> Bool)? = nil
+    /// Window-wide ownership of ⌘G / ⇧⌘G (#1551). Find stepping is routed by
+    /// `FindStepTargetPolicy`: while it resolves to a visible terminal search
+    /// bar, the editor's native find bar must not also step. `nil` keeps the
+    /// editor eligible — previews and tests that do not model panes.
+    var canHandleFindStepping: (() -> Bool)? = nil
     var lineDiffs: [GitLineDiff] = []
     /// Monotonic counter bumped after every `refreshLineDiffs` completion.
     /// Forces SwiftUI to call `updateNSView` even when the `[GitLineDiff]`

--- a/Pine/FindStepTargetPolicy.swift
+++ b/Pine/FindStepTargetPolicy.swift
@@ -1,0 +1,80 @@
+//
+//  FindStepTargetPolicy.swift
+//  Pine
+//
+//  Window-wide routing for Find Next / Find Previous (⌘G / ⇧⌘G), issue #1551.
+//
+
+/// Which surface a window-wide Find Next / Find Previous step drives.
+///
+/// Kept as a pure function of the pane layout — no AppKit, no observation —
+/// so the rule is unit-testable and mutation-verifiable directly, the same
+/// shape as the `TerminalSearchFieldCommand` seam from #1523.
+enum FindStepTargetPolicy {
+    /// The addressee of one ⌘G / ⇧⌘G press.
+    enum Target: Equatable {
+        /// The visible terminal search bar owned by this pane.
+        case terminal(PaneID)
+        /// The editor's native find bar — the pre-#1551 behavior.
+        case editor
+    }
+
+    /// Resolves the target of a find step for one project window.
+    ///
+    /// The rule is the Apple-like "visible target" flow (Terminal.app /
+    /// Safari / Preview): an open terminal search bar stays addressable while
+    /// it is visible, because ⌘G is exactly the binding that must keep
+    /// working after focus leaves the query field — the state where Return
+    /// no longer steps.
+    ///
+    /// 1. A visible bar in the **active pane** wins, even when several bars
+    ///    are open — the active pane is the user's current context.
+    /// 2. Otherwise, when **exactly one** bar is visible in the window, that
+    ///    bar wins — including when focus has moved into the editor.
+    /// 3. Otherwise (no bar visible, or several bars with none in the active
+    ///    pane, which is ambiguous) the command stays with the **editor's**
+    ///    native find bar, preserving pre-#1551 behavior.
+    ///
+    /// This deliberately diverges from ⌘F's active-pane rule (`.findInTerminal`
+    /// targets the active pane only): ⌘F opens a search where focus already
+    /// is, ⌘G steps the search the user can see.
+    ///
+    /// - Parameters:
+    ///   - activePaneID: the pane currently holding focus in the window.
+    ///   - visibleTerminalSearchPaneIDs: every pane whose terminal search bar
+    ///     is visible; order is not significant.
+    static func target(
+        activePaneID: PaneID,
+        visibleTerminalSearchPaneIDs: [PaneID]
+    ) -> Target {
+        if visibleTerminalSearchPaneIDs.contains(activePaneID) {
+            return .terminal(activePaneID)
+        }
+        if visibleTerminalSearchPaneIDs.count == 1,
+           let onlyVisiblePaneID = visibleTerminalSearchPaneIDs.first {
+            return .terminal(onlyVisiblePaneID)
+        }
+        return .editor
+    }
+
+    /// Whether ⌘G / ⇧⌘G has any addressee in the window and the menu item
+    /// may be enabled: a terminal search bar the policy resolves to, or an
+    /// active editor tab for the native find bar.
+    ///
+    /// `hasActiveEditorTab` keeps the exact pre-#1551 editor gate — the
+    /// editor branch of ``target(activePaneID:visibleTerminalSearchPaneIDs:)``
+    /// is a fallback, not proof that an editor tab exists to receive it.
+    static func isCommandEnabled(
+        activePaneID: PaneID,
+        visibleTerminalSearchPaneIDs: [PaneID],
+        hasActiveEditorTab: Bool
+    ) -> Bool {
+        if case .terminal = target(
+            activePaneID: activePaneID,
+            visibleTerminalSearchPaneIDs: visibleTerminalSearchPaneIDs
+        ) {
+            return true
+        }
+        return hasActiveEditorTab
+    }
+}

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -379,6 +379,17 @@ struct PaneLeafView: View {
                 paneManager.activePaneID == paneID
                     && tabManager.activeTabID == tab.id
             },
+            canHandleFindStepping: {
+                // Window-wide ⌘G / ⇧⌘G routing (#1551): the editor's find
+                // bar takes the step only when no visible terminal search bar
+                // claims it. Unaffected by which editor pane/tab is active —
+                // `canHandleCommands` above already narrows to one editor.
+                FindStepTargetPolicy.target(
+                    activePaneID: paneManager.activePaneID,
+                    visibleTerminalSearchPaneIDs:
+                        paneManager.visibleTerminalSearchPaneIDs
+                ) == .editor
+            },
             lineDiffs: lineDiffs,
             diffVersion: diffVersion,
             diffHunks: diffHunks,

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -1534,6 +1534,21 @@ final class PaneManager {
         root.leafIDs.filter { root.content(for: $0) == .terminal }
     }
 
+    /// Panes whose terminal search bar is currently visible (#1551). Feeds
+    /// the window-wide ⌘G / ⇧⌘G routing policy; order is not significant.
+    ///
+    /// Derived from `terminalPaneIDs` (the live pane tree), not from the
+    /// `terminalStates` dictionary: `maximize(paneID:)` dismantles every
+    /// other pane's views — their `TerminalSearchObserver` subscriptions die —
+    /// while their `terminalStates` entries, `isSearchVisible` included,
+    /// survive for the restore. Offering such a bar would enable a ⌘G that
+    /// nothing is left to receive.
+    var visibleTerminalSearchPaneIDs: [PaneID] {
+        terminalPaneIDs.compactMap { paneID in
+            terminalStates[paneID]?.isSearchVisible == true ? paneID : nil
+        }
+    }
+
     var allTerminalTabs: [TerminalTab] {
         terminalStates.values.flatMap(\.terminalTabs)
     }

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -60,6 +60,19 @@ struct PineAppMenuCommands: Commands {
     private var nativeState: NativeMenuCommandState {
         NativeMenuCommandState(projectManager: focusedProject)
     }
+    /// Whether ⌘G / ⇧⌘G has any addressee in the focused window (#1551):
+    /// the editor's native find bar (active editor tab — the pre-#1551 gate)
+    /// or a terminal search bar the window routing policy can address, which
+    /// is what keeps the items alive in a terminal-only window.
+    private var canStepFind: Bool {
+        guard let project = focusedProject else { return false }
+        return FindStepTargetPolicy.isCommandEnabled(
+            activePaneID: project.paneManager.activePaneID,
+            visibleTerminalSearchPaneIDs:
+                project.paneManager.visibleTerminalSearchPaneIDs,
+            hasActiveEditorTab: project.activeTabManager.activeTab != nil
+        )
+    }
     /// What the focused window can do with its projects and agents (#1525).
     private var windowAvailability: ProjectWindowCommandAvailability {
         ProjectWindowCommandAvailability(
@@ -466,7 +479,7 @@ struct PineAppMenuCommands: Commands {
             .effectiveKeyboardShortcut(
                 keybindings.effectiveChord(for: .findNext)
             )
-            .disabled(focusedProject?.activeTabManager.activeTab == nil)
+            .disabled(!canStepFind)
 
             Button {
                 NotificationCenter.default.post(name: .findPrevious, object: nil)
@@ -476,7 +489,7 @@ struct PineAppMenuCommands: Commands {
             .effectiveKeyboardShortcut(
                 keybindings.effectiveChord(for: .findPrevious)
             )
-            .disabled(focusedProject?.activeTabManager.activeTab == nil)
+            .disabled(!canStepFind)
 
             Button {
                 NotificationCenter.default.post(name: .useSelectionForFind, object: nil)

--- a/Pine/TerminalBarView.swift
+++ b/Pine/TerminalBarView.swift
@@ -345,7 +345,8 @@ struct TerminalSearchBarContainer: View {
 // MARK: - Terminal search observer
 
 /// Extracted modifier to reduce body complexity for the type-checker.
-/// Handles debounced search, case-sensitivity changes, and tab switching.
+/// Handles ⌘F presentation, window-routed ⌘G / ⇧⌘G stepping (#1551),
+/// debounced search, case-sensitivity changes, and tab switching.
 struct TerminalSearchObserver: ViewModifier {
     var terminalState: TerminalPaneState
     let paneID: PaneID
@@ -375,6 +376,12 @@ struct TerminalSearchObserver: ViewModifier {
                     // field; the two must move together (#1523).
                     terminalState.presentSearch()
                 }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .findNext)) { notification in
+                stepSearch(forward: true, notification: notification)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .findPrevious)) { notification in
+                stepSearch(forward: false, notification: notification)
             }
             .onChange(of: terminalState.terminalSearchQuery) { _, newQuery in
                 searchTask?.cancel()
@@ -409,5 +416,63 @@ struct TerminalSearchObserver: ViewModifier {
                     )
                 }
             }
+    }
+
+    /// Steps this pane's terminal search from a window-wide ⌘G / ⇧⌘G (#1551).
+    ///
+    /// The bar no longer needs first responder in its field to be steered —
+    /// that is the whole point of the binding: it keeps working after focus
+    /// has left the field, exactly where Return stops stepping.
+    private func stepSearch(forward: Bool, notification: Notification) {
+        guard Self.shouldStepSearch(
+            in: paneID,
+            paneManager: paneManager,
+            notificationObject: notification.object,
+            currentProject: projectManager,
+            isKeyWindow: controlActiveState == .key
+        ) else { return }
+        // Same reentrancy deferral as `.findInTerminal` above (#1051): the
+        // notification is posted synchronously from the menu ButtonAction
+        // callstack, and `nextMatch()`/`previousMatch()` mutate @Observable
+        // `TerminalTab` state.
+        DispatchQueue.main.async {
+            // The bar may have been dismissed between delivery and this
+            // deferred execution; stepping a closed search would move
+            // highlights nobody sees. Losing the step is the correct outcome.
+            guard terminalState.isSearchVisible else { return }
+            if forward {
+                terminalState.activeTab?.nextMatch()
+            } else {
+                terminalState.activeTab?.previousMatch()
+            }
+        }
+    }
+
+    /// Gate for a find-step notification aimed at this pane's search bar.
+    ///
+    /// Two conditions, both extracted so they are testable without a live
+    /// view hierarchy:
+    /// 1. The targeted-command scoping used by every window-routed command —
+    ///    unscoped posts are only for the key window, project-targeted posts
+    ///    (palette, user keybindings) must match this window's project.
+    /// 2. The window routing policy resolves ⌘G / ⇧⌘G to THIS pane's visible
+    ///    bar — unlike `.findInTerminal` the pane need not be active: a
+    ///    single visible bar stays addressable after focus moves elsewhere.
+    static func shouldStepSearch(
+        in paneID: PaneID,
+        paneManager: PaneManager,
+        notificationObject: Any?,
+        currentProject: ProjectManager,
+        isKeyWindow: Bool
+    ) -> Bool {
+        guard ContentView.shouldHandleTargetedCommand(
+            notificationObject: notificationObject,
+            currentProject: currentProject,
+            isKeyWindow: isKeyWindow
+        ) else { return false }
+        return FindStepTargetPolicy.target(
+            activePaneID: paneManager.activePaneID,
+            visibleTerminalSearchPaneIDs: paneManager.visibleTerminalSearchPaneIDs
+        ) == .terminal(paneID)
     }
 }

--- a/PineTests/FindStepTargetPolicyTests.swift
+++ b/PineTests/FindStepTargetPolicyTests.swift
@@ -1,0 +1,505 @@
+//
+//  FindStepTargetPolicyTests.swift
+//  PineTests
+//
+//  Issue #1551 — ⌘G / ⇧⌘G must reach a visible terminal search bar.
+//  Locks the window-wide routing policy branch by branch: active pane's bar
+//  wins, a lone visible bar wins even when focus is in the editor, ambiguity
+//  and "nothing visible" stay with the editor, and the menu gate keeps its
+//  pre-#1551 editor behavior.
+//
+
+import Testing
+@testable import Pine
+
+@Suite("Find Step Target Policy (⌘G / ⇧⌘G routing)")
+struct FindStepTargetPolicyTests {
+
+    // MARK: - Active pane's visible bar wins
+
+    @Test("The active pane's own visible bar wins when it is the only one")
+    func activePaneBarWinsWhenSingle() {
+        let bar = PaneID()
+        #expect(
+            FindStepTargetPolicy.target(
+                activePaneID: bar,
+                visibleTerminalSearchPaneIDs: [bar]
+            ) == .terminal(bar)
+        )
+    }
+
+    @Test("The active pane's bar wins even when several bars are visible")
+    func activePaneBarWinsAmongSeveral() {
+        let first = PaneID()
+        let second = PaneID()
+        #expect(
+            FindStepTargetPolicy.target(
+                activePaneID: first,
+                visibleTerminalSearchPaneIDs: [first, second]
+            ) == .terminal(first)
+        )
+        #expect(
+            FindStepTargetPolicy.target(
+                activePaneID: second,
+                visibleTerminalSearchPaneIDs: [first, second]
+            ) == .terminal(second)
+        )
+    }
+
+    // MARK: - A lone visible bar wins without focus
+
+    @Test("A bar open in a non-active pane wins when it is the only one")
+    func loneBackgroundBarWins() {
+        let terminalPane = PaneID()
+        let editorPane = PaneID()
+        // The exact reported gap: focus moved into the editor, bar stays open.
+        #expect(
+            FindStepTargetPolicy.target(
+                activePaneID: editorPane,
+                visibleTerminalSearchPaneIDs: [terminalPane]
+            ) == .terminal(terminalPane)
+        )
+    }
+
+    @Test("A bar wins when the active terminal pane itself has none open")
+    func loneBarWinsOverUnsearchedActiveTerminal() {
+        let searched = PaneID()
+        let focusedTerminal = PaneID()
+        #expect(
+            FindStepTargetPolicy.target(
+                activePaneID: focusedTerminal,
+                visibleTerminalSearchPaneIDs: [searched]
+            ) == .terminal(searched)
+        )
+    }
+
+    // MARK: - The editor keeps the command
+
+    @Test("No visible bar leaves the command with the editor")
+    func noBarsFallsBackToEditor() {
+        #expect(
+            FindStepTargetPolicy.target(
+                activePaneID: PaneID(),
+                visibleTerminalSearchPaneIDs: []
+            ) == .editor
+        )
+    }
+
+    @Test("Several background bars with none in the active pane are ambiguous")
+    func severalBackgroundBarsFallBackToEditor() {
+        let first = PaneID()
+        let second = PaneID()
+        let editorPane = PaneID()
+        #expect(
+            FindStepTargetPolicy.target(
+                activePaneID: editorPane,
+                visibleTerminalSearchPaneIDs: [first, second]
+            ) == .editor
+        )
+    }
+
+    // MARK: - Menu enablement
+
+    @Test("A terminal-only window with a visible bar enables ⌘G (issue #1551)")
+    func commandEnabledForVisibleBarWithoutEditorTab() {
+        let terminalPane = PaneID()
+        #expect(
+            FindStepTargetPolicy.isCommandEnabled(
+                activePaneID: terminalPane,
+                visibleTerminalSearchPaneIDs: [terminalPane],
+                hasActiveEditorTab: false
+            )
+        )
+    }
+
+    @Test("A lone background bar enables ⌘G even with no editor tab")
+    func commandEnabledForLoneBackgroundBarWithoutEditorTab() {
+        let terminalPane = PaneID()
+        let editorPane = PaneID()
+        #expect(
+            FindStepTargetPolicy.isCommandEnabled(
+                activePaneID: editorPane,
+                visibleTerminalSearchPaneIDs: [terminalPane],
+                hasActiveEditorTab: false
+            )
+        )
+    }
+
+    @Test("No bar and no editor tab leaves ⌘G disabled")
+    func commandDisabledWithNothingAddressable() {
+        #expect(
+            !FindStepTargetPolicy.isCommandEnabled(
+                activePaneID: PaneID(),
+                visibleTerminalSearchPaneIDs: [],
+                hasActiveEditorTab: false
+            )
+        )
+    }
+
+    @Test("An active editor tab keeps ⌘G enabled (pre-#1551 gate)")
+    func commandEnabledForEditorTabWithoutBars() {
+        #expect(
+            FindStepTargetPolicy.isCommandEnabled(
+                activePaneID: PaneID(),
+                visibleTerminalSearchPaneIDs: [],
+                hasActiveEditorTab: true
+            )
+        )
+    }
+
+    @Test("Ambiguous bars fall back to the editor gate")
+    func commandEnabledForAmbiguousBarsFollowsEditorTab() {
+        let first = PaneID()
+        let second = PaneID()
+        let editorPane = PaneID()
+        #expect(
+            FindStepTargetPolicy.isCommandEnabled(
+                activePaneID: editorPane,
+                visibleTerminalSearchPaneIDs: [first, second],
+                hasActiveEditorTab: true
+            )
+        )
+        #expect(
+            !FindStepTargetPolicy.isCommandEnabled(
+                activePaneID: editorPane,
+                visibleTerminalSearchPaneIDs: [first, second],
+                hasActiveEditorTab: false
+            )
+        )
+    }
+
+    @Test("A closed bar no longer enables ⌘G on its own")
+    func commandDisabledOnceTheBarCloses() {
+        let terminalPane = PaneID()
+        let enabled = FindStepTargetPolicy.isCommandEnabled(
+            activePaneID: terminalPane,
+            visibleTerminalSearchPaneIDs: [terminalPane],
+            hasActiveEditorTab: false
+        )
+        let disabled = FindStepTargetPolicy.isCommandEnabled(
+            activePaneID: terminalPane,
+            visibleTerminalSearchPaneIDs: [],
+            hasActiveEditorTab: false
+        )
+        #expect(enabled && !disabled)
+    }
+}
+
+/// The policy fed from real pane state: `visibleTerminalSearchPaneIDs` and
+/// the terminal observer's gate over an actual `PaneManager`.
+@Suite("Find Step Pane Integration")
+@MainActor
+struct FindStepPaneIntegrationTests {
+
+    /// Editor + one terminal pane at the bottom, search bar opened in the
+    /// terminal, focus moved back into the editor.
+    private func makeEditorAndSearchedTerminal()
+        -> (project: ProjectManager, editorPane: PaneID, terminalPane: PaneID) {
+        let project = ProjectManager()
+        let paneManager = project.paneManager
+        let editorPane = paneManager.root.leafIDs.first {
+            paneManager.root.content(for: $0) == .editor
+        } ?? paneManager.activePaneID
+        let terminalPane = paneManager.createTerminalPaneAtBottom(
+            workingDirectory: nil
+        )
+        paneManager.terminalState(for: terminalPane)?.presentSearch()
+        // Simulate focus moving into the editor after the search was opened.
+        paneManager.activePaneID = editorPane
+        return (project, editorPane, terminalPane)
+    }
+
+    @Test("visibleTerminalSearchPaneIDs tracks open and closed bars")
+    func visibleSearchPaneIDsTrackBarVisibility() {
+        let paneManager = PaneManager()
+        #expect(paneManager.visibleTerminalSearchPaneIDs.isEmpty)
+
+        let terminalPane = paneManager.createTerminalPaneAtBottom(
+            workingDirectory: nil
+        )
+        #expect(paneManager.visibleTerminalSearchPaneIDs.isEmpty)
+
+        paneManager.terminalState(for: terminalPane)?.presentSearch()
+        #expect(paneManager.visibleTerminalSearchPaneIDs == [terminalPane])
+
+        paneManager.terminalState(for: terminalPane)?.dismissSearch()
+        #expect(paneManager.visibleTerminalSearchPaneIDs.isEmpty)
+    }
+
+    @Test("The pane owning the lone open bar steps on an untargeted ⌘G")
+    func loneSearchedPaneStepsFromEditorFocus() {
+        let (project, _, terminalPane) = makeEditorAndSearchedTerminal()
+
+        #expect(TerminalSearchObserver.shouldStepSearch(
+            in: terminalPane,
+            paneManager: project.paneManager,
+            notificationObject: nil,
+            currentProject: project,
+            isKeyWindow: true
+        ))
+    }
+
+    @Test("A pane without an open bar never swallows the step")
+    func paneWithoutBarDoesNotStep() throws {
+        let project = ProjectManager()
+        let paneManager = project.paneManager
+        let terminalPane = paneManager.createTerminalPaneAtBottom(
+            workingDirectory: nil
+        )
+        paneManager.terminalState(for: terminalPane)?.presentSearch()
+
+        // A second terminal pane without a bar must not react.
+        let otherPane = try #require(
+            paneManager.createTerminalPane(
+                relativeTo: terminalPane,
+                axis: .horizontal,
+                workingDirectory: nil
+            )
+        )
+        paneManager.activePaneID = terminalPane
+
+        #expect(!TerminalSearchObserver.shouldStepSearch(
+            in: otherPane,
+            paneManager: paneManager,
+            notificationObject: nil,
+            currentProject: project,
+            isKeyWindow: true
+        ))
+        // The active pane's bar still wins for itself.
+        #expect(TerminalSearchObserver.shouldStepSearch(
+            in: terminalPane,
+            paneManager: paneManager,
+            notificationObject: nil,
+            currentProject: project,
+            isKeyWindow: true
+        ))
+    }
+
+    @Test("With two open bars only the active pane's bar steps")
+    func activePaneBarWinsAmongTwoOpenBars() throws {
+        let project = ProjectManager()
+        let paneManager = project.paneManager
+        let first = paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        paneManager.terminalState(for: first)?.presentSearch()
+        let second = try #require(
+            paneManager.createTerminalPane(
+                relativeTo: first,
+                axis: .horizontal,
+                workingDirectory: nil
+            )
+        )
+        paneManager.terminalState(for: second)?.presentSearch()
+
+        // createTerminalPane made the second pane active: its bar wins.
+        paneManager.activePaneID = second
+        #expect(!TerminalSearchObserver.shouldStepSearch(
+            in: first,
+            paneManager: paneManager,
+            notificationObject: nil,
+            currentProject: project,
+            isKeyWindow: true
+        ))
+        #expect(TerminalSearchObserver.shouldStepSearch(
+            in: second,
+            paneManager: paneManager,
+            notificationObject: nil,
+            currentProject: project,
+            isKeyWindow: true
+        ))
+
+        // Activating the first pane flips the winner.
+        paneManager.activePaneID = first
+        #expect(TerminalSearchObserver.shouldStepSearch(
+            in: first,
+            paneManager: paneManager,
+            notificationObject: nil,
+            currentProject: project,
+            isKeyWindow: true
+        ))
+        #expect(!TerminalSearchObserver.shouldStepSearch(
+            in: second,
+            paneManager: paneManager,
+            notificationObject: nil,
+            currentProject: project,
+            isKeyWindow: true
+        ))
+    }
+
+    @Test("A bar hidden by maximizing another pane is not addressable")
+    func maximizedPaneDismantlesGhostBar() throws {
+        let project = ProjectManager()
+        let paneManager = project.paneManager
+        let ghostPane = paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        paneManager.terminalState(for: ghostPane)?.presentSearch()
+        let maximizedPane = try #require(
+            paneManager.createTerminalPane(
+                relativeTo: ghostPane,
+                axis: .horizontal,
+                workingDirectory: nil
+            )
+        )
+
+        paneManager.activePaneID = maximizedPane
+        paneManager.toggleMaximizeOnActiveTerminalPane()
+
+        // The ghost premise: maximize dismantles the other pane's views (its
+        // TerminalSearchObserver dies) but keeps its state, bar included.
+        #expect(paneManager.terminalState(for: ghostPane)?.isSearchVisible == true)
+        // The pane tree, not the state dictionary, decides addressability.
+        #expect(!paneManager.visibleTerminalSearchPaneIDs.contains(ghostPane))
+        #expect(paneManager.visibleTerminalSearchPaneIDs.isEmpty)
+        #expect(FindStepTargetPolicy.target(
+            activePaneID: paneManager.activePaneID,
+            visibleTerminalSearchPaneIDs: paneManager.visibleTerminalSearchPaneIDs
+        ) == .editor)
+        // Menu stays off rather than offering an enabled-but-dead ⌘G.
+        #expect(!FindStepTargetPolicy.isCommandEnabled(
+            activePaneID: paneManager.activePaneID,
+            visibleTerminalSearchPaneIDs: paneManager.visibleTerminalSearchPaneIDs,
+            hasActiveEditorTab: false
+        ))
+        #expect(!TerminalSearchObserver.shouldStepSearch(
+            in: ghostPane,
+            paneManager: paneManager,
+            notificationObject: nil,
+            currentProject: project,
+            isKeyWindow: true
+        ))
+
+        // Restore re-mounts the pane; its bar becomes addressable again.
+        paneManager.toggleMaximizeOnActiveTerminalPane()
+        #expect(paneManager.visibleTerminalSearchPaneIDs == [ghostPane])
+        #expect(TerminalSearchObserver.shouldStepSearch(
+            in: ghostPane,
+            paneManager: paneManager,
+            notificationObject: nil,
+            currentProject: project,
+            isKeyWindow: true
+        ))
+    }
+
+    @Test("A bar in the maximized pane itself stays addressable")
+    func barInMaximizedPaneStaysAddressable() {
+        let project = ProjectManager()
+        let paneManager = project.paneManager
+        let pane = paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        paneManager.terminalState(for: pane)?.presentSearch()
+
+        paneManager.activePaneID = pane
+        paneManager.toggleMaximizeOnActiveTerminalPane()
+
+        #expect(paneManager.visibleTerminalSearchPaneIDs == [pane])
+        #expect(FindStepTargetPolicy.target(
+            activePaneID: paneManager.activePaneID,
+            visibleTerminalSearchPaneIDs: paneManager.visibleTerminalSearchPaneIDs
+        ) == .terminal(pane))
+        #expect(TerminalSearchObserver.shouldStepSearch(
+            in: pane,
+            paneManager: paneManager,
+            notificationObject: nil,
+            currentProject: project,
+            isKeyWindow: true
+        ))
+    }
+
+    @Test("Targeted commands from the palette reach only their project's pane")
+    func targetedNotificationScopesToItsProject() {
+        let (project, _, terminalPane) = makeEditorAndSearchedTerminal()
+        let otherProject = ProjectManager()
+
+        // Palette / user-keybinding route: object identifies the project.
+        #expect(TerminalSearchObserver.shouldStepSearch(
+            in: terminalPane,
+            paneManager: project.paneManager,
+            notificationObject: project,
+            currentProject: project,
+            isKeyWindow: false
+        ))
+        #expect(!TerminalSearchObserver.shouldStepSearch(
+            in: terminalPane,
+            paneManager: project.paneManager,
+            notificationObject: otherProject,
+            currentProject: project,
+            isKeyWindow: true
+        ))
+    }
+
+    @Test("Untargeted commands require the key window")
+    func untargetedCommandRequiresKeyWindow() {
+        let (project, _, terminalPane) = makeEditorAndSearchedTerminal()
+
+        #expect(!TerminalSearchObserver.shouldStepSearch(
+            in: terminalPane,
+            paneManager: project.paneManager,
+            notificationObject: nil,
+            currentProject: project,
+            isKeyWindow: false
+        ))
+    }
+}
+
+/// The editor's side of the same policy: its native find bar must yield the
+/// step while a visible terminal search bar owns it (#1551).
+@Suite("Editor Find Step Yield")
+@MainActor
+struct EditorFindStepYieldTests {
+
+    @Test("Without a seam the editor stays eligible (pre-#1551 behavior)")
+    func nilSeamKeepsEditorEligible() {
+        let editorView = CodeEditorView(
+            text: .constant("hello"),
+            contentVersion: 0,
+            language: "txt",
+            fileName: "test.txt",
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: editorView)
+        #expect(coordinator.canStepFind())
+    }
+
+    @Test("The editor yields while a terminal search bar owns the step")
+    func seamSuppressesEditorStepping() {
+        let yielding = CodeEditorView(
+            text: .constant("hello"),
+            contentVersion: 0,
+            language: "txt",
+            fileName: "test.txt",
+            canHandleFindStepping: { false },
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: yielding)
+        #expect(!coordinator.canStepFind())
+    }
+
+    @Test("The seam tracks the policy live: bar closed, editor steps again")
+    func seamFollowsPolicyLive() {
+        let paneManager = PaneManager()
+        let terminalPane = paneManager.createTerminalPaneAtBottom(
+            workingDirectory: nil
+        )
+        let terminalState = paneManager.terminalState(for: terminalPane)
+
+        terminalState?.presentSearch()
+        #expect(paneManager.visibleTerminalSearchPaneIDs.contains(terminalPane))
+        let editorView = CodeEditorView(
+            text: .constant("hello"),
+            contentVersion: 0,
+            language: "txt",
+            fileName: "test.txt",
+            canHandleFindStepping: {
+                FindStepTargetPolicy.target(
+                    activePaneID: paneManager.activePaneID,
+                    visibleTerminalSearchPaneIDs:
+                        paneManager.visibleTerminalSearchPaneIDs
+                ) == .editor
+            },
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: editorView)
+
+        #expect(!coordinator.canStepFind())
+
+        terminalState?.dismissSearch()
+        #expect(coordinator.canStepFind())
+    }
+}

--- a/PineTests/FindStepTargetPolicyTests.swift
+++ b/PineTests/FindStepTargetPolicyTests.swift
@@ -9,6 +9,7 @@
 //  pre-#1551 editor behavior.
 //
 
+import SwiftUI
 import Testing
 @testable import Pine
 


### PR DESCRIPTION
Closes #1551 · Follow-ups: #1581

## Policy (maintainer decision: Apple-like flow)

`FindStepTargetPolicy` — a pure, testable predicate, per the issue's implementation note:

1. A visible terminal search bar keeps ⌘G/⇧⌘G even after focus returns to the editor — the Terminal.app/Safari/Preview idiom, and the exact gap the issue reported.
2. Among several visible bars, the **active pane's** bar wins.
3. With bars in multiple background panes and none in the active one (ambiguous), the **editor** keeps the command — the pre-#1551 behaviour; the command is never swallowed.

## What changed

- `FindStepTargetPolicy` (new) — the policy predicate + command-enablement predicate.
- `PaneManager.visibleTerminalSearchPaneIDs` — derived from the rendered pane tree (`terminalPaneIDs`), not the `terminalStates` dictionary, so a pane hidden by **maximize** cannot keep a ghost bar addressable (review P1: enabled-but-dead ⌘G while zoomed).
- `TerminalSearchObserver` observes `.findNext`/`.findPrevious`, steps the active tab via `nextMatch()/previousMatch()`, deferred on main with a visibility re-guard at execution — same shape as `.findInTerminal` (#1051).
- Menu gate in `PineAppMenuCommands`: enabled when the policy addresses a terminal search **or** the old editor-tab condition holds (editor path preserved byte-for-byte).
- `CodeEditorView` gains a `canHandleFindStepping` seam; the coordinator yields when the policy targets a terminal — exactly one side steps, structurally.
- Works for both command sources: menu (`object: nil`) and palette/user keybindings (`object: projectManager`) — covered by tests.

## Review gate (3 independent reviewers, fresh context)

- **Correctness**: all policy combinations verified; double-step excluded structurally; editor-only regression-free. Found the maximize ghost-bar P2/P1 — **fixed on the branch** with two dedicated tests.
- **Concurrency**: the same maximize defect independently confirmed as P1 with the tree-derived fix; deferred mutation pattern matches `.findInTerminal`; no new synchronous observer→store chains; tests deterministic. P3 hardening (re-guard in the async block) **applied**.
- **Tests/UX**: all 7 semantic branches covered (23 tests total), mutation-testable; localization untouched (existing keys); no version-sensitive APIs; merging without a UI test is consistent with the #1523 precedent.

Deferred (as **#1581**): Command Palette availability still requires `.activeFile` (terminal-only window keeps the palette rows grey), and a CI UI test pinning the menu enablement wiring.

## Ready to merge when

CI fully green (23 new unit tests run in the Unit Tests job).