### PR TITLE
fix(i18n): wire the dead accessibility strings and translate the catalog

### DIFF
--- a/Pine/BranchSwitcherView.swift
+++ b/Pine/BranchSwitcherView.swift
@@ -100,6 +100,7 @@ struct BranchSwitcherView: View {
                         .buttonStyle(.plain)
                         .id(index)
                         .accessibilityIdentifier(AccessibilityID.branchItem(branch))
+                        .accessibilityHint(Strings.a11yBranchSwitcherHint)
                         .modifier(
                             BranchRowSelectionAccessibility(
                                 isSelected: selection.isSelected(index: index),

--- a/Pine/GoToLineView.swift
+++ b/Pine/GoToLineView.swift
@@ -20,7 +20,7 @@ struct GoToLineView: View {
         VStack(spacing: 8) {
             QuickOpenSearchField(
                 text: $inputText,
-                placeholder: "42 or 42:10",
+                placeholder: Strings.goToLineFieldPlaceholder,
                 accessibility: CommandOverlayTextFieldAccessibility(
                     identifier: AccessibilityID.goToLineField,
                     label: String(localized: "Go to line"),

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -23328,56 +23328,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close tab"
+            "state": "translated",
+            "value": "Tab schließen"
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Close tab"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close tab"
+            "state": "translated",
+            "value": "Cerrar pestaña"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close tab"
+            "state": "translated",
+            "value": "Fermer l’onglet"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close tab"
+            "state": "translated",
+            "value": "タブを閉じる"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close tab"
+            "state": "translated",
+            "value": "탭 닫기"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close tab"
+            "state": "translated",
+            "value": "Fechar aba"
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close tab"
+            "state": "translated",
+            "value": "Закрыть вкладку"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close tab"
+            "state": "translated",
+            "value": "关闭标签页"
           }
         }
       }
@@ -23388,56 +23388,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this editor tab"
+            "state": "translated",
+            "value": "Schließt diesen Editor-Tab"
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Closes this editor tab"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this editor tab"
+            "state": "translated",
+            "value": "Cierra esta pestaña del editor"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this editor tab"
+            "state": "translated",
+            "value": "Ferme cet onglet de l’éditeur"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this editor tab"
+            "state": "translated",
+            "value": "このエディタタブを閉じます"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this editor tab"
+            "state": "translated",
+            "value": "이 에디터 탭을 닫습니다"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this editor tab"
+            "state": "translated",
+            "value": "Fecha esta aba do editor"
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this editor tab"
+            "state": "translated",
+            "value": "Закрывает эту вкладку редактора"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this editor tab"
+            "state": "translated",
+            "value": "关闭此编辑器标签页"
           }
         }
       }
@@ -23988,56 +23988,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "Pane divider"
+            "state": "translated",
+            "value": "Bereichstrennlinie"
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Pane divider"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Pane divider"
+            "state": "translated",
+            "value": "Divisor de paneles"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Pane divider"
+            "state": "translated",
+            "value": "Séparateur de volets"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Pane divider"
+            "state": "translated",
+            "value": "ペイン分割バー"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Pane divider"
+            "state": "translated",
+            "value": "분할 막대"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Pane divider"
+            "state": "translated",
+            "value": "Divisor de painéis"
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Pane divider"
+            "state": "translated",
+            "value": "Разделитель панелей"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "Pane divider"
+            "state": "translated",
+            "value": "窗格分隔条"
           }
         }
       }
