### PR TITLE
fix(agent): survive slow shell mounts and keep valid worktrees switchable

### DIFF
--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -11834,6 +11834,21 @@
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "Pine 无法打开“%@”。" } }
       }
     },
+    "projectSwitcher.error.openWorktree %@ %@": {
+      "comment": "Agent worktree open failure. First argument is the branch, second is the project name.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Pine konnte den Agent-Worktree „%@“ für „%@“ nicht öffnen." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Pine couldn’t open the “%@” agent worktree for “%@”." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Pine no pudo abrir el worktree de agente «%@» para «%@»." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Pine n’a pas pu ouvrir le worktree d’agent « %@ » pour « %@ »." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Pineでエージェントworktree「%@」（プロジェクト「%@」）を開けませんでした。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "Pine에서 에이전트 worktree ‘%@’(%@ 프로젝트)를 열 수 없습니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "O Pine não pôde abrir a worktree de agente “%@” do projeto “%@”." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Pine не удалось открыть worktree агента «%@» для проекта «%@»." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Pine 无法打开“%@”智能体工作树（项目“%@”）。" } }
+      }
+    },
     "projectSwitcher.error.title": {
       "comment": "Title for project switcher and agent launch errors.",
       "extractionState": "manual",

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -11841,7 +11841,7 @@
         "de": { "stringUnit": { "state": "translated", "value": "Pine konnte den Agent-Worktree „%@“ für „%@“ nicht öffnen." } },
         "en": { "stringUnit": { "state": "translated", "value": "Pine couldn’t open the “%@” agent worktree for “%@”." } },
         "es": { "stringUnit": { "state": "translated", "value": "Pine no pudo abrir el worktree de agente «%@» para «%@»." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Pine n’a pas pu ouvrir le worktree d’agent « %@ » pour « %@ »." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Pine n’a pas pu ouvrir le worktree d’agent « %@ » pour « %@ »." } },
         "ja": { "stringUnit": { "state": "translated", "value": "Pineでエージェントworktree「%@」（プロジェクト「%@」）を開けませんでした。" } },
         "ko": { "stringUnit": { "state": "translated", "value": "Pine에서 에이전트 worktree ‘%@’(%@ 프로젝트)를 열 수 없습니다." } },
         "pt-BR": { "stringUnit": { "state": "translated", "value": "O Pine não pôde abrir a worktree de agente “%@” do projeto “%@”." } },

--- a/Pine/Logging.swift
+++ b/Pine/Logging.swift
@@ -21,6 +21,7 @@ nonisolated enum LogCategory: String, CaseIterable {
     case lsp
     case task
     case extensibility
+    case agent
 
     /// Subsystem для всех логгеров Pine.
     static let subsystem = Bundle.main.bundleIdentifier ?? "io.github.batonogov.pine"
@@ -61,5 +62,11 @@ nonisolated extension Logger {
     /// Lightweight extensibility: user grammars, keybindings (issue #1009).
     static let extensibility = Logger(
         subsystem: LogCategory.subsystem, category: LogCategory.extensibility.rawValue
+    )
+
+    /// Agent launches: worktree creation, admission, PTY start, reservations
+    /// (issue #1590).
+    static let agent = Logger(
+        subsystem: LogCategory.subsystem, category: LogCategory.agent.rawValue
     )
 }

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -2828,7 +2828,9 @@ final class ProjectRegistry: LSPSettingsObserver {
             ) else { return false }
             // The window can refuse — the directory may have gone missing
             // between admission and here, and the session drops targets it
-            // cannot activate. Only claim the window if it took the project.
+            // cannot activate (a managed worktree whose root still exists
+            // is the one target it deliberately keeps, #1590). Only claim
+            // the window if it took the project.
             if session.contains(canonicalProjectURL(projectURL)) {
                 openProjectWindow(session.sceneProjectURL)
                 return true

--- a/Pine/ProjectWindowSession.swift
+++ b/Pine/ProjectWindowSession.swift
@@ -8,6 +8,7 @@
 import CryptoKit
 import Foundation
 import Observation
+import os
 
 nonisolated struct ProjectAgentLaunchOption: Identifiable, Equatable, Sendable {
     let id: String
@@ -466,12 +467,50 @@ final class ProjectWindowSession {
             manager = registry.projectManager(for: target)
         }
         guard let manager else {
+            let worktree = managedWorktrees[target]
             if reportFailure {
-                alertMessage = Strings.projectSwitcherOpenFailureText(
-                    target.lastPathComponent
+                alertMessage = if let worktree {
+                    Strings.projectSwitcherWorktreeOpenFailureText(
+                        Self.shortBranchName(worktree.branchName),
+                        projectName: displayName(for: worktree.repositoryRoot)
+                    )
+                } else {
+                    Strings.projectSwitcherOpenFailureText(
+                        target.lastPathComponent
+                    )
+                }
+            }
+            // A worktree the registry would not admit is not necessarily gone:
+            // the admission revalidates the live filesystem, and a transient
+            // miss in the noisy moment after a launch used to evict a healthy
+            // worktree from the session forever while it stayed on disk,
+            // unreachable from every surface (issue #1590). Only a root that
+            // no longer exists ends its membership; anything else stays
+            // switchable so the user can simply click it again.
+            let worktreeStillExists: Bool
+            if let worktree {
+                worktreeStillExists = await Self.worktreeRootExists(
+                    worktree.worktreeRoot
+                )
+            } else {
+                worktreeStillExists = false
+            }
+            if worktree == nil || !worktreeStillExists {
+                if worktree == nil {
+                    Logger.agent.error(
+                        "Evicting unavailable project \(target.path, privacy: .public)"
+                    )
+                } else {
+                    Logger.agent.error(
+                        "Evicting worktree \(worktree?.worktreeRoot.path ?? target.path, privacy: .public): the root no longer exists on disk"
+                    )
+                }
+                removeUnavailableTarget(target)
+            } else {
+                Logger.agent.error(
+                    "Worktree \(worktree?.worktreeRoot.path ?? target.path, privacy: .public) kept in the session: activation refused, root exists"
                 )
             }
-            removeUnavailableTarget(target)
             return
         }
         guard target != activeProjectURL else {
@@ -629,6 +668,9 @@ final class ProjectWindowSession {
             agentIdentifier: option.id,
             worktreeID: worktreeID
         )
+        Logger.agent.debug(
+            "Launching agent \(option.id, privacy: .public) in \(repository.path, privacy: .public) on branch \(branch, privacy: .public)"
+        )
         let result = await worktreeService.create(AgentWorktreeCreateRequest(
             taskID: worktreeID,
             repositoryRoot: repository,
@@ -637,14 +679,24 @@ final class ProjectWindowSession {
             startPoint: "HEAD"
         ))
         guard case .created(let worktree) = result else {
+            Logger.agent.error(
+                "Worktree creation failed: \(Self.worktreeFailureDescription(result), privacy: .public)"
+            )
             alertMessage = Strings.projectSwitcherWorktreeFailureText(
                 Self.worktreeFailureDescription(result)
             )
             return
         }
+        Logger.agent.debug(
+            "Worktree created at \(worktree.worktreeRoot.path, privacy: .public)"
+        )
         guard let manager = await registry.projectManager(for: worktree) else {
-            alertMessage = Strings.projectSwitcherOpenFailureText(
-                worktree.worktreeRoot.lastPathComponent
+            Logger.agent.error(
+                "Registry refused to admit fresh worktree \(worktree.worktreeRoot.path, privacy: .public)"
+            )
+            alertMessage = Strings.projectSwitcherWorktreeOpenFailureText(
+                Self.shortBranchName(worktree.branchName),
+                projectName: displayName(for: worktree.repositoryRoot)
             )
             return
         }
@@ -671,6 +723,9 @@ final class ProjectWindowSession {
             )
             return
         }
+        Logger.agent.debug(
+            "Agent \(option.id, privacy: .public) launched in \(worktree.worktreeRoot.path, privacy: .public)"
+        )
         defaults.set(option.id, forKey: Self.lastAgentIdentifierKey)
     }
 
@@ -740,6 +795,21 @@ final class ProjectWindowSession {
             projectURLs.removeAll { $0 == target }
         }
         saveState()
+    }
+
+    /// Whether a worktree's checkout is still on disk. File I/O stays off the
+    /// main actor (#1509's pool rule); a missing root is the one eviction
+    /// reason that cannot be retried, so the answer decides membership.
+    nonisolated private static func worktreeRootExists(
+        _ root: URL
+    ) async -> Bool {
+        await runOnBackground(qos: .userInitiated) {
+            var isDirectory: ObjCBool = false
+            return FileManager.default.fileExists(
+                atPath: root.path,
+                isDirectory: &isDirectory
+            ) && isDirectory.boolValue
+        }
     }
 
     private func saveState() {

--- a/Pine/ProjectWindowSession.swift
+++ b/Pine/ProjectWindowSession.swift
@@ -459,15 +459,16 @@ final class ProjectWindowSession {
     ) async {
         guard !isLaunchingAgent else { return }
         let target = url.standardizedFileURL
+        let worktreeLookupKey = Self.worktreeMembershipKey(url)
 
         let manager: ProjectManager?
-        if let worktree = managedWorktrees[target] {
+        if let worktree = managedWorktrees[worktreeLookupKey] {
             manager = await registry.projectManager(for: worktree)
         } else {
             manager = registry.projectManager(for: target)
         }
         guard let manager else {
-            let worktree = managedWorktrees[target]
+            let worktree = managedWorktrees[worktreeLookupKey]
             if reportFailure {
                 alertMessage = if let worktree {
                     Strings.projectSwitcherWorktreeOpenFailureText(
@@ -495,21 +496,26 @@ final class ProjectWindowSession {
             } else {
                 worktreeStillExists = false
             }
-            if worktree == nil || !worktreeStillExists {
-                if worktree == nil {
-                    Logger.agent.error(
-                        "Evicting unavailable project \(target.path, privacy: .public)"
-                    )
-                } else {
-                    Logger.agent.error(
-                        "Evicting worktree \(worktree?.worktreeRoot.path ?? target.path, privacy: .public): the root no longer exists on disk"
-                    )
-                }
+            if worktree == nil {
+                Logger.agent.error(
+                    "Evicting unavailable project \(target.path, privacy: .public)"
+                )
                 removeUnavailableTarget(target)
+            } else if !worktreeStillExists {
+                Logger.agent.error(
+                    "Evicting worktree \(worktree?.worktreeRoot.path ?? target.path, privacy: .public): the root no longer exists on disk"
+                )
+                removeUnavailableTarget(worktreeLookupKey)
             } else {
                 Logger.agent.error(
                     "Worktree \(worktree?.worktreeRoot.path ?? target.path, privacy: .public) kept in the session: activation refused, root exists"
                 )
+                // Persist the current truth even though nothing switched.
+                // A restore whose remembered active URL was this worktree
+                // returns `.unavailable` before `restoreIfNeeded`'s own
+                // save, and without this write the stale active URL would
+                // dismiss that scene to Welcome on every relaunch forever.
+                saveState()
             }
             return
         }
@@ -795,6 +801,20 @@ final class ProjectWindowSession {
             projectURLs.removeAll { $0 == target }
         }
         saveState()
+    }
+
+    /// A stable dictionary key for directory-valued membership URLs.
+    /// `standardizedFileURL` consults the filesystem on modern Foundation
+    /// and drops the trailing slash once the path stops hosting a
+    /// directory, so a worktree replaced by a regular file would miss its
+    /// own entry and an eviction would write under a dead key (#1590).
+    nonisolated private static func worktreeMembershipKey(
+        _ url: URL
+    ) -> URL {
+        URL(
+            fileURLWithPath: url.standardizedFileURL.path,
+            isDirectory: true
+        )
     }
 
     /// Whether a worktree's checkout is still on disk. File I/O stays off the

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -942,6 +942,26 @@ enum Strings {
         )
     }
 
+    /// Names the branch and its project rather than the worktree's UUID
+    /// directory: a person deciding whether to retry has no use for the UUID
+    /// (issue #1590).
+    static func projectSwitcherWorktreeOpenFailureText(
+        _ branchName: String,
+        projectName: String,
+        locale: Locale = .current
+    ) -> String {
+        let format = localizedString(
+            forKey: "projectSwitcher.error.openWorktree %@ %@",
+            fallback: "Pine couldn’t open the “%@” agent worktree for “%@”.",
+            locale: locale
+        )
+        return String(
+            format: format,
+            locale: locale,
+            arguments: [branchName, projectName]
+        )
+    }
+
     static func projectSwitcherAgentMissingText(
         _ agentName: String,
         locale: Locale = .current

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import os
 
 nonisolated enum AgentTaskRecoveryLaunchResult: Equatable, Sendable {
     case openedNewSession(terminalID: UUID)
@@ -709,38 +710,95 @@ final class TerminalManager {
     /// waits for its exact PTY generation to become writable, then uses the
     /// existing Pine-owned reservation path to launch one known agent token.
     /// The shell remains interactive after the agent exits.
+    ///
+    /// The wait budget has to cover the whole chain that stands between tab
+    /// creation and a live shell: SwiftUI mounting the just-transitioned
+    /// worktree project, AppKit giving the terminal container real bounds
+    /// (a zero-sized placeholder must not spawn the PTY), the async
+    /// working-directory admission validation, and SwiftTerm's fork. Three
+    /// seconds covered none of that on a large first render (issue #1590), so
+    /// the budget is generous while the deterministic dead ends — admission
+    /// refusal, a tab that died first — fail in one hop.
     func launchAgentInNewTerminal(
         _ command: String,
         descriptor: AgentDescriptor,
         workingDirectory: URL,
-        maximumAttempts: Int = 120,
+        maximumAttempts: Int = TerminalManager
+            .agentLaunchProcessStartAttempts,
         waitForNextAttempt: (@MainActor () async -> Void)? = nil
     ) async -> AgentTaskLaunchResult {
-        guard Self.exactAgentLaunchDescriptor(for: command) == descriptor,
-              !isPermanentlyInvalidated else { return .rejected }
+        let descriptorMatches =
+            Self.exactAgentLaunchDescriptor(for: command) == descriptor
+        guard descriptorMatches, !isPermanentlyInvalidated else {
+            Logger.agent.error(
+                "Agent launch rejected before terminal creation (descriptor \(descriptorMatches), invalidated \(self.isPermanentlyInvalidated))"
+            )
+            return .rejected
+        }
         ensureAgentDetectionStarted()
         guard let (_, tab) = createTerminalTabForRecovery(
             workingDirectory: workingDirectory,
             initialProcess: nil
-        ) else { return .rejected }
+        ) else {
+            Logger.agent.error(
+                "Agent launch could not create a terminal tab at \(workingDirectory.path, privacy: .public)"
+            )
+            return .rejected
+        }
 
         let wait = waitForNextAttempt ?? {
             try? await Task.sleep(for: .milliseconds(25))
         }
+        var attempts = 0
         for _ in 0..<max(0, maximumAttempts) where !tab.isProcessRunning {
             guard !Task.isCancelled else {
                 cancelAgentLaunch(in: tab)
                 return .rejected
             }
+            if tab.isTerminated {
+                Logger.agent.error(
+                    "Agent launch terminal ended before its shell started (after \(attempts) waits)"
+                )
+                return .rejected
+            }
+            if tab.processStartAdmissionRefused {
+                Logger.agent.error(
+                    "Agent launch shell start was refused by working-directory admission (after \(attempts) waits)"
+                )
+                return .rejected
+            }
+            attempts += 1
             await wait()
         }
-        guard tab.isProcessRunning else { return .rejected }
-        return await launchAgentCommand(
+        guard tab.isProcessRunning else {
+            Logger.agent.error(
+                "Agent launch shell never started: \(attempts) waits exhausted at \(workingDirectory.path, privacy: .public)"
+            )
+            return .rejected
+        }
+        Logger.agent.debug(
+            "Agent launch shell started after \(attempts) waits at \(workingDirectory.path, privacy: .public)"
+        )
+        let launch = await launchAgentCommand(
             command,
             descriptor: descriptor,
             in: tab
         )
+        if case .reserved = launch {
+            Logger.agent.debug("Agent launch reserved its terminal")
+        } else {
+            Logger.agent.error(
+                "Agent launch command did not reserve: \(String(describing: launch), privacy: .public)"
+            )
+        }
+        return launch
     }
+
+    /// 25 ms per attempt × 800 attempts = a 20 s ceiling for the shell to come
+    /// up. Real mounts finish far inside it; the ceiling exists so a launch
+    /// that can never succeed still reports, rather than hanging the session's
+    /// `isLaunchingAgent` gate forever.
+    static let agentLaunchProcessStartAttempts = 800
 
 #if DEBUG
     var agentCallbacksFrozenForTesting: Bool {

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -750,6 +750,7 @@ final class TerminalManager {
             try? await Task.sleep(for: .milliseconds(25))
         }
         var attempts = 0
+        var refusalRekicks = 0
         for _ in 0..<max(0, maximumAttempts) where !tab.isProcessRunning {
             guard !Task.isCancelled else {
                 cancelAgentLaunch(in: tab)
@@ -762,10 +763,24 @@ final class TerminalManager {
                 return .rejected
             }
             if tab.processStartAdmissionRefused {
-                Logger.agent.error(
-                    "Agent launch shell start was refused by working-directory admission (after \(attempts) waits)"
+                // The mark means "the last attempt was refused", not "this
+                // directory is forbidden": a transient admission miss must
+                // not turn into the launch failure it is meant to prevent
+                // (#1590). Re-arm one fresh validation before believing it;
+                // a genuine refusal repeats and still fails fast.
+                guard refusalRekicks < 2 else {
+                    Logger.agent.error(
+                        "Agent launch shell start was refused by working-directory admission twice (after \(attempts) waits)"
+                    )
+                    return .rejected
+                }
+                refusalRekicks += 1
+                Logger.agent.debug(
+                    "Agent launch re-arming terminal validation after a refused admission (re-kick \(refusalRekicks))"
                 )
-                return .rejected
+                tab.startIfNeeded()
+                await wait()
+                continue
             }
             attempts += 1
             await wait()
@@ -784,19 +799,28 @@ final class TerminalManager {
             descriptor: descriptor,
             in: tab
         )
-        if case .reserved = launch {
+        switch launch {
+        case .reserved:
             Logger.agent.debug("Agent launch reserved its terminal")
-        } else {
+        case .sentWithoutReservation:
+            // The command reached the shell but no reservation was armed —
+            // an agent may be running unmanaged. Operational, hence error.
             Logger.agent.error(
-                "Agent launch command did not reserve: \(String(describing: launch), privacy: .public)"
+                "Agent launch command was sent without a reservation at \(workingDirectory.path, privacy: .public)"
+            )
+        case .rejected:
+            Logger.agent.error(
+                "Agent launch command was rejected after the shell started at \(workingDirectory.path, privacy: .public)"
             )
         }
         return launch
     }
 
-    /// 25 ms per attempt × 800 attempts = a 20 s ceiling for the shell to come
-    /// up. Real mounts finish far inside it; the ceiling exists so a launch
-    /// that can never succeed still reports, rather than hanging the session's
+    /// 25 ms per attempt × 800 attempts = a 20 s ceiling for the shell to
+    /// come up — measured in idle main-actor time: each hop resumes on the
+    /// main actor, so heavy contention stretches the wall clock further.
+    /// Real mounts finish far inside it; the ceiling exists so a launch that
+    /// can never succeed still reports, rather than hanging the session's
     /// `isLaunchingAgent` gate forever.
     static let agentLaunchProcessStartAttempts = 800
 

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -1936,6 +1936,12 @@ final class TerminalTab: Identifiable, Hashable {
     private let shellSettings: ShellSettings
     private let agentHandoffSettings: AgentHandoffSettings
     private var processStarted = false
+    /// The most recent start attempt was refused by the working-directory
+    /// admission validator, so the shell will not spawn until a later
+    /// `startIfNeeded()` revalidates successfully. `launchAgentInNewTerminal`
+    /// fast-fails on this instead of burning its whole wait budget on a tab
+    /// that has already been told "no" (issue #1590).
+    private(set) var processStartAdmissionRefused = false
     /// Identity-qualified ownership for the exact shell generation and every
     /// observed descendant launched through this tab's real PTY.
     private var processTreeController: TerminalProcessTreeController?
@@ -2168,6 +2174,9 @@ final class TerminalTab: Identifiable, Hashable {
         processStartValidationGeneration = UUID()
         processStartValidationTask?.cancel()
         processStartValidationTask = nil
+        // A new validator is a new set of rules; a refusal recorded against
+        // the old one must not fast-fail a launch that this one would admit.
+        processStartAdmissionRefused = false
         workingDirectoryValidator = validator
     }
 
@@ -2263,9 +2272,14 @@ final class TerminalTab: Identifiable, Hashable {
               terminalView.frame.size.height > 0 else { return }
         if let workingDirectory, let workingDirectoryValidator {
             let generation = processStartValidationGeneration
+            // The mark describes the *last* outcome; a fresh attempt is now
+            // underway, so it must not read as a standing refusal while this
+            // validation is pending.
+            processStartAdmissionRefused = false
             processStartValidationTask = Task { @MainActor [weak self] in
                 guard await workingDirectoryValidator(workingDirectory) else {
                     self?.processStartValidationTask = nil
+                    self?.markProcessStartRefused()
                     return
                 }
                 #if DEBUG
@@ -2274,8 +2288,11 @@ final class TerminalTab: Identifiable, Hashable {
                 let valid = await workingDirectoryValidator(workingDirectory)
                 guard let self else { return }
                 self.processStartValidationTask = nil
+                guard valid else {
+                    self.markProcessStartRefused()
+                    return
+                }
                 guard !Task.isCancelled,
-                      valid,
                       !self.isTerminated,
                       !self.processStarted,
                       self.processStartValidationGeneration == generation,
@@ -2287,9 +2304,21 @@ final class TerminalTab: Identifiable, Hashable {
         startProcessNow()
     }
 
+    /// A refused start is a dead end for this attempt, not a pause: surface it
+    /// for callers and for the log, so an agent launch that can never come up
+    /// fails in one hop instead of after a full wait budget.
+    private func markProcessStartRefused() {
+        guard !processStartAdmissionRefused else { return }
+        processStartAdmissionRefused = true
+        Logger.terminal.error(
+            "Terminal shell start refused by working-directory admission at \(self.workingDirectory?.path ?? "?", privacy: .public)"
+        )
+    }
+
     private func startProcessNow() {
         guard !isTerminated, !processStarted else { return }
         processStarted = true
+        processStartAdmissionRefused = false
 
         let env = buildEnvironment()
         let envStrings = env.map { "\($0.key)=\($0.value)" }

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -2162,6 +2162,11 @@ final class TerminalTab: Identifiable, Hashable {
     ) {
         self.workingDirectory = workingDirectory
         self.initialProcess = initialProcess
+        // A rebound directory is a new admission question. Rotate the
+        // validation generation so a refusal recorded against the previous
+        // directory cannot fast-fail a launch into this one.
+        processStartValidationGeneration = UUID()
+        processStartAdmissionRefused = false
     }
 
     /// Installs the project admission validator used immediately before a
@@ -2278,8 +2283,15 @@ final class TerminalTab: Identifiable, Hashable {
             processStartAdmissionRefused = false
             processStartValidationTask = Task { @MainActor [weak self] in
                 guard await workingDirectoryValidator(workingDirectory) else {
-                    self?.processStartValidationTask = nil
-                    self?.markProcessStartRefused()
+                    // Generation fence: a validator superseded by a rebind or
+                    // a re-admission must not poison the current attempt —
+                    // the same token rule that guards the spawn below.
+                    guard let self,
+                          !Task.isCancelled,
+                          self.processStartValidationGeneration == generation
+                    else { return }
+                    self.processStartValidationTask = nil
+                    self.markProcessStartRefused()
                     return
                 }
                 #if DEBUG
@@ -2287,11 +2299,15 @@ final class TerminalTab: Identifiable, Hashable {
                 #endif
                 let valid = await workingDirectoryValidator(workingDirectory)
                 guard let self else { return }
-                self.processStartValidationTask = nil
                 guard valid else {
+                    guard !Task.isCancelled,
+                          self.processStartValidationGeneration == generation
+                    else { return }
+                    self.processStartValidationTask = nil
                     self.markProcessStartRefused()
                     return
                 }
+                self.processStartValidationTask = nil
                 guard !Task.isCancelled,
                       !self.isTerminated,
                       !self.processStarted,

--- a/PineTests/AgentLaunchResilienceTests.swift
+++ b/PineTests/AgentLaunchResilienceTests.swift
@@ -5,8 +5,14 @@
 //  Issue #1590: the agent launch chain used to die inside a fixed
 //  three-second PTY budget and evict healthy worktrees from the window
 //  session after a single refused activation. These tests pin the wait
-//  behaviour, the fast-fail on deterministic dead ends, and the retention
-//  rule for worktrees whose root is still on disk.
+//  behaviour, the fast-fail on deterministic dead ends, the re-arm after a
+//  transient refusal, and the retention rule for worktrees whose root is
+//  still on disk.
+//
+//  Terminal tests spawn real PTY children, so this suite is serialized and
+//  injects a no-op detection runner — forking `/bin/ps` from a test host is
+//  the documented macos-26 hang (#1060), and these tests outlive the
+//  coordinator's first poll.
 //
 
 import AppKit
@@ -16,8 +22,44 @@ import Testing
 
 @testable import Pine
 
-@Suite("Agent launch resilience")
+/// Polls a condition on a wall-clock deadline and reports a distinguishable
+/// expectation failure when the deadline hits, so triage reads "deadline
+/// exhausted", not a silent wrong predicate.
+@MainActor
+private func waitUntil(
+    _ what: String,
+    within limit: ContinuousClock.Duration,
+    condition: () -> Bool
+) async {
+    let deadline = ContinuousClock.now + limit
+    while ContinuousClock.now < deadline {
+        if condition() { return }
+        try? await Task.sleep(for: .milliseconds(2))
+    }
+    #expect(condition(), "deadline exhausted waiting for \(what)")
+}
+
+/// A sendable first-call-only switch: the first evaluation reads `false`,
+/// every later one `true`. Used to model an admission that refuses once —
+/// the transient miss this suite has to survive — and admits afterwards.
+nonisolated private final class RefuseOnce: @unchecked Sendable {
+    private let lock = NSLock()
+    private var calls = 0
+
+    func validator() -> Bool {
+        lock.withLock {
+            calls += 1
+            return calls > 1
+        }
+    }
+}
+
+@Suite("Agent launch resilience", .serialized)
 struct AgentLaunchResilienceTests {
+
+    private static let noOpProcessRunner: ProcessRunner = { _, _, _, _ in
+        ProcessRunResult(stdout: "", stderr: "", exitCode: 0, timedOut: false)
+    }
 
     private static func claudeDescriptor() throws -> AgentDescriptor {
         try #require(TerminalManager.exactAgentLaunchDescriptor(for: "claude"))
@@ -25,10 +67,22 @@ struct AgentLaunchResilienceTests {
 
     private static func makeManager() -> (PaneManager, TerminalManager) {
         let paneManager = PaneManager()
-        let manager = TerminalManager()
+        // TerminalManager holds the pane weakly; the caller must keep it
+        // alive for the whole launch.
+        let manager = TerminalManager(
+            agentDetectionProcessRunner: noOpProcessRunner
+        )
         manager.paneManager = paneManager
         return (paneManager, manager)
     }
+
+    /// A process that never exits and never reads stdin: the PTY write the
+    /// launch performs lands in the tty line discipline (echo) and nowhere
+    /// else, so no command of the user's environment ever executes.
+    private static let inertProcess = TerminalInitialProcess(
+        executablePath: "/bin/sleep",
+        arguments: ["60"]
+    )
 
     // MARK: - Admission refusal is observable on the tab
 
@@ -36,8 +90,9 @@ struct AgentLaunchResilienceTests {
     @MainActor
     func refusedAdmissionMarksTabWithoutSpawning() async throws {
         let (paneManager, manager) = Self.makeManager()
-        // A nil working directory bypasses admission validation entirely;
-        // the validator only runs for a tab that names its directory.
+        defer { manager.terminateAll() }
+        // The validator only runs for a tab that names its working
+        // directory, so the tab must carry a real one.
         manager.createTerminalTab(
             relativeTo: paneManager.activePaneID,
             workingDirectory: FileManager.default.temporaryDirectory
@@ -47,21 +102,20 @@ struct AgentLaunchResilienceTests {
         tab.configureWorkingDirectoryValidation { _ in false }
         tab.terminalView.frame = NSRect(x: 0, y: 0, width: 640, height: 320)
         tab.startIfNeeded()
-        for _ in 0..<200 where tab.isStartValidationPendingForTesting {
-            try? await Task.sleep(for: .milliseconds(2))
-        }
+        await waitUntil(
+            "the validation task to conclude",
+            within: .milliseconds(400)
+        ) { [weak tab] in tab?.isStartValidationPendingForTesting == false }
 
         #expect(tab.processStartAdmissionRefused)
         #expect(!tab.isProcessRunning)
-        manager.terminateAll()
     }
 
     @Test("a later successful start clears the refusal mark")
     @MainActor
     func successfulStartClearsRefusalMark() async throws {
         let (paneManager, manager) = Self.makeManager()
-        // A nil working directory bypasses admission validation entirely;
-        // the validator only runs for a tab that names its directory.
+        defer { manager.terminateAll() }
         manager.createTerminalTab(
             relativeTo: paneManager.activePaneID,
             workingDirectory: FileManager.default.temporaryDirectory
@@ -71,31 +125,38 @@ struct AgentLaunchResilienceTests {
         tab.configureWorkingDirectoryValidation { _ in false }
         tab.terminalView.frame = NSRect(x: 0, y: 0, width: 640, height: 320)
         tab.startIfNeeded()
-        for _ in 0..<200 where tab.isStartValidationPendingForTesting {
-            try? await Task.sleep(for: .milliseconds(2))
-        }
+        await waitUntil(
+            "the first validation task to conclude",
+            within: .milliseconds(400)
+        ) { [weak tab] in tab?.isStartValidationPendingForTesting == false }
         #expect(tab.processStartAdmissionRefused)
 
         // A relayout re-runs `startIfNeeded`; an admitting validator now
-        // lets the shell through and the mark must not outlive it.
+        // lets the process through and the mark must not outlive it.
+        tab.configure(
+            workingDirectory: FileManager.default.temporaryDirectory,
+            initialProcess: Self.inertProcess
+        )
         tab.configureWorkingDirectoryValidation { _ in true }
         tab.startIfNeeded()
-        for _ in 0..<200 where tab.isStartValidationPendingForTesting {
-            try? await Task.sleep(for: .milliseconds(2))
-        }
-        for _ in 0..<200 where !tab.isProcessRunning {
-            try? await Task.sleep(for: .milliseconds(5))
-        }
+        await waitUntil(
+            "the second validation task to conclude",
+            within: .milliseconds(400)
+        ) { [weak tab] in tab?.isStartValidationPendingForTesting == false }
+        await waitUntil(
+            "the inert process to spawn",
+            within: .seconds(2)
+        ) { [weak tab] in tab?.isProcessRunning == true }
 
         #expect(tab.isProcessRunning)
         #expect(!tab.processStartAdmissionRefused)
-        manager.terminateAll()
     }
 
     @Test("re-arming the validator clears a standing refusal")
     @MainActor
     func rearmingValidatorClearsRefusal() async throws {
         let (paneManager, manager) = Self.makeManager()
+        defer { manager.terminateAll() }
         manager.createTerminalTab(
             relativeTo: paneManager.activePaneID,
             workingDirectory: FileManager.default.temporaryDirectory
@@ -105,27 +166,58 @@ struct AgentLaunchResilienceTests {
         tab.configureWorkingDirectoryValidation { _ in false }
         tab.terminalView.frame = NSRect(x: 0, y: 0, width: 640, height: 320)
         tab.startIfNeeded()
-        for _ in 0..<200 where tab.isStartValidationPendingForTesting {
-            try? await Task.sleep(for: .milliseconds(2))
-        }
+        await waitUntil(
+            "the validation task to conclude",
+            within: .milliseconds(400)
+        ) { [weak tab] in tab?.isStartValidationPendingForTesting == false }
         #expect(tab.processStartAdmissionRefused)
 
         // A re-admitted project installs a fresh validator; the old refusal
         // must not fast-fail a launch that the new rules would admit.
         tab.configureWorkingDirectoryValidation { _ in true }
         #expect(!tab.processStartAdmissionRefused)
-        manager.terminateAll()
+    }
+
+    @Test("rebinding the working directory clears a standing refusal")
+    @MainActor
+    func rebindingDirectoryClearsRefusal() async throws {
+        let (paneManager, manager) = Self.makeManager()
+        defer { manager.terminateAll() }
+        manager.createTerminalTab(
+            relativeTo: paneManager.activePaneID,
+            workingDirectory: FileManager.default.temporaryDirectory
+        )
+        let tab = try #require(manager.allTerminalTabs.first)
+
+        tab.configureWorkingDirectoryValidation { _ in false }
+        tab.terminalView.frame = NSRect(x: 0, y: 0, width: 640, height: 320)
+        tab.startIfNeeded()
+        await waitUntil(
+            "the validation task to conclude",
+            within: .milliseconds(400)
+        ) { [weak tab] in tab?.isStartValidationPendingForTesting == false }
+        #expect(tab.processStartAdmissionRefused)
+
+        // A rebound directory is a new admission question (#1590 review):
+        // the mark recorded against the previous directory must not survive.
+        tab.configure(
+            workingDirectory: FileManager.default.temporaryDirectory
+                .appendingPathComponent("rebound", isDirectory: true),
+            initialProcess: Self.inertProcess
+        )
+        #expect(!tab.processStartAdmissionRefused)
     }
 
     // MARK: - launchAgentInNewTerminal wait behaviour
 
-    @Test("launch fast-fails when the shell start is refused by admission")
+    @Test("launch fast-fails when the shell start is refused again after a re-arm")
     @MainActor
-    func launchFastFailsOnAdmissionRefusal() async throws {
+    func launchFastFailsOnRepeatedAdmissionRefusal() async throws {
         // The pane must stay alive for the whole launch: TerminalManager
         // holds it weakly.
         let (paneManager, manager) = Self.makeManager()
         _ = paneManager
+        defer { manager.terminateAll() }
         var waits = 0
         let result = await manager.launchAgentInNewTerminal(
             "claude",
@@ -135,21 +227,33 @@ struct AgentLaunchResilienceTests {
             waitForNextAttempt: {
                 waits += 1
                 if waits == 1, let tab = manager.allTerminalTabs.first {
+                    // Always refuse: both the first attempt and each
+                    // re-armed one must be told "no", so the launch can
+                    // only conclude by fast-fail, never by spawning.
                     tab.configureWorkingDirectoryValidation { _ in false }
                     tab.terminalView.frame = NSRect(
                         x: 0, y: 0, width: 640, height: 320
                     )
                     tab.startIfNeeded()
                 }
-                await Task.yield()
+                // Hand control back only once no validation is in flight:
+                // the loop's next look at the mark then reflects a
+                // concluded outcome, not a task parked on another
+                // executor that a yield would not wake (SE-0338).
+                if let tab = manager.allTerminalTabs.first {
+                    let deadline = ContinuousClock.now + .milliseconds(400)
+                    while tab.isStartValidationPendingForTesting,
+                          ContinuousClock.now < deadline {
+                        try? await Task.sleep(for: .milliseconds(2))
+                    }
+                }
             }
         )
 
         #expect(result == .rejected)
-        // The refusal is a dead end: the remaining budget must not be spent
-        // polling a tab that has already been told "no".
-        #expect(waits <= 3)
-        manager.terminateAll()
+        // One initial wait plus one per re-arm (two allowed): a tab that
+        // has now thrice been told "no" must not consume the budget.
+        #expect(waits == 3)
     }
 
     @Test("launch fast-fails when the terminal dies before its shell starts")
@@ -159,6 +263,7 @@ struct AgentLaunchResilienceTests {
         // holds it weakly.
         let (paneManager, manager) = Self.makeManager()
         _ = paneManager
+        defer { manager.terminateAll() }
         var waits = 0
         let result = await manager.launchAgentInNewTerminal(
             "claude",
@@ -176,19 +281,64 @@ struct AgentLaunchResilienceTests {
 
         #expect(result == .rejected)
         #expect(waits == 1)
-        manager.terminateAll()
     }
 
-    @Test("launch waits past the old three-second budget for a slow shell")
+    @Test("launch re-arms once after a transient admission refusal")
     @MainActor
-    func launchWaitsPastOldBudgetForSlowShell() async throws {
+    func launchRecoversFromTransientRefusal() async throws {
         // The pane must stay alive for the whole launch: TerminalManager
         // holds it weakly.
         let (paneManager, manager) = Self.makeManager()
         _ = paneManager
+        defer { manager.terminateAll() }
         var waits = 0
-        // 150 waits is already past the entire old budget of 120 attempts,
-        // which used to reject the launch and orphan the worktree.
+        let result = await manager.launchAgentInNewTerminal(
+            "claude",
+            descriptor: try Self.claudeDescriptor(),
+            workingDirectory: FileManager.default.temporaryDirectory,
+            maximumAttempts: 400,
+            waitForNextAttempt: {
+                waits += 1
+                if waits == 1, let tab = manager.allTerminalTabs.first {
+                    // The first validation refuses (a transient miss); the
+                    // re-armed second one admits: the launch must proceed,
+                    // not die on the first "no" (#1590 review).
+                    let refuseOnce = RefuseOnce()
+                    tab.configureWorkingDirectoryValidation { _ in
+                        refuseOnce.validator()
+                    }
+                    tab.configure(
+            workingDirectory: FileManager.default.temporaryDirectory,
+            initialProcess: Self.inertProcess
+        )
+                    tab.terminalView.frame = NSRect(
+                        x: 0, y: 0, width: 640, height: 320
+                    )
+                    tab.startIfNeeded()
+                }
+                try? await Task.sleep(for: .milliseconds(2))
+            }
+        )
+
+        // No registry is installed, so an acknowledged write reports as a
+        // sent-without-reservation — the launch got past the wait.
+        #expect(result == .sentWithoutReservation)
+        #expect(manager.allTerminalTabs.first?.isProcessRunning == true)
+    }
+
+    @Test("launch keeps waiting past the old three-second budget")
+    @MainActor
+    func launchWaitsPastOldBudgetForSlowStart() async throws {
+        // The pane must stay alive for the whole launch: TerminalManager
+        // holds it weakly.
+        let (paneManager, manager) = Self.makeManager()
+        _ = paneManager
+        defer { manager.terminateAll() }
+        var waits = 0
+        // The PTY fork itself is synchronous, so "slow" here is the loop's
+        // patience, not the fork: the process is armed on wait 150 — past
+        // the entire old budget of 120 attempts, which used to reject the
+        // launch and orphan the worktree.
         let result = await manager.launchAgentInNewTerminal(
             "claude",
             descriptor: try Self.claudeDescriptor(),
@@ -196,6 +346,10 @@ struct AgentLaunchResilienceTests {
             waitForNextAttempt: {
                 waits += 1
                 if waits == 150, let tab = manager.allTerminalTabs.first {
+                    tab.configure(
+            workingDirectory: FileManager.default.temporaryDirectory,
+            initialProcess: Self.inertProcess
+        )
                     tab.terminalView.frame = NSRect(
                         x: 0, y: 0, width: 640, height: 320
                     )
@@ -205,18 +359,14 @@ struct AgentLaunchResilienceTests {
             }
         )
 
-        #expect(result != .rejected)
-        // The shell came up on wait 150 — past the entire old budget — and
-        // `process.running` is set by the fork itself, so the wait that
-        // started it can also be the last one counted.
+        #expect(result == .sentWithoutReservation)
         #expect(waits >= 150)
         #expect(manager.allTerminalTabs.first?.isProcessRunning == true)
-        manager.terminateAll()
     }
 
-    @Test("the default wait budget stays far above the old 120 attempts")
-    func defaultBudgetExceedsOldCeiling() {
-        #expect(TerminalManager.agentLaunchProcessStartAttempts >= 800)
+    @Test("the default wait budget is the documented 20-second ceiling")
+    func defaultBudgetMatchesDocumentedCeiling() {
+        #expect(TerminalManager.agentLaunchProcessStartAttempts == 800)
     }
 }
 
@@ -227,6 +377,9 @@ struct AgentWorktreeSessionRetentionTests {
         ProcessRunResult(stdout: "", stderr: "", exitCode: 0, timedOut: false)
     }
 
+    /// A real repository with a real linked worktree: the refusal these
+    /// tests need has to come from the admission chain, not from a fixture
+    /// that is not a git repository at all.
     @MainActor
     private final class Fixture {
         let root: URL
@@ -236,14 +389,22 @@ struct AgentWorktreeSessionRetentionTests {
         let defaults: UserDefaults
         private let suiteName: String
 
-        /// `worktreeOnDisk` decides whether the checkout exists, which is the
-        /// one fact that separates retention from eviction (issue #1590).
-        init(worktreeOnDisk: Bool) throws {
-            root = FileManager.default.temporaryDirectory
+        /// `worktreeOnDisk` decides whether the checkout exists, which is
+        /// the one fact that separates retention from eviction (#1590).
+        /// `worktreeIsFile` replaces the checkout with a regular file.
+        init(worktreeOnDisk: Bool, worktreeIsFile: Bool = false) throws {
+            let rootDirectory = FileManager.default.temporaryDirectory
                 .appendingPathComponent(
                     "Pine-AgentLaunchResilience-\(UUID().uuidString)",
                     isDirectory: true
                 )
+            var didCompleteSetup = false
+            defer {
+                if !didCompleteSetup {
+                    try? FileManager.default.removeItem(at: rootDirectory)
+                }
+            }
+            root = rootDirectory
             project = root.appendingPathComponent(
                 "Repository",
                 isDirectory: true
@@ -264,15 +425,62 @@ struct AgentWorktreeSessionRetentionTests {
                 at: managedRoot,
                 withIntermediateDirectories: true
             )
-            if worktreeOnDisk {
-                try FileManager.default.createDirectory(
-                    at: worktreeRoot,
-                    withIntermediateDirectories: true
+            try Self.git(["init", "--initial-branch=main"], at: project)
+            try Self.git(
+                ["config", "user.name", "Agent Launch Tests"],
+                at: project
+            )
+            try Self.git(
+                ["config", "user.email", "agent-launch-tests@pine.invalid"],
+                at: project
+            )
+            try Data("seed".utf8).write(
+                to: project.appendingPathComponent("seed.txt")
+            )
+            try Self.git(["add", "seed.txt"], at: project)
+            try Self.git(["commit", "-m", "seed"], at: project)
+            try Self.git(
+                [
+                    "worktree", "add", "--no-track", "-b",
+                    "pine/agent/codex/12345678", "--", worktreeRoot.path,
+                ],
+                at: project
+            )
+            if worktreeIsFile {
+                try FileManager.default.removeItem(at: worktreeRoot)
+                try Data("not a directory".utf8).write(
+                    to: URL(fileURLWithPath: worktreeRoot.path)
+                )
+            } else if !worktreeOnDisk {
+                try Self.git(
+                    [
+                        "worktree", "remove", "--force", "--",
+                        worktreeRoot.path,
+                    ],
+                    at: project
                 )
             }
             suiteName = "AgentLaunchResilienceTests.\(UUID().uuidString)"
             defaults = try #require(UserDefaults(suiteName: suiteName))
             defaults.removePersistentDomain(forName: suiteName)
+            didCompleteSetup = true
+        }
+
+        private static func git(
+            _ arguments: [String],
+            at directory: URL
+        ) throws {
+            let result = GitCommand.run(arguments, at: directory, timeout: 5)
+            guard result.succeeded else {
+                throw FixtureError.gitFailed(
+                    arguments: arguments,
+                    diagnostics: result.errorOutput
+                )
+            }
+        }
+
+        private enum FixtureError: Error {
+            case gitFailed(arguments: [String], diagnostics: String)
         }
 
         func makeRegistry() -> ProjectRegistry {
@@ -286,8 +494,9 @@ struct AgentWorktreeSessionRetentionTests {
         }
 
         func makeWorktree() -> AgentManagedWorktree {
-            // A proof that matches nothing on disk: the registry must refuse
-            // to admit this worktree, which is the failure under test.
+            // The repository and worktree are real, but the recorded proof
+            // matches nothing on disk, so admission fails the way it does
+            // for a healthy worktree after a repository-identity change.
             AgentManagedWorktree(
                 taskID: UUID(),
                 repositoryRoot: project,
@@ -305,34 +514,49 @@ struct AgentWorktreeSessionRetentionTests {
             )
         }
 
-        func makeSession(
-            worktree: AgentManagedWorktree
-        ) -> ProjectWindowSession {
+        struct PersistedFixture: Codable {
+            let version: Int
+            let projectURLs: [URL]
+            let worktrees: [AgentManagedWorktree]
+            let activeURL: URL?
+        }
+
+        private var persistenceKey: String {
             let digest = SHA256.hash(data: Data(
                 project.standardizedFileURL.path.utf8
             ))
             let suffix = digest.prefix(16).map {
                 String(format: "%02x", $0)
             }.joined()
-            struct PersistedFixture: Codable {
-                let version: Int
-                let projectURLs: [URL]
-                let worktrees: [AgentManagedWorktree]
-                let activeURL: URL
-            }
-            defaults.set(
-                try? JSONEncoder().encode(PersistedFixture(
-                    version: 1,
-                    projectURLs: [project],
-                    worktrees: [worktree],
-                    activeURL: project
-                )),
-                forKey: "projectWindowSession.\(suffix)"
-            )
-            return ProjectWindowSession(
+            return "projectWindowSession.\(suffix)"
+        }
+
+        func persist(
+            worktree: AgentManagedWorktree,
+            activeURL: URL
+        ) throws {
+            let data = try JSONEncoder().encode(PersistedFixture(
+                version: 1,
+                projectURLs: [project],
+                worktrees: [worktree],
+                activeURL: activeURL
+            ))
+            defaults.set(data, forKey: persistenceKey)
+        }
+
+        func makeSession() -> ProjectWindowSession {
+            ProjectWindowSession(
                 initialProjectURL: project,
                 defaults: defaults
             )
+        }
+
+        func persistedActiveURL() throws -> URL? {
+            let data = try #require(defaults.data(forKey: persistenceKey))
+            return try JSONDecoder().decode(
+                PersistedFixture.self,
+                from: data
+            ).activeURL
         }
 
         func cleanup() {
@@ -345,10 +569,11 @@ struct AgentWorktreeSessionRetentionTests {
     @MainActor
     func refusedActivationKeepsLiveWorktree() async throws {
         let fixture = try Fixture(worktreeOnDisk: true)
-        defer { fixture.cleanup() }
         let registry = fixture.makeRegistry()
+        defer { fixture.cleanup() }
         let worktree = fixture.makeWorktree()
-        let session = fixture.makeSession(worktree: worktree)
+        try fixture.persist(worktree: worktree, activeURL: fixture.project)
+        let session = fixture.makeSession()
         _ = await session.restoreIfNeeded(registry: registry)
         #expect(session.managedWorktrees.count == 1)
 
@@ -367,10 +592,11 @@ struct AgentWorktreeSessionRetentionTests {
     @MainActor
     func refusedActivationEvictsMissingWorktree() async throws {
         let fixture = try Fixture(worktreeOnDisk: false)
-        defer { fixture.cleanup() }
         let registry = fixture.makeRegistry()
+        defer { fixture.cleanup() }
         let worktree = fixture.makeWorktree()
-        let session = fixture.makeSession(worktree: worktree)
+        try fixture.persist(worktree: worktree, activeURL: fixture.project)
+        let session = fixture.makeSession()
         _ = await session.restoreIfNeeded(registry: registry)
         #expect(session.managedWorktrees.count == 1)
 
@@ -378,17 +604,39 @@ struct AgentWorktreeSessionRetentionTests {
 
         #expect(session.managedWorktrees.isEmpty)
         #expect(session.alertMessage != nil)
-        #expect(session.projectURLs.count == 1)
+        #expect(
+            session.projectURLs == [fixture.project.standardizedFileURL]
+        )
+    }
+
+    @Test("a worktree root replaced by a file evicts too")
+    @MainActor
+    func refusedActivationEvictsFileRoot() async throws {
+        let fixture = try Fixture(worktreeOnDisk: true, worktreeIsFile: true)
+        let registry = fixture.makeRegistry()
+        defer { fixture.cleanup() }
+        let worktree = fixture.makeWorktree()
+        try fixture.persist(worktree: worktree, activeURL: fixture.project)
+        let session = fixture.makeSession()
+        _ = await session.restoreIfNeeded(registry: registry)
+        #expect(session.managedWorktrees.count == 1)
+
+        await session.activate(worktree.worktreeRoot, registry: registry)
+
+        // A regular file where the checkout should be is not a worktree
+        // the user can retry into.
+        #expect(session.managedWorktrees.isEmpty)
     }
 
     @Test("a plain project that cannot open still reports and leaves")
     @MainActor
     func plainProjectFailureStillEvicts() async throws {
         let fixture = try Fixture(worktreeOnDisk: true)
-        defer { fixture.cleanup() }
         let registry = fixture.makeRegistry()
+        defer { fixture.cleanup() }
         let worktree = fixture.makeWorktree()
-        let session = fixture.makeSession(worktree: worktree)
+        try fixture.persist(worktree: worktree, activeURL: fixture.project)
+        let session = fixture.makeSession()
         _ = await session.restoreIfNeeded(registry: registry)
 
         let missing = fixture.root.appendingPathComponent(
@@ -403,22 +651,69 @@ struct AgentWorktreeSessionRetentionTests {
         #expect(alert.contains("Vanished"))
         #expect(session.managedWorktrees.count == 1)
     }
+
+    @Test("a refused restore rewrites the remembered active URL")
+    @MainActor
+    func refusedRestoreHealsRememberedActiveURL() async throws {
+        let fixture = try Fixture(worktreeOnDisk: true)
+        let registry = fixture.makeRegistry()
+        defer { fixture.cleanup() }
+        let worktree = fixture.makeWorktree()
+        // The window was showing the worktree when it closed; on relaunch
+        // admission refuses it. The refusal keeps the entry (the root
+        // exists) but must not leave the dead active URL remembered, or
+        // every relaunch would dismiss the scene back to Welcome.
+        try fixture.persist(
+            worktree: worktree,
+            activeURL: worktree.worktreeRoot
+        )
+        let session = fixture.makeSession()
+        _ = await session.restoreIfNeeded(registry: registry)
+        #expect(session.managedWorktrees.count == 1)
+
+        let remembered = try fixture.persistedActiveURL()
+        #expect(remembered == fixture.project.standardizedFileURL)
+
+        // The next relaunch restores normally instead of wedging.
+        let second = fixture.makeSession()
+        let result = await second.restoreIfNeeded(registry: registry)
+        if case .restored = result {} else {
+            Issue.record("second restore did not complete: \(result)")
+        }
+    }
 }
 
 @Suite("Agent worktree open-failure text")
 struct AgentWorktreeOpenFailureTextTests {
 
-    @Test("the text names the branch and the project, never the raw UUID")
-    func textNamesBranchAndProject() {
-        for locale in [Locale(identifier: "en_US"), Locale(identifier: "ru_RU")] {
+    private static let locales = [
+        "en_US", "de_DE", "es_ES", "fr_FR", "ja_JP", "ko_KR", "pt_BR",
+        "ru_RU", "zh_Hans_CN",
+    ]
+
+    @Test("every locale names the branch first, then the project, once each")
+    func textNamesBranchAndProjectInOrder() {
+        for identifier in Self.locales {
             let text = Strings.projectSwitcherWorktreeOpenFailureText(
                 "codex/12345678",
-                projectName: "pine",
-                locale: locale
+                projectName: "fixture-project",
+                locale: Locale(identifier: identifier)
             )
-            #expect(text.contains("codex/12345678"))
-            #expect(text.contains("pine"))
-            #expect(!text.contains("%@"))
+            guard let branch = text.range(of: "codex/12345678"),
+                  let project = text.range(of: "fixture-project") else {
+                Issue.record(
+                    "\(identifier): an argument went unresolved in \(text)"
+                )
+                continue
+            }
+            #expect(
+                branch.lowerBound < project.lowerBound,
+                "\(identifier): the branch must precede the project — got \(text)"
+            )
+            #expect(
+                !text.contains("%@"),
+                "\(identifier): unresolved format specifier in \(text)"
+            )
         }
     }
 }

--- a/PineTests/AgentLaunchResilienceTests.swift
+++ b/PineTests/AgentLaunchResilienceTests.swift
@@ -1,0 +1,424 @@
+//
+//  AgentLaunchResilienceTests.swift
+//  PineTests
+//
+//  Issue #1590: the agent launch chain used to die inside a fixed
+//  three-second PTY budget and evict healthy worktrees from the window
+//  session after a single refused activation. These tests pin the wait
+//  behaviour, the fast-fail on deterministic dead ends, and the retention
+//  rule for worktrees whose root is still on disk.
+//
+
+import AppKit
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Agent launch resilience")
+struct AgentLaunchResilienceTests {
+
+    private static func claudeDescriptor() throws -> AgentDescriptor {
+        try #require(TerminalManager.exactAgentLaunchDescriptor(for: "claude"))
+    }
+
+    private static func makeManager() -> (PaneManager, TerminalManager) {
+        let paneManager = PaneManager()
+        let manager = TerminalManager()
+        manager.paneManager = paneManager
+        return (paneManager, manager)
+    }
+
+    // MARK: - Admission refusal is observable on the tab
+
+    @Test("a refused working-directory admission marks the tab and never spawns")
+    @MainActor
+    func refusedAdmissionMarksTabWithoutSpawning() async throws {
+        let (paneManager, manager) = Self.makeManager()
+        // A nil working directory bypasses admission validation entirely;
+        // the validator only runs for a tab that names its directory.
+        manager.createTerminalTab(
+            relativeTo: paneManager.activePaneID,
+            workingDirectory: FileManager.default.temporaryDirectory
+        )
+        let tab = try #require(manager.allTerminalTabs.first)
+
+        tab.configureWorkingDirectoryValidation { _ in false }
+        tab.terminalView.frame = NSRect(x: 0, y: 0, width: 640, height: 320)
+        tab.startIfNeeded()
+        for _ in 0..<200 where tab.isStartValidationPendingForTesting {
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+
+        #expect(tab.processStartAdmissionRefused)
+        #expect(!tab.isProcessRunning)
+        manager.terminateAll()
+    }
+
+    @Test("a later successful start clears the refusal mark")
+    @MainActor
+    func successfulStartClearsRefusalMark() async throws {
+        let (paneManager, manager) = Self.makeManager()
+        // A nil working directory bypasses admission validation entirely;
+        // the validator only runs for a tab that names its directory.
+        manager.createTerminalTab(
+            relativeTo: paneManager.activePaneID,
+            workingDirectory: FileManager.default.temporaryDirectory
+        )
+        let tab = try #require(manager.allTerminalTabs.first)
+
+        tab.configureWorkingDirectoryValidation { _ in false }
+        tab.terminalView.frame = NSRect(x: 0, y: 0, width: 640, height: 320)
+        tab.startIfNeeded()
+        for _ in 0..<200 where tab.isStartValidationPendingForTesting {
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        #expect(tab.processStartAdmissionRefused)
+
+        // A relayout re-runs `startIfNeeded`; an admitting validator now
+        // lets the shell through and the mark must not outlive it.
+        tab.configureWorkingDirectoryValidation { _ in true }
+        tab.startIfNeeded()
+        for _ in 0..<200 where tab.isStartValidationPendingForTesting {
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        for _ in 0..<200 where !tab.isProcessRunning {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+
+        #expect(tab.isProcessRunning)
+        #expect(!tab.processStartAdmissionRefused)
+        manager.terminateAll()
+    }
+
+    @Test("re-arming the validator clears a standing refusal")
+    @MainActor
+    func rearmingValidatorClearsRefusal() async throws {
+        let (paneManager, manager) = Self.makeManager()
+        manager.createTerminalTab(
+            relativeTo: paneManager.activePaneID,
+            workingDirectory: FileManager.default.temporaryDirectory
+        )
+        let tab = try #require(manager.allTerminalTabs.first)
+
+        tab.configureWorkingDirectoryValidation { _ in false }
+        tab.terminalView.frame = NSRect(x: 0, y: 0, width: 640, height: 320)
+        tab.startIfNeeded()
+        for _ in 0..<200 where tab.isStartValidationPendingForTesting {
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        #expect(tab.processStartAdmissionRefused)
+
+        // A re-admitted project installs a fresh validator; the old refusal
+        // must not fast-fail a launch that the new rules would admit.
+        tab.configureWorkingDirectoryValidation { _ in true }
+        #expect(!tab.processStartAdmissionRefused)
+        manager.terminateAll()
+    }
+
+    // MARK: - launchAgentInNewTerminal wait behaviour
+
+    @Test("launch fast-fails when the shell start is refused by admission")
+    @MainActor
+    func launchFastFailsOnAdmissionRefusal() async throws {
+        // The pane must stay alive for the whole launch: TerminalManager
+        // holds it weakly.
+        let (paneManager, manager) = Self.makeManager()
+        _ = paneManager
+        var waits = 0
+        let result = await manager.launchAgentInNewTerminal(
+            "claude",
+            descriptor: try Self.claudeDescriptor(),
+            workingDirectory: FileManager.default.temporaryDirectory,
+            maximumAttempts: 25,
+            waitForNextAttempt: {
+                waits += 1
+                if waits == 1, let tab = manager.allTerminalTabs.first {
+                    tab.configureWorkingDirectoryValidation { _ in false }
+                    tab.terminalView.frame = NSRect(
+                        x: 0, y: 0, width: 640, height: 320
+                    )
+                    tab.startIfNeeded()
+                }
+                await Task.yield()
+            }
+        )
+
+        #expect(result == .rejected)
+        // The refusal is a dead end: the remaining budget must not be spent
+        // polling a tab that has already been told "no".
+        #expect(waits <= 3)
+        manager.terminateAll()
+    }
+
+    @Test("launch fast-fails when the terminal dies before its shell starts")
+    @MainActor
+    func launchFastFailsOnTerminatedTab() async throws {
+        // The pane must stay alive for the whole launch: TerminalManager
+        // holds it weakly.
+        let (paneManager, manager) = Self.makeManager()
+        _ = paneManager
+        var waits = 0
+        let result = await manager.launchAgentInNewTerminal(
+            "claude",
+            descriptor: try Self.claudeDescriptor(),
+            workingDirectory: FileManager.default.temporaryDirectory,
+            maximumAttempts: 25,
+            waitForNextAttempt: {
+                waits += 1
+                if waits == 1, let tab = manager.allTerminalTabs.first {
+                    tab.stop()
+                }
+                await Task.yield()
+            }
+        )
+
+        #expect(result == .rejected)
+        #expect(waits == 1)
+        manager.terminateAll()
+    }
+
+    @Test("launch waits past the old three-second budget for a slow shell")
+    @MainActor
+    func launchWaitsPastOldBudgetForSlowShell() async throws {
+        // The pane must stay alive for the whole launch: TerminalManager
+        // holds it weakly.
+        let (paneManager, manager) = Self.makeManager()
+        _ = paneManager
+        var waits = 0
+        // 150 waits is already past the entire old budget of 120 attempts,
+        // which used to reject the launch and orphan the worktree.
+        let result = await manager.launchAgentInNewTerminal(
+            "claude",
+            descriptor: try Self.claudeDescriptor(),
+            workingDirectory: FileManager.default.temporaryDirectory,
+            waitForNextAttempt: {
+                waits += 1
+                if waits == 150, let tab = manager.allTerminalTabs.first {
+                    tab.terminalView.frame = NSRect(
+                        x: 0, y: 0, width: 640, height: 320
+                    )
+                    tab.startIfNeeded()
+                }
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+        )
+
+        #expect(result != .rejected)
+        // The shell came up on wait 150 — past the entire old budget — and
+        // `process.running` is set by the fork itself, so the wait that
+        // started it can also be the last one counted.
+        #expect(waits >= 150)
+        #expect(manager.allTerminalTabs.first?.isProcessRunning == true)
+        manager.terminateAll()
+    }
+
+    @Test("the default wait budget stays far above the old 120 attempts")
+    func defaultBudgetExceedsOldCeiling() {
+        #expect(TerminalManager.agentLaunchProcessStartAttempts >= 800)
+    }
+}
+
+@Suite("Agent worktree session retention")
+struct AgentWorktreeSessionRetentionTests {
+
+    private static let noOpProcessRunner: ProcessRunner = { _, _, _, _ in
+        ProcessRunResult(stdout: "", stderr: "", exitCode: 0, timedOut: false)
+    }
+
+    @MainActor
+    private final class Fixture {
+        let root: URL
+        let project: URL
+        let managedRoot: URL
+        let worktreeRoot: URL
+        let defaults: UserDefaults
+        private let suiteName: String
+
+        /// `worktreeOnDisk` decides whether the checkout exists, which is the
+        /// one fact that separates retention from eviction (issue #1590).
+        init(worktreeOnDisk: Bool) throws {
+            root = FileManager.default.temporaryDirectory
+                .appendingPathComponent(
+                    "Pine-AgentLaunchResilience-\(UUID().uuidString)",
+                    isDirectory: true
+                )
+            project = root.appendingPathComponent(
+                "Repository",
+                isDirectory: true
+            )
+            managedRoot = root.appendingPathComponent(
+                "Managed",
+                isDirectory: true
+            )
+            worktreeRoot = managedRoot.appendingPathComponent(
+                "616166cb-6a92-4735-aaf8-d7fa15e9b7ae",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(
+                at: project,
+                withIntermediateDirectories: true
+            )
+            try FileManager.default.createDirectory(
+                at: managedRoot,
+                withIntermediateDirectories: true
+            )
+            if worktreeOnDisk {
+                try FileManager.default.createDirectory(
+                    at: worktreeRoot,
+                    withIntermediateDirectories: true
+                )
+            }
+            suiteName = "AgentLaunchResilienceTests.\(UUID().uuidString)"
+            defaults = try #require(UserDefaults(suiteName: suiteName))
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        func makeRegistry() -> ProjectRegistry {
+            ProjectRegistry(
+                defaults: defaults,
+                agentDetectionProcessRunner:
+                    AgentWorktreeSessionRetentionTests.noOpProcessRunner,
+                agentDetectionPollInterval: 3_600,
+                backgroundReclamationInterval: .seconds(3_600)
+            )
+        }
+
+        func makeWorktree() -> AgentManagedWorktree {
+            // A proof that matches nothing on disk: the registry must refuse
+            // to admit this worktree, which is the failure under test.
+            AgentManagedWorktree(
+                taskID: UUID(),
+                repositoryRoot: project,
+                managedRoot: managedRoot,
+                worktreeRoot: worktreeRoot,
+                branchName: "pine/agent/codex/12345678",
+                baseCommit: String(repeating: "a", count: 40),
+                repositoryProof: RecentAgentTaskRepositoryProof(
+                    commonDirectoryDevice: 1,
+                    commonDirectoryInode: 2,
+                    commonDirectoryGeneration: 3,
+                    commonDirectoryBirthSeconds: 4,
+                    commonDirectoryBirthNanoseconds: 5
+                )
+            )
+        }
+
+        func makeSession(
+            worktree: AgentManagedWorktree
+        ) -> ProjectWindowSession {
+            let digest = SHA256.hash(data: Data(
+                project.standardizedFileURL.path.utf8
+            ))
+            let suffix = digest.prefix(16).map {
+                String(format: "%02x", $0)
+            }.joined()
+            struct PersistedFixture: Codable {
+                let version: Int
+                let projectURLs: [URL]
+                let worktrees: [AgentManagedWorktree]
+                let activeURL: URL
+            }
+            defaults.set(
+                try? JSONEncoder().encode(PersistedFixture(
+                    version: 1,
+                    projectURLs: [project],
+                    worktrees: [worktree],
+                    activeURL: project
+                )),
+                forKey: "projectWindowSession.\(suffix)"
+            )
+            return ProjectWindowSession(
+                initialProjectURL: project,
+                defaults: defaults
+            )
+        }
+
+        func cleanup() {
+            defaults.removePersistentDomain(forName: suiteName)
+            try? FileManager.default.removeItem(at: root)
+        }
+    }
+
+    @Test("a refused activation keeps a worktree whose root is still on disk")
+    @MainActor
+    func refusedActivationKeepsLiveWorktree() async throws {
+        let fixture = try Fixture(worktreeOnDisk: true)
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        let worktree = fixture.makeWorktree()
+        let session = fixture.makeSession(worktree: worktree)
+        _ = await session.restoreIfNeeded(registry: registry)
+        #expect(session.managedWorktrees.count == 1)
+
+        await session.activate(worktree.worktreeRoot, registry: registry)
+
+        // The activation was refused, yet the checkout exists: the session
+        // must keep the entry switchable instead of evicting it forever.
+        #expect(session.managedWorktrees.count == 1)
+        let alert = try #require(session.alertMessage)
+        #expect(alert.contains("codex/12345678"))
+        #expect(alert.contains("Repository"))
+        #expect(!alert.contains("616166cb-6a92-4735-aaf8-d7fa15e9b7ae"))
+    }
+
+    @Test("a refused activation evicts a worktree whose root is gone")
+    @MainActor
+    func refusedActivationEvictsMissingWorktree() async throws {
+        let fixture = try Fixture(worktreeOnDisk: false)
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        let worktree = fixture.makeWorktree()
+        let session = fixture.makeSession(worktree: worktree)
+        _ = await session.restoreIfNeeded(registry: registry)
+        #expect(session.managedWorktrees.count == 1)
+
+        await session.activate(worktree.worktreeRoot, registry: registry)
+
+        #expect(session.managedWorktrees.isEmpty)
+        #expect(session.alertMessage != nil)
+        #expect(session.projectURLs.count == 1)
+    }
+
+    @Test("a plain project that cannot open still reports and leaves")
+    @MainActor
+    func plainProjectFailureStillEvicts() async throws {
+        let fixture = try Fixture(worktreeOnDisk: true)
+        defer { fixture.cleanup() }
+        let registry = fixture.makeRegistry()
+        let worktree = fixture.makeWorktree()
+        let session = fixture.makeSession(worktree: worktree)
+        _ = await session.restoreIfNeeded(registry: registry)
+
+        let missing = fixture.root.appendingPathComponent(
+            "Vanished",
+            isDirectory: true
+        )
+        await session.activate(missing, registry: registry)
+
+        // The non-worktree path is unchanged: report the folder name and
+        // drop the target from the session.
+        let alert = try #require(session.alertMessage)
+        #expect(alert.contains("Vanished"))
+        #expect(session.managedWorktrees.count == 1)
+    }
+}
+
+@Suite("Agent worktree open-failure text")
+struct AgentWorktreeOpenFailureTextTests {
+
+    @Test("the text names the branch and the project, never the raw UUID")
+    func textNamesBranchAndProject() {
+        for locale in [Locale(identifier: "en_US"), Locale(identifier: "ru_RU")] {
+            let text = Strings.projectSwitcherWorktreeOpenFailureText(
+                "codex/12345678",
+                projectName: "pine",
+                locale: locale
+            )
+            #expect(text.contains("codex/12345678"))
+            #expect(text.contains("pine"))
+            #expect(!text.contains("%@"))
+        }
+    }
+}

--- a/PineTests/LoggerTests.swift
+++ b/PineTests/LoggerTests.swift
@@ -85,7 +85,7 @@ struct LoggerTests {
     // MARK: - CaseIterable
 
     @Test func expectedCategoryCount() {
-        #expect(LogCategory.allCases.count == 11)
+        #expect(LogCategory.allCases.count == 12)
     }
 
     @Test func allCasesContainsAllCategories() {
@@ -101,6 +101,7 @@ struct LoggerTests {
             .lsp,
             .task,
             .extensibility,
+            .agent,
         ]
         #expect(Set(LogCategory.allCases) == expected)
     }


### PR DESCRIPTION
Fixes #1590. Sibling of #1563.

## What was happening

Three real launches on 2026-08-31 (devops-team, pine, terraform-provider-remnawave) each created a healthy, git-registered worktree and then failed before the agent ever ran, leaving the worktree plus its `pine/agent/*` branch orphaned on disk with no Pine surface able to reach it. Two user-visible symptoms, one chain:

- **«Pine создал worktree, но не смог запустить Claude Code»** — `launchAgentInNewTerminal` polled `tab.isProcessRunning` for a fixed 120 × 25 ms. The PTY only starts after SwiftUI mounts the just-transitioned worktree project, AppKit gives the container real bounds, and the async working-directory admission passes — none of which is bounded by that budget.
- **«Pine не удалось открыть «616166cb-…»»** — a later click on the worktree row failed admission once, and `removeUnavailableTarget` evicted the entry from the session forever while the checkout stayed on disk. The alert printed the raw UUID directory name.

## What changed

- **`TerminalManager.launchAgentInNewTerminal`** — the wait budget is a documented 20 s ceiling (`agentLaunchProcessStartAttempts = 800`; measured in idle main-actor time — heavy contention stretches the wall clock). The two deterministic dead ends (admission refusal, a tab that died first) fail in a bounded number of hops; a refusal re-arms one fresh validation first, so a *transient* admission miss no longer becomes the launch failure the wait exists to prevent.
- **`TerminalTab`** — a refused working-directory admission is observable (`processStartAdmissionRefused`) and logged; the mark is set only behind the validation-generation fence, and is reset by a fresh attempt, a re-armed validator, a rebound directory (`configure`), or a successful start.
- **`ProjectWindowSession.activate`** — a refused activation evicts a managed worktree only when its root is gone from disk (existence checked off-main, pooled); the lookup goes through a normalized membership key because `standardizedFileURL` drops the trailing slash once a path stops hosting a directory. A kept worktree re-persists state so a remembered-but-refused active URL heals instead of dismissing its scene to Welcome on every relaunch.
- **Alerts** — worktree open failures name the branch and the project (`projectSwitcher.error.openWorktree %@ %@`), localized in all nine shipped locales via targeted xcstrings edits.
- **Diagnostics** — new `agent` log category covering the launch gates; the launch outcome distinguishes sent-without-reservation from a rejection.

## Review follow-up (second commit)

The first cut went through a five-lens independent review (correctness/concurrency, call-site regressions, test rigor, localization, repo conventions). The second commit fixes everything it found, including one regression the review caught in the first cut (a refused restore could wedge a scene into Welcome forever) and one latent key-normalization bug that the new file-at-root test then exposed empirically.

## Tests

`AgentLaunchResilienceTests` (serialized, no-op detection runner per #1060):
- refusal marks the tab and never spawns; a later successful start, a re-armed validator, and a rebound directory each clear the mark;
- launch fails fast on a repeated refusal and on a dead tab without burning the budget (wall-clock-determined waits, not yield ordering);
- launch recovers from a transient refusal via the re-arm (inert `/bin/sleep` process — no user shell, no agent CLI is ever executed);
- launch keeps waiting past the old 120-attempt budget (process armed at wait 150);
- the default budget is pinned to the documented 800.

`AgentWorktreeSessionRetentionTests` (real git repository + linked worktree fixtures, refusals come from the admission chain):
- refused activation keeps a worktree whose root exists (alert names the branch, never the UUID), evicts one whose root is gone, and evicts one replaced by a regular file;
- a plain project that cannot open still reports and leaves;
- a refused restore rewrites the remembered active URL and the next relaunch restores normally.

`AgentWorktreeOpenFailureTextTests`: all nine locales put the branch before the project with no unresolved specifier.

`LoggerTests` updated for the new category.

## Verification

- Full `xcodebuild build` green; `swiftlint` clean on all touched files.
- First push ran fully green CI (all 7 UI shards, unit tests, both lint lanes, Xcode 27 preview compatibility).
- Local full `PineTests`: every failure outside this diff's suites passes in isolation (documented local parallel-load flake pattern; CI is the signal). The one diff-related failure (`LoggerTests` count) is fixed.

## Ready to merge when

All CI checks are green on the final head. No migration, no settings, no API changes.