### PR TITLE
fix(agent): survive OS provenance restamps and re-derive a stale admission lease

### DIFF
--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -1573,6 +1573,11 @@ final class ProjectManager {
     #if DEBUG
     private(set) var editorServiceSuspendCountForTesting = 0
     private(set) var editorServiceResumeCountForTesting = 0
+    /// Locks the regression where a lease rebuild rotated the admission
+    /// generation and froze the workspace filesystem validator (#1593).
+    var admissionGenerationForTesting: UUID {
+        agentTaskFilesystemAdmissionGeneration
+    }
     #endif
     private var editorContextCommandGeneration: UInt64 = 0
     private let contextPresentationIdentity: ContextPresentationIdentity
@@ -2295,6 +2300,22 @@ final class ProjectManager {
         paneManager.allTerminalTabs.forEach(configureFilesystemAdmission)
     }
 
+    /// Re-derivation of the same admission rules after a refused
+    /// revalidation (#1593): identity and validation semantics are
+    /// unchanged, so the admission generation must NOT rotate here — a
+    /// workspace filesystem validator captured at `loadDirectory` keeps
+    /// comparing against that generation, and rotating it would make every
+    /// later tree reload fail validation and suspend the file watcher.
+    /// Suspended revalidations of the replaced lease stay fenced by the
+    /// `agentTaskFilesystemAdmission ===` identity check in
+    /// `revalidateAgentTaskFilesystemAdmission`.
+    private func swapRevalidatedAdmission(
+        _ admission: RecentAgentTaskFilesystemValidationLease
+    ) {
+        agentTaskFilesystemAdmission = admission
+        paneManager.allTerminalTabs.forEach(configureFilesystemAdmission)
+    }
+
     private func configureFilesystemAdmission(for tab: TerminalTab) {
         guard agentTaskFilesystemAdmission != nil else {
             tab.configureWorkingDirectoryValidation(nil)
@@ -2374,7 +2395,19 @@ final class ProjectManager {
         guard agentTaskFilesystemAdmission === staleAdmission,
               agentTaskFilesystemIdentity == identity,
               !Task.isCancelled else { return false }
-        replaceAgentTaskFilesystemAdmission(rebuilt, identity: identity)
+        swapRevalidatedAdmission(rebuilt)
+        // Re-arming tab validation cancels any in-flight terminal validation
+        // task — including the one whose refusal triggered this rebuild. A
+        // cancelled task exits without marking its refusal, and nothing else
+        // re-drives `startIfNeeded` (the validation fields are not read by
+        // any view), so a tab whose shell never came up would wait out the
+        // whole launch budget instead of starting against the rebuilt lease.
+        // Restart every tab that still has no live process.
+        paneManager.allTerminalTabs.forEach { tab in
+            if !tab.isProcessRunning {
+                tab.startIfNeeded()
+            }
+        }
         Logger.agent.error(
             "Rebuilt agent-task filesystem admission after a refused revalidation at \(identity.canonicalWorktreePath, privacy: .public)"
         )

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -1583,6 +1583,16 @@ final class ProjectManager {
     private var agentTaskFilesystemAdmissionGeneration = UUID()
     @ObservationIgnored
     private var agentTaskFilesystemIdentity: AgentTaskProjectIdentity?
+    /// When a refused admission revalidation last attempted a whole-lease
+    /// rebuild (#1593). Throttles the rebuild so a layout-driven refusal
+    /// loop cannot turn into a graph-walk storm.
+    @ObservationIgnored
+    private var admissionRebuildAttempt: ContinuousClock.Instant?
+    /// Minimum spacing between whole-lease rebuild attempts. A rebuild that
+    /// cannot succeed fails deterministically in `validationLease`, so
+    /// retrying sooner than this adds cost without adding information.
+    private static let admissionRebuildMinimumInterval: Duration =
+        .milliseconds(250)
 
     /// The crash-recovery entries still worth putting in front of the user.
     ///
@@ -2319,11 +2329,56 @@ final class ProjectManager {
         let valid = await Task.detached(priority: .utility) {
             admission.revalidate()
         }.value
-        return !Task.isCancelled
-            && valid
-            && agentTaskFilesystemAdmission === admission
-            && agentTaskFilesystemAdmissionGeneration == generation
-            && agentTaskFilesystemIdentity == identity
+        if valid {
+            return !Task.isCancelled
+                && agentTaskFilesystemAdmission === admission
+                && agentTaskFilesystemAdmissionGeneration == generation
+                && agentTaskFilesystemIdentity == identity
+        }
+        return await rebuildAgentTaskFilesystemAdmissionIfEligible(
+            replacing: admission,
+            identity: identity
+        )
+    }
+
+    /// A refused revalidation used to stay refused until the next full
+    /// project open, which stranded a fresh agent worktree behind a launch
+    /// that could never come up (#1593). The filesystem can legitimately
+    /// move past a captured descriptor — the OS restamps metadata,
+    /// `git worktree repair` rewrites control files — so before believing a
+    /// permanent refusal, rebuild the lease from the current graph and swap
+    /// it in when the recomputed proof still identifies the same repository.
+    /// Per-descriptor strictness is unchanged; this only re-derives the
+    /// baseline the descriptors compare against.
+    private func rebuildAgentTaskFilesystemAdmissionIfEligible(
+        replacing staleAdmission: RecentAgentTaskFilesystemValidationLease,
+        identity: AgentTaskProjectIdentity
+    ) async -> Bool {
+        guard !Task.isCancelled,
+              agentTaskFilesystemAdmission === staleAdmission,
+              agentTaskFilesystemIdentity == identity else { return false }
+        let now = ContinuousClock.now
+        if let last = admissionRebuildAttempt,
+           now - last < Self.admissionRebuildMinimumInterval {
+            return false
+        }
+        admissionRebuildAttempt = now
+        let expectedProof = staleAdmission.proof
+        let rebuilt = await Task.detached(priority: .utility) {
+            RecentAgentTaskFilesystemValidator.validationLease(
+                for: identity,
+                expectedProof: expectedProof
+            )
+        }.value
+        guard let rebuilt else { return false }
+        guard agentTaskFilesystemAdmission === staleAdmission,
+              agentTaskFilesystemIdentity == identity,
+              !Task.isCancelled else { return false }
+        replaceAgentTaskFilesystemAdmission(rebuilt, identity: identity)
+        Logger.agent.error(
+            "Rebuilt agent-task filesystem admission after a refused revalidation at \(identity.canonicalWorktreePath, privacy: .public)"
+        )
+        return true
     }
 
     // MARK: - Agent activity file-system correlation (#1072)

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -142,10 +142,22 @@ nonisolated private struct StableFilesystemObjectIdentity: Equatable, Sendable {
 nonisolated private final class StablePathDescriptor: @unchecked Sendable {
     let url: URL
     let descriptor: Int32
-    let information: stat
     let kind: UInt16
     private let parent: StablePathDescriptor?
     private let entryName: String?
+
+    /// Captured identity and metadata baseline. Mutable for exactly one
+    /// reason: adopting a metadata-only ctime bump that macOS issues
+    /// asynchronously on freshly created files (`com.apple.provenance`,
+    /// issue #1593). Guarded by its own lock because one lease's descriptors
+    /// revalidate concurrently from detached tasks.
+    private let informationLock = NSLock()
+    private var informationStorage: stat
+    var information: stat {
+        informationLock.lock()
+        defer { informationLock.unlock() }
+        return informationStorage
+    }
 
     init?(url: URL, kind: UInt16) {
         let flags = O_RDONLY | O_CLOEXEC | O_NOFOLLOW
@@ -167,7 +179,7 @@ nonisolated private final class StablePathDescriptor: @unchecked Sendable {
         }
         self.url = url
         self.descriptor = descriptor
-        self.information = information
+        self.informationStorage = information
         self.kind = kind
         parent = nil
         entryName = nil
@@ -207,7 +219,7 @@ nonisolated private final class StablePathDescriptor: @unchecked Sendable {
         }
         self.url = url
         self.descriptor = descriptor
-        self.information = information
+        self.informationStorage = information
         self.kind = kind
         self.parent = parent
         self.entryName = entryName
@@ -233,10 +245,11 @@ nonisolated private final class StablePathDescriptor: @unchecked Sendable {
         } else {
             pathResult = lstat(url.path, &pathState)
         }
+        let baseline = information
         guard fstat(descriptor, &descriptorState) == 0,
               pathResult == 0,
               RecentAgentTaskFilesystemValidator.stableIdentityMatches(
-                  information,
+                  baseline,
                   descriptorState,
                   kind: kind
               ),
@@ -246,8 +259,23 @@ nonisolated private final class StablePathDescriptor: @unchecked Sendable {
                   kind: kind
               ) else { return false }
         if kind == S_IFREG {
-            return RecentAgentTaskFilesystemValidator
-                .stableFileMetadataMatches(information, descriptorState)
+            guard RecentAgentTaskFilesystemValidator.stableFileStateMatches(
+                baseline,
+                descriptorState
+            ) else { return false }
+            // macOS stamps freshly created files with `com.apple.provenance`
+            // asynchronously — a ctime-only bump that can land long after
+            // this descriptor was captured and never reverts (#1593). Every
+            // field a content or ownership change would move (identity,
+            // mode, size, links, mtime) is still compared strictly above;
+            // adopt the new ctime as the baseline instead of refusing the
+            // descriptor forever.
+            if !RecentAgentTaskFilesystemValidator
+                .stableChangeTimeMatches(baseline, descriptorState) {
+                informationLock.lock()
+                informationStorage = descriptorState
+                informationLock.unlock()
+            }
         }
         return true
     }
@@ -462,7 +490,7 @@ nonisolated enum RecentAgentTaskFilesystemValidator {
         )
     }
 
-    fileprivate static func validationLease(
+    static func validationLease(
         for identity: AgentTaskProjectIdentity,
         expectedProof: RecentAgentTaskRepositoryProof?
     ) -> RecentAgentTaskFilesystemValidationLease? {
@@ -960,7 +988,7 @@ nonisolated enum RecentAgentTaskFilesystemValidator {
 
         var after = stat()
         guard fstat(descriptor.descriptor, &after) == 0,
-              stableFileMetadataMatches(before, after),
+              stableFileStateMatches(before, after),
               descriptor.revalidate(),
               reachedEndOfFile,
               Int64(count) == before.st_size,
@@ -968,7 +996,11 @@ nonisolated enum RecentAgentTaskFilesystemValidator {
         return Data(bytes.prefix(count))
     }
 
-    fileprivate static func stableFileMetadataMatches(
+    /// Identity plus every metadata field a content or ownership change
+    /// moves. Deliberately excludes ctime: macOS itself bumps ctime
+    /// asynchronously (`com.apple.provenance`) without touching contents
+    /// (#1593), so ctime is tracked separately and may be re-baselined.
+    fileprivate static func stableFileStateMatches(
         _ lhs: stat,
         _ rhs: stat
     ) -> Bool {
@@ -978,7 +1010,13 @@ nonisolated enum RecentAgentTaskFilesystemValidator {
             && lhs.st_nlink == rhs.st_nlink
             && lhs.st_mtimespec.tv_sec == rhs.st_mtimespec.tv_sec
             && lhs.st_mtimespec.tv_nsec == rhs.st_mtimespec.tv_nsec
-            && lhs.st_ctimespec.tv_sec == rhs.st_ctimespec.tv_sec
+    }
+
+    fileprivate static func stableChangeTimeMatches(
+        _ lhs: stat,
+        _ rhs: stat
+    ) -> Bool {
+        lhs.st_ctimespec.tv_sec == rhs.st_ctimespec.tv_sec
             && lhs.st_ctimespec.tv_nsec == rhs.st_ctimespec.tv_nsec
     }
 

--- a/PineTests/AgentTaskFilesystemAdmissionDriftTests.swift
+++ b/PineTests/AgentTaskFilesystemAdmissionDriftTests.swift
@@ -207,6 +207,65 @@ struct AgentTaskFilesystemAdmissionDriftTests {
         #expect(stable)
     }
 
+    @Test("A second restamp after an adopted one keeps the lease valid")
+    func repeatedProvenanceRestampsStayValid() async throws {
+        let fixture = try makeDriftFixture(name: "RepeatedRestamp")
+        defer { removeFixture(fixture.root) }
+        let (_, lease) = try await makeProofAndLease(for: fixture)
+
+        // Production observed the OS stamping the same fresh file more than
+        // once (ctime deltas of +1.4 s and then +5.4 s on one probe). Each
+        // restamp must be adoptable against the previously adopted baseline.
+        for round in 0..<2 {
+            try restampMetadataOnly(atPath: fixture.worktreeCommonDir.path)
+            let validated = await Task.detached(priority: .utility) {
+                lease.revalidate()
+            }.value
+            #expect(
+                validated,
+                "restamp round \(round) must not invalidate the lease"
+            )
+        }
+    }
+
+    @Test("Rewrite with an mtime rollback is the documented tolerance edge")
+    func rewriteWithMtimeRollbackIsTolerated() async throws {
+        let fixture = try makeDriftFixture(name: "MtimeRollback")
+        defer { removeFixture(fixture.root) }
+
+        // Pin the file to a millisecond-rounded mtime BEFORE the lease is
+        // captured: a Date round-trips through double, so restoring a
+        // git-written nanosecond mtime would not land bit-identical and the
+        // test would fail on mtime, not on the behavior it exists to pin.
+        let target = fixture.worktreeCommonDir
+        let roundedModification = Date(
+            timeIntervalSince1970: (Date().timeIntervalSince1970 * 1000)
+                .rounded(.down) / 1000
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: roundedModification],
+            ofItemAtPath: target.path
+        )
+        let (_, lease) = try await makeProofAndLease(for: fixture)
+
+        // This pins the security trade-off accepted in #1593: a same-size
+        // rewrite followed by an mtime rollback leaves only ctime moved, and
+        // ctime-only drift is tolerated because the OS itself produces it.
+        // Detection of this synthetic sequence relies on the next whole-lease
+        // re-derivation (proof comparison), not on per-descriptor stats.
+        let original = try Data(contentsOf: target)
+        try rewriteInPlace(target, contents: original)
+        try FileManager.default.setAttributes(
+            [.modificationDate: roundedModification],
+            ofItemAtPath: target.path
+        )
+
+        let validated = await Task.detached(priority: .utility) {
+            lease.revalidate()
+        }.value
+        #expect(validated)
+    }
+
     @Test("In-place control-file rewrite with identical bytes is rejected")
     func inPlaceRewriteIsRejected() async throws {
         let fixture = try makeDriftFixture(name: "InPlaceRewrite")

--- a/PineTests/AgentTaskFilesystemAdmissionDriftTests.swift
+++ b/PineTests/AgentTaskFilesystemAdmissionDriftTests.swift
@@ -1,0 +1,373 @@
+//
+//  AgentTaskFilesystemAdmissionDriftTests.swift
+//  PineTests
+//
+//  Filesystem drift between admission-lease capture and revalidation
+//  (#1593): the OS restamps freshly created files asynchronously
+//  (`com.apple.provenance` — a ctime-only bump), and git may rewrite a
+//  control file in place or replace it. The lease must tolerate the
+//  restamp, re-derive itself after a legitimate rewrite, and still reject
+//  genuine identity changes.
+//
+
+import Darwin
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Agent task filesystem admission drift")
+struct AgentTaskFilesystemAdmissionDriftTests {
+
+    // MARK: - Fixtures
+
+    private struct DriftFixture {
+        let root: URL
+        let repository: URL
+        let worktree: URL
+        let identity: AgentTaskProjectIdentity
+        /// `<repository>/.git/worktrees/<name>/commondir` of the linked
+        /// worktree — the regular-file descriptor whose captured ctime the
+        /// OS restamps in production.
+        let worktreeCommonDir: URL
+        /// The linked worktree's `.git` pointer file.
+        let worktreeControlFile: URL
+    }
+
+    private func makeDriftFixture(name: String) throws -> DriftFixture {
+        let rawRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "PineAdmissionDrift-\(name)-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: rawRoot,
+            withIntermediateDirectories: true
+        )
+        // `/tmp` is a symlink to `/private/tmp`; canonicalization in the
+        // validator resolves it, so the fixture must ship resolved paths.
+        let root = rawRoot.resolvingSymlinksInPath().standardizedFileURL
+        let repository = root.appendingPathComponent(
+            "Repository",
+            isDirectory: true
+        )
+        let worktree = root.appendingPathComponent(
+            "Worktree",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: repository,
+            withIntermediateDirectories: true
+        )
+        try runGit(["init", "--initial-branch=main"], at: repository)
+        try runGit(
+            ["config", "user.name", "Pine Admission Drift Tests"],
+            at: repository
+        )
+        try runGit(
+            ["config", "user.email", "admission-drift-tests@pine.invalid"],
+            at: repository
+        )
+        try Data("drift-seed\n".utf8).write(
+            to: repository.appendingPathComponent("seed.txt")
+        )
+        try runGit(["add", "--", "seed.txt"], at: repository)
+        try runGit(["commit", "-m", "fixture"], at: repository)
+        try runGit(
+            ["worktree", "add", "-b", "feature/drift", "--", worktree.path],
+            at: repository
+        )
+        let gitDirectory = repository.appendingPathComponent(
+            ".git",
+            isDirectory: true
+        )
+        return DriftFixture(
+            root: root,
+            repository: repository,
+            worktree: worktree,
+            identity: AgentTaskProjectIdentity(
+                canonicalProjectPath: repository.path,
+                canonicalWorktreePath: worktree.path
+            ),
+            worktreeCommonDir: gitDirectory
+                .appendingPathComponent("worktrees", isDirectory: true)
+                .appendingPathComponent("Worktree", isDirectory: true)
+                .appendingPathComponent("commondir"),
+            worktreeControlFile: worktree.appendingPathComponent(".git")
+        )
+    }
+
+    private func removeFixture(_ root: URL) {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    private func runGit(
+        _ arguments: [String],
+        at directory: URL
+    ) throws {
+        let result = GitCommand.run(arguments, at: directory, timeout: 10)
+        guard result.succeeded else {
+            throw DriftFixtureError.gitFailed(
+                arguments: arguments,
+                diagnostics: result.errorOutput
+            )
+        }
+    }
+
+    private func makeProofAndLease(
+        for fixture: DriftFixture
+    ) async throws -> (
+        proof: RecentAgentTaskRepositoryProof,
+        lease: RecentAgentTaskFilesystemValidationLease
+    ) {
+        let identity = fixture.identity
+        let proof = await Task.detached(priority: .utility) {
+            RecentAgentTaskFilesystemValidator.repositoryProof(for: identity)
+        }.value
+        #expect(proof != nil)
+        let expectedProof = try #require(proof)
+        let lease = await Task.detached(priority: .utility) {
+            RecentAgentTaskFilesystemValidator.validationLease(
+                for: identity,
+                expectedProof: expectedProof
+            )
+        }.value
+        #expect(lease != nil)
+        return (expectedProof, try #require(lease))
+    }
+
+    private func changeTimeNanoseconds(
+        atPath path: String
+    ) -> Int64? {
+        var information = stat()
+        guard stat(path, &information) == 0 else { return nil }
+        return Int64(information.st_ctimespec.tv_sec) * 1_000_000_000
+            + Int64(information.st_ctimespec.tv_nsec)
+    }
+
+    private func mode(atPath path: String) -> mode_t? {
+        var information = stat()
+        guard stat(path, &information) == 0 else { return nil }
+        return information.st_mode & 0o7777
+    }
+
+    /// Rewrites `url` in place — same inode, fresh mtime/ctime — so only the
+    /// timestamps drift and identity detection cannot mask a regression.
+    private func rewriteInPlace(_ url: URL, contents: Data) throws {
+        let handle = try FileHandle(forWritingTo: url)
+        try handle.truncate(atOffset: 0)
+        try handle.write(contentsOf: contents)
+        try handle.close()
+    }
+
+    /// A metadata-only restamp, exactly like the OS provenance stamp: chmod
+    /// with the mode the file already has updates ctime and nothing else.
+    private func restampMetadataOnly(atPath path: String) throws {
+        let currentMode = try #require(mode(atPath: path))
+        try FileManager.default.setAttributes(
+            [.posixPermissions: Int(currentMode)],
+            ofItemAtPath: path
+        )
+    }
+
+    // MARK: - Descriptor drift tolerance
+
+    @Test("OS provenance restamp keeps the lease valid")
+    func provenanceRestampKeepsLeaseValid() async throws {
+        let fixture = try makeDriftFixture(name: "ProvenanceRestamp")
+        defer { removeFixture(fixture.root) }
+        let (_, lease) = try await makeProofAndLease(for: fixture)
+
+        let beforeRestamp = try #require(
+            changeTimeNanoseconds(
+                atPath: fixture.worktreeCommonDir.path
+            )
+        )
+        try restampMetadataOnly(atPath: fixture.worktreeCommonDir.path)
+        // The restamp is the precondition this whole test exists for: if it
+        // ever stops moving ctime on its own, the assertions below would
+        // pass vacuously.
+        let afterRestamp = try #require(
+            changeTimeNanoseconds(
+                atPath: fixture.worktreeCommonDir.path
+            )
+        )
+        #expect(afterRestamp != beforeRestamp)
+
+        let restamped = await Task.detached(priority: .utility) {
+            lease.revalidate()
+        }.value
+        #expect(restamped)
+
+        // Adopting the new ctime is a re-baseline, not a one-shot pardon:
+        // a second validation with no further drift must also pass.
+        let stable = await Task.detached(priority: .utility) {
+            lease.revalidate()
+        }.value
+        #expect(stable)
+    }
+
+    @Test("In-place control-file rewrite with identical bytes is rejected")
+    func inPlaceRewriteIsRejected() async throws {
+        let fixture = try makeDriftFixture(name: "InPlaceRewrite")
+        defer { removeFixture(fixture.root) }
+        let (_, lease) = try await makeProofAndLease(for: fixture)
+
+        let original = try Data(contentsOf: fixture.worktreeCommonDir)
+        try rewriteInPlace(fixture.worktreeCommonDir, contents: original)
+
+        let validated = await Task.detached(priority: .utility) {
+            lease.revalidate()
+        }.value
+        #expect(!validated)
+    }
+
+    @Test("Control-file replacement is rejected")
+    func controlFileReplacementIsRejected() async throws {
+        let fixture = try makeDriftFixture(name: "ControlReplacement")
+        defer { removeFixture(fixture.root) }
+        let (_, lease) = try await makeProofAndLease(for: fixture)
+
+        let original = try Data(contentsOf: fixture.worktreeCommonDir)
+        try FileManager.default.removeItem(at: fixture.worktreeCommonDir)
+        try original.write(to: fixture.worktreeCommonDir)
+
+        let validated = await Task.detached(priority: .utility) {
+            lease.revalidate()
+        }.value
+        #expect(!validated)
+    }
+
+    // MARK: - Lease re-derivation
+
+    @Test("A rewritten control graph still re-derives the same lease")
+    func rewrittenControlGraphRebuildsLease() async throws {
+        let fixture = try makeDriftFixture(name: "RebuildLease")
+        defer { removeFixture(fixture.root) }
+        let (proof, lease) = try await makeProofAndLease(for: fixture)
+
+        // Atomic rewrite is what git itself does (`git worktree repair`):
+        // fresh inode, same logical pointer contents.
+        let original = try Data(contentsOf: fixture.worktreeControlFile)
+        try original.write(
+            to: fixture.worktreeControlFile,
+            options: .atomic
+        )
+
+        let stale = await Task.detached(priority: .utility) {
+            lease.revalidate()
+        }.value
+        #expect(!stale)
+
+        let identity = fixture.identity
+        let rebuilt = await Task.detached(priority: .utility) {
+            RecentAgentTaskFilesystemValidator.validationLease(
+                for: identity,
+                expectedProof: proof
+            )
+        }.value
+        #expect(rebuilt != nil)
+
+        let rebuiltValid = await Task.detached(priority: .utility) {
+            rebuilt?.revalidate()
+        }.value
+        #expect(rebuiltValid == true)
+    }
+
+    // MARK: - Manager-level re-arm
+
+    @Test("Manager revalidation rebuilds the lease after a control rewrite")
+    @MainActor
+    func managerRebuildsAdmissionAfterControlRewrite() async throws {
+        let fixture = try makeDriftFixture(name: "ManagerRebuild")
+        defer { removeFixture(fixture.root) }
+        let (_, lease) = try await makeProofAndLease(for: fixture)
+
+        let project = ProjectManager()
+        project.loadDirectory(
+            url: fixture.worktree,
+            agentTaskProject: fixture.identity,
+            filesystemAdmission: lease
+        )
+
+        let beforeRewrite = await project
+            .revalidateAgentTaskFilesystemAdmission(
+                workingDirectory: fixture.worktree
+            )
+        #expect(beforeRewrite)
+
+        let original = try Data(contentsOf: fixture.worktreeControlFile)
+        try original.write(
+            to: fixture.worktreeControlFile,
+            options: .atomic
+        )
+
+        // The captured lease is stale now; the manager must re-derive it
+        // from the current graph instead of refusing forever (#1593).
+        let afterRewrite = await project
+            .revalidateAgentTaskFilesystemAdmission(
+                workingDirectory: fixture.worktree
+            )
+        #expect(afterRewrite)
+
+        // The rebuilt lease is the new baseline: repeated validation with no
+        // further drift stays valid.
+        let stable = await project
+            .revalidateAgentTaskFilesystemAdmission(
+                workingDirectory: fixture.worktree
+            )
+        #expect(stable)
+    }
+
+    @Test("Manager revalidation refuses a worktree that changed identity")
+    @MainActor
+    func managerRefusesAfterWorktreeReplacement() async throws {
+        let fixture = try makeDriftFixture(name: "ManagerRefuse")
+        defer { removeFixture(fixture.root) }
+        let (_, lease) = try await makeProofAndLease(for: fixture)
+
+        let project = ProjectManager()
+        project.loadDirectory(
+            url: fixture.worktree,
+            agentTaskProject: fixture.identity,
+            filesystemAdmission: lease
+        )
+
+        // Swap the worktree for a different worktree of the same shape: the
+        // inode identity of the worktree root changes, and no re-derivation
+        // can honestly admit the replacement.
+        let replacement = fixture.root.appendingPathComponent(
+            "Replacement",
+            isDirectory: true
+        )
+        try runGit(
+            ["worktree", "add", "-b", "feature/replacement", "--",
+             replacement.path],
+            at: fixture.repository
+        )
+        try FileManager.default.removeItem(at: fixture.worktree)
+        var isDirectory: ObjCBool = false
+        try FileManager.default.moveItem(
+            at: replacement,
+            to: fixture.worktree
+        )
+        #expect(FileManager.default.fileExists(
+            atPath: fixture.worktree.path,
+            isDirectory: &isDirectory
+        ))
+
+        // First refusal attempts a throttled rebuild that cannot reproduce
+        // the proof; validation must stay false.
+        for _ in 0..<3 {
+            let validated = await project
+                .revalidateAgentTaskFilesystemAdmission(
+                    workingDirectory: fixture.worktree
+                )
+            #expect(!validated)
+        }
+    }
+}
+
+private enum DriftFixtureError: Error {
+    case gitFailed(arguments: [String], diagnostics: String)
+}

--- a/PineTests/AgentTaskFilesystemAdmissionDriftTests.swift
+++ b/PineTests/AgentTaskFilesystemAdmissionDriftTests.swift
@@ -348,6 +348,8 @@ struct AgentTaskFilesystemAdmissionDriftTests {
             agentTaskProject: fixture.identity,
             filesystemAdmission: lease
         )
+        let generationAtLoad = project
+            .admissionGenerationForTesting
 
         let beforeRewrite = await project
             .revalidateAgentTaskFilesystemAdmission(
@@ -368,6 +370,21 @@ struct AgentTaskFilesystemAdmissionDriftTests {
                 workingDirectory: fixture.worktree
             )
         #expect(afterRewrite)
+
+        // A rebuild re-derives the same rules, so it must not rotate the
+        // admission generation: the workspace filesystem validator captured
+        // at loadDirectory keeps validating against it, and a rotation would
+        // suspend the file watcher on the next tree reload.
+        #expect(
+            project.admissionGenerationForTesting
+                == generationAtLoad
+        )
+        let epochValidator = await project
+            .revalidateAgentTaskFilesystemAdmission(
+                expectedGeneration: generationAtLoad,
+                workingDirectory: fixture.worktree
+            )
+        #expect(epochValidator)
 
         // The rebuilt lease is the new baseline: repeated validation with no
         // further drift stays valid.


### PR DESCRIPTION
Closes #1593.

## What happened

Launching an agent from a repo under `~/Documents` failed with **“Pine created the worktree, but couldn’t start Claude Code.”** and left an orphaned worktree. Root cause (reproduced deterministically on this machine, twice in production logs): macOS stamps freshly created files with `com.apple.provenance` **asynchronously** — a ctime-only bump 0.5–10 s after creation, sometimes repeated — while the admission lease compares the gitdir `commondir`'s ctime with nanosecond strictness. The stamp lands between lease capture and shell-start admission, so `revalidate()` refused permanently; the #1590 re-kick budget (2 attempts in ~120 ms) could never clear it. Refusal log from the incident: 1 278 consecutive rejections over 7.4 s.

## The fix (both halves of the option chosen in #1593)

1. **ctime-only drift tolerance** — `StablePathDescriptor.revalidate()` for regular files: identity (dev/ino/gen/birth/kind), mode, size, nlink, and mtime sec+nsec are still compared strictly; a **ctime-only** delta is adopted as the new baseline instead of refusing forever. Baseline storage is lock-guarded because one lease revalidates concurrently from detached tasks. `stableFileMetadataMatches` is split into `stableFileStateMatches` (everything but ctime) + `stableChangeTimeMatches`; `stableRegularFileBytes` uses the state comparator for its microsecond before/after read window.
2. **Lease re-derivation (re-arm)** — when a revalidation is refused, `ProjectManager` rebuilds the whole lease from the current graph and swaps it in **iff** the recomputed proof still identifies the same repository (also recovers `git worktree repair`-style control rewrites). Rebuilds are throttled to one per 250 ms so a layout-driven refusal loop cannot become a graph-walk storm. Per-descriptor strictness is unchanged — only the baseline the descriptors compare against is re-derived.

What is **not** weakened: a same-inode content rewrite (mtime moves), an atomic replacement (inode moves), a path retarget, and a worktree swap all still fail closed.

## Review follow-ups (second commit)

An adversarial review pass found two defects in the original rebuild path, both fixed:

- **Restartability** — a successful rebuild ran inside a terminal validation task, and re-arming tab validators cancelled that very task; a cancelled task exits without marking its refusal and nothing re-drives `startIfNeeded`, so a shell-less tab would silently burn the 20 s launch budget. The rebuild now restarts every tab that still has no live process.
- **Generation stability** — a rebuild rotated the admission generation while the workspace filesystem validator captured at `loadDirectory` keeps validating against it; the first tree reload after a rebuild would suspend the file watcher until reopen. Rebuilds now swap the lease **without** rotating the generation (same rules, same identity; suspended revalidations of the replaced lease stay fenced by the existing reference-identity check).

The known security trade-off (same-size rewrite + `utimes` mtime rollback leaves only ctime moved, which is tolerated) is documented in #1593 and pinned by an explicit test.

## Tests

New `AgentTaskFilesystemAdmissionDriftTests` (8 tests, real git fixtures):

- provenance-style restamp (chmod with the same mode — verified to move ctime and nothing else) keeps the lease valid; repeated validation stays valid (re-baseline, not a one-shot pardon)
- a second restamp after an adopted one keeps the lease valid (production saw repeated stamps)
- in-place rewrite with identical bytes is rejected (mtime drift)
- delete-and-recreate of a control file is rejected (identity drift)
- a rewritten control graph still re-derives the same lease from the proof (the re-arm path)
- manager-level: rebuild after a control rewrite, **admission generation stable across it**, a loadDirectory-epoch validator stays valid after it, and repeated validation stays green
- manager-level: a replaced worktree (same shape, different inode) keeps being refused across attempts
- the mtime-rollback tolerance edge is pinned as documented behavior

Adjacent suites re-run locally, all green: `QuickTerminalAgentDetectionTests`, `ProjectRegistryTests`, `AgentWorktreeServiceTests`, `BackgroundProjectLifecycleTests`, `AgentProjectTerminalOwnershipTests` (83 tests), plus the drift suite after each review fix. `swiftlint` clean.

## Merge readiness

Merge when CI is fully green on the final head (first commit already passed all 19 checks including the 7 UI shards; the review-follow-up head is re-running). No localization, no UI-surface change; the fix is confined to `ProjectRegistry.swift` / `ProjectManager.swift` + the new test file.