@@ -24048,56 +24048,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "Drag to resize the panes"
+            "state": "translated",
+            "value": "Ziehen, um die Größe der Bereiche anzupassen"
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Drag to resize the panes"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Drag to resize the panes"
+            "state": "translated",
+            "value": "Arrastra para cambiar el tamaño de los paneles"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Drag to resize the panes"
+            "state": "translated",
+            "value": "Faites glisser pour redimensionner les volets"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Drag to resize the panes"
+            "state": "translated",
+            "value": "ドラッグしてペインのサイズを変更します"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Drag to resize the panes"
+            "state": "translated",
+            "value": "드래그하여 분할 창 크기를 조정합니다"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Drag to resize the panes"
+            "state": "translated",
+            "value": "Arraste para redimensionar os painéis"
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Drag to resize the panes"
+            "state": "translated",
+            "value": "Потяните, чтобы изменить размер панелей"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "Drag to resize the panes"
+            "state": "translated",
+            "value": "拖移以调整窗格大小"
           }
         }
       }
@@ -24108,56 +24108,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Minimap"
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Minimap"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Minimap"
+            "state": "translated",
+            "value": "Minimapa"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Minimap"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Minimap"
+            "state": "translated",
+            "value": "ミニマップ"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Minimap"
+            "state": "translated",
+            "value": "미니맵"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Minimap"
+            "state": "translated",
+            "value": "Minimapa"
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Minimap"
+            "state": "translated",
+            "value": "Миникарта"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "Minimap"
+            "state": "translated",
+            "value": "小地图"
           }
         }
       }
@@ -24168,56 +24168,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "Code overview. Click to jump to a line."
+            "state": "translated",
+            "value": "Codeübersicht. Klicken, um zu einer Zeile zu springen."
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Code overview. Click to jump to a line."
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Code overview. Click to jump to a line."
+            "state": "translated",
+            "value": "Vista general del código. Haz clic para saltar a una línea."
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Code overview. Click to jump to a line."
+            "state": "translated",
+            "value": "Aperçu du code. Cliquez pour aller à une ligne."
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Code overview. Click to jump to a line."
+            "state": "translated",
+            "value": "コードの概要。クリックで行に移動します。"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Code overview. Click to jump to a line."
+            "state": "translated",
+            "value": "코드 개요. 클릭하면 해당 줄로 이동합니다."
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Code overview. Click to jump to a line."
+            "state": "translated",
+            "value": "Visão geral do código. Clique para ir para uma linha."
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Code overview. Click to jump to a line."
+            "state": "translated",
+            "value": "Обзор кода. Щёлкните, чтобы перейти к строке."
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "Code overview. Click to jump to a line."
+            "state": "translated",
+            "value": "代码概览。点按可跳转到某一行。"
           }
         }
       }
@@ -24228,56 +24228,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "New terminal tab"
+            "state": "translated",
+            "value": "Neues Terminal-Tab"
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "New terminal tab"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "New terminal tab"
+            "state": "translated",
+            "value": "Nueva pestaña de terminal"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "New terminal tab"
+            "state": "translated",
+            "value": "Nouvel onglet de terminal"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "New terminal tab"
+            "state": "translated",
+            "value": "新規ターミナルタブ"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "New terminal tab"
+            "state": "translated",
+            "value": "새 터미널 탭"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "New terminal tab"
+            "state": "translated",
+            "value": "Nova aba de terminal"
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "New terminal tab"
+            "state": "translated",
+            "value": "Новая вкладка терминала"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "New terminal tab"
+            "state": "translated",
+            "value": "新建终端标签页"
           }
         }
       }
@@ -24288,56 +24288,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "Maximize terminal pane"
+            "state": "translated",
+            "value": "Terminal-Bereich maximieren"
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Maximize terminal pane"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Maximize terminal pane"
+            "state": "translated",
+            "value": "Maximizar panel de terminal"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Maximize terminal pane"
+            "state": "translated",
+            "value": "Agrandir le volet de terminal"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Maximize terminal pane"
+            "state": "translated",
+            "value": "ターミナルペインを最大化"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Maximize terminal pane"
+            "state": "translated",
+            "value": "터미널 창 최대화"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Maximize terminal pane"
+            "state": "translated",
+            "value": "Maximizar painel de terminal"
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Maximize terminal pane"
+            "state": "translated",
+            "value": "Развернуть панель терминала"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "Maximize terminal pane"
+            "state": "translated",
+            "value": "最大化终端窗格"
           }
         }
       }
