### PR TITLE
fix(accessibility): name the unsaved state of editor tabs for VoiceOver

### DIFF
--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -409,12 +409,10 @@ struct EditorTabBar: View {
                             paneManager.selectEditorTab(tab.id, in: paneID)
                         } label: {
                             Label {
-                                HStack(spacing: 0) {
-                                    Text(verbatim: tab.fileName)
-                                    if tab.isDirty {
-                                        Text(" \u{25CF}")
-                                    }
-                                }
+                                Text(verbatim: EditorTabOverflowTitle.make(
+                                    fileName: tab.fileName,
+                                    isDirty: tab.isDirty
+                                ))
                             } icon: {
                                 Image(systemName: tab.isPinned
                                       ? "pin.fill"
@@ -474,6 +472,36 @@ struct EditorTabBar: View {
         // propagate to inline buttons (e.g. `markdownPreviewToggle`).
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier(AccessibilityID.editorTabBar)
+    }
+}
+
+/// The `.accessibilityValue` of an editor tab (#1528): the states a tab can
+/// carry, announced in a stable order. The dirty dot and the preview style
+/// are drawn shapes — without this value a VoiceOver user cannot tell an
+/// unsaved tab from a saved one.
+enum EditorTabAccessibilityValue {
+    static func compose(
+        isDirty: Bool,
+        isTransientPreview: Bool
+    ) -> String? {
+        var parts: [String] = []
+        if isTransientPreview {
+            parts.append(Strings.a11yTransientPreviewTab)
+        }
+        if isDirty {
+            parts.append(Strings.a11yDirtyTab)
+        }
+        guard !parts.isEmpty else { return nil }
+        return parts.joined(separator: ", ")
+    }
+}
+
+/// The overflow menu's entry title for a tab (#1528). An `NSMenuItem`'s
+/// title is what VoiceOver reads, so the dirty state is said in words —
+/// the bare ● glyph the menu used before announced as "black circle".
+enum EditorTabOverflowTitle {
+    static func make(fileName: String, isDirty: Bool) -> String {
+        isDirty ? fileName + " — " + Strings.a11yDirtyTab : fileName
     }
 }
 
@@ -646,7 +674,10 @@ struct EditorTabItem: View {
                     .accessibilityIdentifier(AccessibilityID.editorTab(tab.fileName))
                     .accessibilityAddTraits(isActive ? .isSelected : [])
                     .accessibilityValue(
-                        tab.isTransientPreview ? Strings.a11yTransientPreviewTab : ""
+                        EditorTabAccessibilityValue.compose(
+                            isDirty: tab.isDirty,
+                            isTransientPreview: tab.isTransientPreview
+                        ) ?? ""
                     )
                     .accessibilityActions {
                         if let onMoveLeading {

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -23562,6 +23562,66 @@
         }
       }
     },
+    "a11y.editorTab.dirty.value": {
+      "comment": "VoiceOver value announcing an editor tab with unsaved changes (#1528).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungespeicherte Änderungen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unsaved changes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambios sin guardar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifications non enregistrées"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未保存の変更"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장되지 않은 변경 사항"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alterações não salvas"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Несохранённые изменения"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未保存的更改"
+          }
+        }
+      }
+    },
     "a11y.sidebar.disclosure.expanded": {
       "comment": "VoiceOver value describing an expanded sidebar folder.",
       "extractionState": "manual",

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -3002,6 +3002,8 @@ enum Strings {
         String(localized: "a11y.editorTab.close.hint", defaultValue: "Closes this editor tab")
     static let a11yTransientPreviewTab: String =
         String(localized: "a11y.editorTab.preview.value", defaultValue: "Preview")
+    static let a11yDirtyTab: String =
+        String(localized: "a11y.editorTab.dirty.value", defaultValue: "Unsaved changes")
 
     // Sidebar file activation
     static let a11ySidebarFileOpenHint: String =

--- a/PineTests/EditorTabAccessibilityValueTests.swift
+++ b/PineTests/EditorTabAccessibilityValueTests.swift
@@ -1,0 +1,87 @@
+//
+//  EditorTabAccessibilityValueTests.swift
+//  PineTests
+//
+//  #1528 — an editor tab's unsaved state must be perceivable without the
+//  visual dirty dot: the tab's accessibility value names the state, and the
+//  overflow menu entry says it in words instead of a ● glyph.
+//
+
+import Testing
+
+@testable import Pine
+
+@Suite("Editor tab accessibility value (#1528)")
+struct EditorTabAccessibilityValueTests {
+    @Test("A clean tab keeps the pre-#1528 empty value")
+    func cleanTabHasNoValue() {
+        #expect(
+            EditorTabAccessibilityValue.compose(
+                isDirty: false,
+                isTransientPreview: false
+            ) == nil
+        )
+    }
+
+    @Test("The value flips with the dirty flag")
+    func dirtyTabAnnouncesUnsavedChanges() {
+        #expect(
+            EditorTabAccessibilityValue.compose(
+                isDirty: true,
+                isTransientPreview: false
+            ) == Strings.a11yDirtyTab
+        )
+        #expect(
+            EditorTabAccessibilityValue.compose(
+                isDirty: false,
+                isTransientPreview: false
+            ) == nil
+        )
+    }
+
+    @Test("A preview-only tab keeps the exact pre-#1528 value")
+    func previewOnlyTabIsUnchanged() {
+        // PineUITests/EditorTabNavigationTests asserts the value equals
+        // "Preview" exactly — the composer must not grow that string.
+        #expect(
+            EditorTabAccessibilityValue.compose(
+                isDirty: false,
+                isTransientPreview: true
+            ) == Strings.a11yTransientPreviewTab
+        )
+    }
+
+    @Test("A dirty preview announces both states in a stable order")
+    func dirtyPreviewAnnouncesBoth() {
+        #expect(
+            EditorTabAccessibilityValue.compose(
+                isDirty: true,
+                isTransientPreview: true
+            )
+            == Strings.a11yTransientPreviewTab + ", " + Strings.a11yDirtyTab
+        )
+    }
+
+    @Test("The dirty string is localized, non-empty, and menu-ready")
+    func dirtyStringIsPresentable() {
+        #expect(!Strings.a11yDirtyTab.isEmpty)
+        #expect(!Strings.a11yDirtyTab.contains("\u{25CF}"))
+    }
+
+    @Test("The overflow menu entry says the state in words, not a glyph")
+    func overflowMenuTitleNamesTheState() {
+        #expect(
+            EditorTabOverflowTitle.make(fileName: "main.swift", isDirty: false)
+                == "main.swift"
+        )
+        #expect(
+            EditorTabOverflowTitle.make(fileName: "main.swift", isDirty: true)
+                == "main.swift — " + Strings.a11yDirtyTab
+        )
+        #expect(
+            !EditorTabOverflowTitle.make(
+                fileName: "main.swift", isDirty: true
+            ).contains("\u{25CF}")
+        )
+    }
+}