@@ -24348,56 +24348,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "Restore terminal pane"
+            "state": "translated",
+            "value": "Terminal-Bereich wiederherstellen"
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Restore terminal pane"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Restore terminal pane"
+            "state": "translated",
+            "value": "Restaurar panel de terminal"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Restore terminal pane"
+            "state": "translated",
+            "value": "Restaurer le volet de terminal"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Restore terminal pane"
+            "state": "translated",
+            "value": "ターミナルペインを元に戻す"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Restore terminal pane"
+            "state": "translated",
+            "value": "터미널 창 원래대로"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Restore terminal pane"
+            "state": "translated",
+            "value": "Restaurar painel de terminal"
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Restore terminal pane"
+            "state": "translated",
+            "value": "Восстановить панель терминала"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "Restore terminal pane"
+            "state": "translated",
+            "value": "恢复终端窗格"
           }
         }
       }
@@ -24408,56 +24408,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close terminal pane"
+            "state": "translated",
+            "value": "Terminal-Bereich schließen"
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Close terminal pane"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close terminal pane"
+            "state": "translated",
+            "value": "Cerrar panel de terminal"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close terminal pane"
+            "state": "translated",
+            "value": "Fermer le volet de terminal"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close terminal pane"
+            "state": "translated",
+            "value": "ターミナルペインを閉じる"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close terminal pane"
+            "state": "translated",
+            "value": "터미널 창 닫기"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close terminal pane"
+            "state": "translated",
+            "value": "Fechar painel de terminal"
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close terminal pane"
+            "state": "translated",
+            "value": "Закрыть панель терминала"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "Close terminal pane"
+            "state": "translated",
+            "value": "关闭终端窗格"
           }
         }
       }
@@ -24468,56 +24468,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this terminal pane"
+            "state": "translated",
+            "value": "Schließt diesen Terminal-Bereich"
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Closes this terminal pane"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this terminal pane"
+            "state": "translated",
+            "value": "Cierra este panel de terminal"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this terminal pane"
+            "state": "translated",
+            "value": "Ferme ce volet de terminal"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this terminal pane"
+            "state": "translated",
+            "value": "このターミナルペインを閉じます"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this terminal pane"
+            "state": "translated",
+            "value": "이 터미널 창을 닫습니다"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this terminal pane"
+            "state": "translated",
+            "value": "Fecha este painel de terminal"
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this terminal pane"
+            "state": "translated",
+            "value": "Закрывает эту панель терминала"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "Closes this terminal pane"
+            "state": "translated",
+            "value": "关闭此终端窗格"
           }
         }
       }
@@ -24528,56 +24528,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switches to this git branch"
+            "state": "translated",
+            "value": "Wechselt zu diesem Git-Branch"
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Switches to this git branch"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switches to this git branch"
+            "state": "translated",
+            "value": "Cambia a esta rama de git"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switches to this git branch"
+            "state": "translated",
+            "value": "Bascule vers cette branche git"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switches to this git branch"
+            "state": "translated",
+            "value": "この git ブランチに切り替えます"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switches to this git branch"
+            "state": "translated",
+            "value": "이 git 브랜치로 전환합니다"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switches to this git branch"
+            "state": "translated",
+            "value": "Muda para esta branch do git"
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switches to this git branch"
+            "state": "translated",
+            "value": "Переключается на эту git-ветку"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "Switches to this git branch"
+            "state": "translated",
+            "value": "切换到此 git 分支"
           }
         }
       }
@@ -24588,56 +24588,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "Opens this file"
+            "state": "translated",
+            "value": "Öffnet diese Datei"
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Opens this file"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Opens this file"
+            "state": "translated",
+            "value": "Abre este archivo"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Opens this file"
+            "state": "translated",
+            "value": "Ouvre ce fichier"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Opens this file"
+            "state": "translated",
+            "value": "このファイルを開きます"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Opens this file"
+            "state": "translated",
+            "value": "이 파일을 엽니다"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Opens this file"
+            "state": "translated",
+            "value": "Abre este arquivo"
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Opens this file"
+            "state": "translated",
+            "value": "Открывает этот файл"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "Opens this file"
+            "state": "translated",
+            "value": "打开此文件"
           }
         }
       }
@@ -24648,56 +24648,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "Jumps to this symbol"
+            "state": "translated",
+            "value": "Springt zu diesem Symbol"
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Jumps to this symbol"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Jumps to this symbol"
+            "state": "translated",
+            "value": "Salta a este símbolo"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Jumps to this symbol"
+            "state": "translated",
+            "value": "Va à ce symbole"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Jumps to this symbol"
+            "state": "translated",
+            "value": "このシンボルに移動します"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Jumps to this symbol"
+            "state": "translated",
+            "value": "이 심볼로 이동합니다"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Jumps to this symbol"
+            "state": "translated",
+            "value": "Vai para este símbolo"
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Jumps to this symbol"
+            "state": "translated",
+            "value": "Переходит к этому символу"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "Jumps to this symbol"
+            "state": "translated",
+            "value": "跳转到此符号"
           }
         }
       }
@@ -24828,56 +24828,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "Status bar"
+            "state": "translated",
+            "value": "Statusleiste"
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Status bar"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Status bar"
+            "state": "translated",
+            "value": "Barra de estado"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Status bar"
+            "state": "translated",
+            "value": "Barre d’état"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Status bar"
+            "state": "translated",
+            "value": "ステータスバー"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Status bar"
+            "state": "translated",
+            "value": "상태 표시줄"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Status bar"
+            "state": "translated",
+            "value": "Barra de status"
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Status bar"
+            "state": "translated",
+            "value": "Строка состояния"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "Status bar"
+            "state": "translated",
+            "value": "状态栏"
           }
         }
       }
@@ -24888,56 +24888,56 @@
       "localizations": {
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "Shows or hides the terminal"
+            "state": "translated",
+            "value": "Blendet das Terminal ein oder aus"
           }
         },
         "en": {
           "stringUnit": {
-            "state": "new",
+            "state": "translated",
             "value": "Shows or hides the terminal"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Shows or hides the terminal"
+            "state": "translated",
+            "value": "Muestra u oculta la terminal"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Shows or hides the terminal"
+            "state": "translated",
+            "value": "Affiche ou masque le terminal"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "new",
-            "value": "Shows or hides the terminal"
+            "state": "translated",
+            "value": "ターミナルの表示を切り替えます"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Shows or hides the terminal"
+            "state": "translated",
+            "value": "터미널을 표시하거나 가립니다"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Shows or hides the terminal"
+            "state": "translated",
+            "value": "Mostra ou oculta o terminal"
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Shows or hides the terminal"
+            "state": "translated",
+            "value": "Показывает или скрывает терминал"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "new",
-            "value": "Shows or hides the terminal"
+            "state": "translated",
+            "value": "显示或隐藏终端"
           }
         }
       }