### PR DESCRIPTION
Closes #1528.

## What was wrong

An editor tab's unsaved state existed only as drawn shapes: a `Circle()` dot on the tab, and a bare `●` glyph appended to the overflow-menu entry. A VoiceOver user could not tell a modified tab from a saved one; the menu glyph announced as "black circle".

## What this adds

- **Tab accessibility value** — `EditorTabAccessibilityValue.compose` names the state through the tab's existing accessibility representation: "Unsaved changes" when dirty, joined with "Preview" in a stable order when both apply. Clean, saved tabs keep the exact pre-#1528 value, so `EditorTabNavigationTests`' exact `value == "Preview"` assertions are untouched.
- **Overflow menu says it in words** — `EditorTabOverflowTitle.make` renders "file — Unsaved changes" instead of "file ●". An `NSMenuItem`'s title is what VoiceOver reads; the word beats the glyph. The bullet is gone rather than hidden — the criterion "the bullet glyph is `.accessibilityHidden(true)` once a real value exists" is satisfied by removal, which also declutters the menu.
- **Localization** — `a11y.editorTab.dirty.value` added and translated in all nine locales (targeted text insertion only).

## Acceptance criteria

- [x] Dirty tab exposes a localized `.accessibilityValue`
- [x] Overflow menu entry announces the state instead of `●`
- [x] The glyph no longer reaches assistive tech (removed)
- [x] Test asserts the value flips with the dirty flag
- [ ] **N/A — terminal tabs**: `TerminalPaneState` has no equivalent unsaved state to name (a terminal's output is not persisted); nothing to announce.

## Verification

- `EditorTabAccessibilityValueTests` — 6 tests: flip with the dirty flag, preview-only value byte-identical to the old behaviour, stable order for dirty previews, no glyph in the menu title.
- `EditorTabItemSnapshotTests` — all dirty/pinned/active renders byte-identical: the tab's drawing is untouched, only the AX layer and menu title changed.
- `swiftlint` 0 violations in 842 files; touched suites green locally (`TEST SUCCEEDED`).
- Built binary launched against a scratch project — window renders, no runtime change to the tab bar path. The menu-title surface is unit-locked; local clicking is not available on this machine (no TCC), and the CI UI suite exercises the tab bar end to end.

## Merge timing

Ready to merge when CI is green. Rides the next 2.6.x via Release Please.