--- a/Pine/MinimapView.swift
+++ b/Pine/MinimapView.swift
@@ -117,7 +117,10 @@ final class MinimapView: NSView {
         setAccessibilityIdentifier(AccessibilityID.minimap)
         setAccessibilityElement(true)
         setAccessibilityRole(.group)
-        setAccessibilityLabel("Minimap")
+        setAccessibilityLabel(Strings.a11yMinimapLabel)
+        // AppKit has no hint attribute on a plain NSView — `help` is its
+        // vehicle for the same "what does this do" text (#1529).
+        setAccessibilityHelp(Strings.a11yMinimapHint)
 
         NotificationCenter.default.addObserver(
             self, selector: #selector(contentDidChange),

--- a/Pine/QuickOpenView.swift
+++ b/Pine/QuickOpenView.swift
@@ -100,6 +100,9 @@ struct QuickOpenView: View {
                                         result.fileName
                                     )
                                 )
+                                .accessibilityHint(
+                                    Strings.a11yQuickOpenItemHint
+                                )
                                 .accessibilityAddTraits(
                                     CommandOverlayRowAccessibility
                                         .selectionTraits(

--- a/Pine/StatusBarView.swift
+++ b/Pine/StatusBarView.swift
@@ -279,11 +279,13 @@ struct StatusBarView: View {
             }
             .buttonStyle(.plain)
             .accessibilityIdentifier(AccessibilityID.terminalToggleButton)
+            .accessibilityHint(Strings.a11yTerminalToggleHint)
         }
         .padding(.horizontal, LayoutMetrics.statusBarHorizontalPadding)
         .frame(height: LayoutMetrics.statusBarHeight)
         .background(.bar)
         .accessibilityElement(children: .contain)
+        .accessibilityLabel(Strings.a11yStatusBarLabel)
         .accessibilityIdentifier(AccessibilityID.statusBar)
     }
 

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -2299,6 +2299,25 @@ enum Strings {
         )
     }
 
+    /// The secondary label of a symbol-navigator row. Reads the catalog key
+    /// `%@ — line %lld`, whose translations may reorder the parts, instead of
+    /// hand-building the string (#1529).
+    static func symbolNavigatorItemDetail(
+        kind: String,
+        line: Int
+    ) -> String {
+        String(
+            format: String(localized: "%@ — line %lld"),
+            kind,
+            line
+        )
+    }
+
+    /// The Go to Line field's placeholder, from its existing catalog key
+    /// rather than the literal (#1529).
+    static let goToLineFieldPlaceholder: String =
+        String(localized: "42 or 42:10")
+
     private static func localizedString(
         forKey key: String,
         fallback: String,

--- a/Pine/SymbolNavigatorView.swift
+++ b/Pine/SymbolNavigatorView.swift
@@ -223,6 +223,9 @@ struct SymbolNavigatorView: View {
                                         entry.symbol.name
                                     )
                                 )
+                                .accessibilityHint(
+                                    Strings.a11ySymbolItemHint
+                                )
                                 .accessibilityAddTraits(
                                     CommandOverlayRowAccessibility
                                         .selectionTraits(
@@ -320,7 +323,12 @@ struct SymbolNavigatorView: View {
             entry.symbol.kind,
             locale: locale
         )
-        return "\(kind) — line \(entry.line)"
+        // The localized "kind — line N" format, not a hand-built string —
+        // the catalog key exists translated in all nine locales (#1529).
+        return Strings.symbolNavigatorItemDetail(
+            kind: kind,
+            line: entry.line
+        )
     }
 
     // MARK: - Loading

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -351,7 +351,7 @@ struct TerminalPaneTabBar: View {
                 .buttonStyle(.plain)
                 .help(Strings.newTerminal)
                 .accessibilityIdentifier(AccessibilityID.newTerminalButton)
-                .accessibilityLabel(Strings.newTerminal)
+                .accessibilityLabel(Strings.a11yNewTerminalLabel)
                 .accessibilityAddTraits(.isButton)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -382,8 +382,8 @@ struct TerminalPaneTabBar: View {
             .accessibilityIdentifier(AccessibilityID.maximizeTerminalButton)
             .accessibilityLabel(
                 paneManager.maximizedPaneID == paneID
-                    ? Strings.restoreTerminal
-                    : Strings.maximizeTerminal
+                    ? Strings.a11yRestoreTerminalLabel
+                    : Strings.a11yMaximizeTerminalLabel
             )
 
             // Close terminal pane

--- a/PineTests/AccessibilityStringGuardTests.swift
+++ b/PineTests/AccessibilityStringGuardTests.swift
@@ -1,0 +1,122 @@
+//
+//  AccessibilityStringGuardTests.swift
+//  PineTests
+//
+//  The guard half of #1529. Wiring ten accessors and translating nineteen
+//  keys fixes those; it does nothing about the next `a11y.*` key someone
+//  adds English-only, or the next accessor authored and never shown to
+//  VoiceOver. So the invariant is stated over the source and the catalog
+//  themselves, the way `MenuHardcodedShortcutGuardTests` states its own.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Accessibility strings are wired and translated")
+struct AccessibilityStringGuardTests {
+    /// What VoiceOver reads is user-facing text: every `a11y.*` key must be
+    /// translated in all nine shipped locales.
+    static let shippedLocales = [
+        "en", "de", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-Hans",
+    ]
+
+    /// Accessors and catalog keys currently owned by the in-flight #1586,
+    /// which wires the three git-status names and translates their keys.
+    /// Once that branch merges, the set is empty on `main` too — delete
+    /// this property and both references to it below together.
+    static let ownedByInFlightPR = [
+        "a11yGitStatusAdded",
+        "a11yGitStatusModified",
+        "a11yGitStatusUntracked",
+    ]
+
+    /// The catalog keys behind ``ownedByInFlightPR`` — spelled out, because
+    /// the catalog does not camelCase its key segments uniformly
+    /// (`a11y.gitStatus.modified`, but `a11y.branchSwitcher.hint`).
+    static let catalogKeysOwnedByInFlightPR: Set<String> = [
+        "a11y.gitStatus.added",
+        "a11y.gitStatus.modified",
+        "a11y.gitStatus.untracked",
+    ]
+
+    @Test("Every a11y accessor in Strings.swift is referenced by a view")
+    func everyAccessorReachesAView() throws {
+        let root = try ProductionSourceScan.repositoryRoot()
+        let stringsSource = try String(
+            contentsOf: root.appendingPathComponent("Pine/Strings.swift"),
+            encoding: .utf8
+        )
+
+        let declared = Set(
+            stringsSource.matches(of: /static (?:let|var|func) (a11y\w+)/)
+                .map { String($0.1) }
+        )
+        #expect(
+            !declared.isEmpty,
+            "The scan found no accessors — the regex no longer matches, so this guard proves nothing"
+        )
+
+        var referenced: Set<String> = []
+        for url in try ProductionSourceScan.productionSwiftFileURLs() {
+            guard url.lastPathComponent != "Strings.swift" else { continue }
+            let source = try String(contentsOf: url, encoding: .utf8)
+            referenced.formUnion(
+                source.matches(of: /Strings\.(a11y\w+)/)
+                    .map { String($0.1) }
+            )
+        }
+
+        let dead = declared.subtracting(referenced)
+        #expect(
+            dead.isSubset(of: Set(Self.ownedByInFlightPR)),
+            """
+            Dead a11y accessors — authored, localized, and never shown to \
+            VoiceOver: \(dead.sorted()). Wire each one into the view it \
+            names, or delete it from Strings.swift and the catalog (#1529).
+            """
+        )
+    }
+
+    @Test("Every a11y catalog key is translated in all nine locales")
+    func everyCatalogKeyIsTranslated() throws {
+        let root = try ProductionSourceScan.repositoryRoot()
+        let data = try Data(
+            contentsOf: root.appendingPathComponent("Pine/Localizable.xcstrings")
+        )
+        let catalog = try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let strings = try #require(catalog["strings"] as? [String: Any])
+
+        var offenders: [String] = []
+        for (key, value) in strings where key.hasPrefix("a11y.") {
+            let localizations = (value as? [String: Any])?["localizations"]
+                as? [String: Any] ?? [:]
+            for locale in Self.shippedLocales {
+                let unit = (localizations[locale] as? [String: Any])?["stringUnit"]
+                    as? [String: Any]
+                let state = unit?["state"] as? String
+                if state != "translated" {
+                    offenders.append("\(key) [\(locale): \(state ?? "missing")]")
+                }
+            }
+        }
+
+        let residual = Set(
+            offenders.map {
+                $0.prefix(while: { $0 != "[" })
+                    .trimmingCharacters(in: .whitespaces)
+            }
+        ).subtracting(Self.catalogKeysOwnedByInFlightPR)
+        #expect(
+            residual.isEmpty,
+            """
+            a11y keys that ship untranslated: \(offenders). Accessibility \
+            text is user-facing text; add the eight missing translations or \
+            do not ship the key (#1529).
+            """
+        )
+    }
+}


### PR DESCRIPTION
Closes #1529. On top of, and independent of, #1586 (which owns the three `a11y.gitStatus.*` keys).

## What was wrong

Ten `a11y` accessors in `Strings.swift` were authored and localized but read by no view — dead code paths that buy false confidence. 19 `a11y.*` catalog keys shipped English in all nine locales. Two strings bypassed their fully translated catalog keys entirely.

## What this does

**Wired (10 accessors → the controls they name):**

| Accessor | Surface |
|---|---|
| `a11yBranchSwitcherHint` | branch rows in the Branch Switcher |
| `a11yMinimapLabel` / `a11yMinimapHint` | the minimap group (replaces the hardcoded `"Minimap"`; AppKit has no hint attribute on a plain `NSView`, so the hint rides `setAccessibilityHelp`) |
| `a11yNewTerminalLabel` | the terminal pane's `+` button (was the menu string) |
| `a11yMaximizeTerminalLabel` / `a11yRestoreTerminalLabel` | the maximize/restore button's state-dependent label (was the menu strings) |
| `a11yQuickOpenItemHint` | Quick Open result rows |
| `a11ySymbolItemHint` | Symbol Navigator result rows |
| `a11yStatusBarLabel` | the status bar group (alongside its existing `.contain`) |
| `a11yTerminalToggleHint` | the status bar terminal toggle |

**Translated:** the 16 keys this branch owns, ×8 locales, by targeted text insertion in the existing block shape — 270 lines replaced symmetrically, no reserialization. The remaining 3 (`a11y.gitStatus.*`) ship translated in #1586.

**De-bypassed:** `SymbolNavigatorView`'s row detail now reads `%1$@ — line %2$lld` from the catalog (`Strings.symbolNavigatorItemDetail`) instead of hand-building `\(kind) — line \(line)`; the Go to Line placeholder reads its key instead of the literal `"42 or 42:10"`. Both keys were fully translated in all nine locales since before this branch — the translations simply never rendered.

**Guarded, so this cannot regrow:** `AccessibilityStringGuardTests` states the invariant over the source and catalog themselves, in the `MenuHardcodedShortcutGuardTests` style:

1. every `a11y` accessor declared in `Strings.swift` must be referenced from production code (else: wire it or delete it);
2. every `a11y.*` catalog key must carry `state: translated` in all nine locales.

Both tests carry the three git-status names/keys as "owned by in-flight #1586" with explicit instructions to delete the exception when that branch merges — after which the sets must be empty on `main`.

## Verification

- `AccessibilityStringGuardTests` — 2/2 green locally.
- The audit repro from the issue, re-run on this branch: 13 dead accessors → 3 (all #1586's); 19 untranslated keys → 3 (all #1586's).
- `swiftlint` 0 violations; touched-area suites green: StatusBar, EditorTabItem, BranchSwitcher, SymbolNavigator and GoToLine snapshots byte-identical (EN values resolve to the same strings), GoToLine unit tests, and the #1533 status-bar hosted-a11y suite.
- Catalog JSON re-validated; `a11y.*` key count unchanged at 40.

## Merge timing

Ready to merge when CI is green — merge after or together with #1586 (the guard's in-flight exception references it). Rides the next 2.6.x via Release Please.