### PR TITLE
fix(sidebar): read keyboard navigation from a live selection mirror

### DIFF
--- a/Pine/SidebarTreeNavigation.swift
+++ b/Pine/SidebarTreeNavigation.swift
@@ -462,14 +462,36 @@ struct SidebarTypeAhead {
 /// changes through one place so the SwiftUI `.onKeyPress` handlers and
 /// the AppKit ``SidebarKeyboardResponderView`` never diverge (#1238).
 ///
-/// The model is **stateless** with respect to the tree contents: every
-/// navigation method receives the current flattened row list as a
-/// parameter and returns the new selection. Only the type-ahead buffer
-/// and the optional scroll callback are stored.
+/// Stored state: the type-ahead buffer, the scroll callback and viewport
+/// height for reveal geometry, and the live selection mirror
+/// (``currentSelection``). The model stays **stateless** with respect to
+/// the tree contents: every navigation method receives the current
+/// flattened row list as a parameter and returns the new selection.
 @MainActor
 @Observable
 final class SidebarTreeNavigation {
     private(set) var typeAhead = SidebarTypeAhead()
+
+    /// Live selection used by every keyboard navigation path (#1544).
+    ///
+    /// `.onKeyPress` closures dispatch through a snapshot of the view
+    /// structure captured when the modifier was installed, and the
+    /// `@Binding` read inside such a snapshot can be stale after a pointer
+    /// click writes the selection: Left arrived with `current == nil` while
+    /// the row still rendered expanded. This model is `@Observable`, and the
+    /// closures reach it through the `@State` storage of their captured view
+    /// structure — a reference shared across every epoch of that view's
+    /// identity — so reading a property here observes the current value
+    /// whichever epoch the calling closure belongs to. (The row views
+    /// separately receive the same instance through the environment.)
+    ///
+    /// ``SidebarView`` is the single writer: the row binding,
+    /// `navigate(to:)`, and reload reconciliation update the mirror in the
+    /// same step as the binding; an `onChange(of:, initial: true)` safety
+    /// net mirrors selection writes made outside the sidebar (tab sync,
+    /// Reveal in Sidebar) on the next graph pass, and re-seeds the mirror
+    /// whenever the view re-mounts with a live binding selection.
+    var currentSelection: FileNode?
 
     /// Scroll callback invoked after selection changes to keep the
     /// selected row visible. Set by ``SidebarView`` via the

--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -660,7 +660,7 @@ struct SidebarView: View {
                             SidebarFileTree(
                                 nodes: workspace.rootNodes,
                                 treeRevision: workspace.rootNodesRevision,
-                                selection: $selectedFile,
+                                selection: mirroredSelection,
                                 onFileOpen: { node, disposition in
                                     if disposition.requestsEditorFocus {
                                         keyboardFocusController
@@ -704,6 +704,18 @@ struct SidebarView: View {
                     .environment(editState)
                     .environment(expansion)
                     .environment(navigation)
+                    .onChange(of: selectedFile, initial: true) { _, selection in
+                        // Selections written outside the sidebar (tab sync,
+                        // Reveal in Sidebar) bypass `mirroredSelection`; keep
+                        // the live model in step whenever this view observes
+                        // the change. `initial: true` also seeds the mirror
+                        // on insertion, so a SidebarView that re-mounts after
+                        // the search branch (fresh @State navigation) starts
+                        // from the live binding selection instead of nil —
+                        // otherwise a background reload reconciliation would
+                        // erase the visible selection (#1544).
+                        navigation.currentSelection = selection
+                    }
                     .onChange(of: workspace.rootNodesRevision) { _, _ in
                         // Drop expanded entries for folders that disappeared
                         // (e.g. after delete) so the set stays bounded.
@@ -806,7 +818,7 @@ struct SidebarView: View {
                                         newURL,
                                         rootNodes: workspace.rootNodes
                                     ) {
-                                    selectedFile = node
+                                    selectSidebarRow(node)
                                 }
                             }
                         }
@@ -830,7 +842,7 @@ struct SidebarView: View {
                                     targetID,
                                     rootNodes: workspace.rootNodes
                                 ) {
-                                selectedFile = node
+                                selectSidebarRow(node)
                             }
                             performSidebarScroll(
                                 .intentionalReveal(
@@ -932,7 +944,7 @@ struct SidebarView: View {
         modifiers: SidebarKeyboardModifiers
     ) -> Bool {
         guard editState.renamingURL == nil,
-              let selected = selectedFile,
+              let selected = navigation.currentSelection,
               let action = SidebarReturnAction.resolve(
                 modifiers: modifiers,
                 isRenaming: false,
@@ -956,7 +968,7 @@ struct SidebarView: View {
 
     private func handleSidebarSpace() -> Bool {
         guard editState.renamingURL == nil,
-              let selected = selectedFile,
+              let selected = navigation.currentSelection,
               !selected.isDirectory else {
             return false
         }
@@ -967,6 +979,35 @@ struct SidebarView: View {
     }
 
     // MARK: - Finder-style keyboard navigation (#1238)
+
+    /// Selection binding that mirrors every row-driven write into the live
+    /// navigation model inside the same setter call (#1544).
+    ///
+    /// The `.onKeyPress` handlers dispatch through a snapshot of the view
+    /// structure captured when the modifier was installed, and the binding
+    /// read in that snapshot can be stale after a pointer click writes the
+    /// selection — Left arrived with `current == nil` while the row still
+    /// rendered expanded. `navigation` is `@Observable` and the closures
+    /// reach it through the `@State` storage of that same captured
+    /// structure — a reference shared across every epoch of the view's
+    /// identity — so a read there is always live. The mirror therefore
+    /// updates in the same setter step as the write, never via graph
+    /// invalidation.
+    private var mirroredSelection: Binding<FileNode?> {
+        Binding(
+            get: { selectedFile },
+            set: { selectSidebarRow($0) }
+        )
+    }
+
+    /// The single writer for the selection pair: the binding drives the
+    /// rendered row highlight, the live navigation mirror drives the
+    /// keyboard path (#1544). Every sidebar selection change goes through
+    /// here so the two stores can never drift apart.
+    private func selectSidebarRow(_ node: FileNode?) {
+        selectedFile = node
+        navigation.currentSelection = node
+    }
 
     /// Flattened list of currently-visible rows (respecting expansion state).
     private var visibleRows: [SidebarVisibleRow] {
@@ -979,7 +1020,7 @@ struct SidebarView: View {
     /// Updates the selection and ensures the newly-selected row is visible.
     private func navigate(to node: FileNode?) {
         guard let node else { return }
-        selectedFile = node
+        selectSidebarRow(node)
         navigation.scroll(to: node)
     }
 
@@ -987,7 +1028,7 @@ struct SidebarView: View {
     private func handleArrow(delta: Int) {
         let rows = visibleRows
         guard !rows.isEmpty else { return }
-        navigate(to: navigation.move(by: delta, current: selectedFile, rows: rows))
+        navigate(to: navigation.move(by: delta, current: navigation.currentSelection, rows: rows))
     }
 
     /// Left: collapse an expanded folder, or move to the parent.
@@ -996,7 +1037,7 @@ struct SidebarView: View {
         guard !rows.isEmpty else { return }
         navigate(
             to: navigation.handleLeftArrow(
-                current: selectedFile,
+                current: navigation.currentSelection,
                 rows: rows,
                 expansion: expansion
             )
@@ -1009,7 +1050,7 @@ struct SidebarView: View {
         guard !rows.isEmpty else { return }
         navigate(
             to: navigation.handleRightArrow(
-                current: selectedFile,
+                current: navigation.currentSelection,
                 rows: rows,
                 expansion: expansion
             )
@@ -1027,13 +1068,13 @@ struct SidebarView: View {
     private func handlePageUp() {
         let rows = visibleRows
         guard !rows.isEmpty else { return }
-        navigate(to: navigation.pageUp(current: selectedFile, rows: rows))
+        navigate(to: navigation.pageUp(current: navigation.currentSelection, rows: rows))
     }
 
     private func handlePageDown() {
         let rows = visibleRows
         guard !rows.isEmpty else { return }
-        navigate(to: navigation.pageDown(current: selectedFile, rows: rows))
+        navigate(to: navigation.pageDown(current: navigation.currentSelection, rows: rows))
     }
 
     /// Type-to-select with repeated-character cycling and Unicode support.
@@ -1043,7 +1084,7 @@ struct SidebarView: View {
         navigate(
             to: navigation.typeSelect(
                 character: characters,
-                current: selectedFile,
+                current: navigation.currentSelection,
                 rows: rows
             )
         )
@@ -1052,11 +1093,11 @@ struct SidebarView: View {
     private func reconcileSelectionAfterReload() {
         let rows = visibleRows
         let reconciled = navigation.reconciledSelection(
-            current: selectedFile,
+            current: navigation.currentSelection,
             rootNodes: workspace.rootNodes,
             rows: rows
         )
-        selectedFile = reconciled
+        selectSidebarRow(reconciled)
         // A passive file-system refresh must preserve the viewport. The row
         // was already selected and visible (or intentionally off-screen), so
         // asking ScrollViewReader to reveal it again only forces another

--- a/PineTests/SidebarLiveSelectionMirrorTests.swift
+++ b/PineTests/SidebarLiveSelectionMirrorTests.swift
@@ -1,0 +1,482 @@
+//
+//  SidebarLiveSelectionMirrorTests.swift
+//  PineTests
+//
+//  Hosted coverage for the live selection mirror of #1544: the keyboard
+//  path reads `SidebarTreeNavigation.currentSelection`, which every
+//  selection writer updates in the same step as the binding. The three
+//  cases here execute the fix through the production view in a real
+//  window:
+//
+//  1. The core #1544 journey: a press opens a folder and writes the
+//     selection through the mirroring setter, and the Left command must
+//     observe it and collapse the folder.
+//  2. A SidebarView that re-mounts after the search branch continues
+//     keyboard navigation from the selected row — Down moves past it, not
+//     back to the first row.
+//  3. A reload after such a re-mount reconciles from the seeded mirror
+//     (`onChange(of:, initial: true)`) and keeps the externally-written
+//     selection visible — without the initial seed, reconciliation reads
+//     `nil` and erases the selection. This is the case that fails
+//     deterministically when the seed is removed.
+//
+//  Keyboard commands are dispatched through the responder's `onCommand`
+//  closure, which `updateNSView` keeps current — the same dispatch point
+//  the AppKit key path uses.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+@Suite("Sidebar live selection mirror", .serialized)
+@MainActor
+struct SidebarLiveSelectionMirrorTests {
+
+    // MARK: - Cases
+
+    @Test("A press-driven selection reaches the keyboard path and collapses")
+    func pressSelectionThenLeftCollapses() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.tearDown() }
+
+        guard let alphaRow = await waitFor(seconds: 3, until: {
+            Self.row(named: "fileNode_alpha", in: fixture.hosting)
+        }) else {
+            Issue.record("alpha accessibility row never appeared")
+            return
+        }
+        guard alphaRow.accessibilityPerformPress() else {
+            Issue.record("production press was refused")
+            return
+        }
+        guard await waitFor(seconds: 2, until: {
+            alphaRow.accessibilityValue() as? String
+                == Strings.a11ySidebarDisclosureExpanded
+        }) else {
+            Issue.record("row never reported expanded after press")
+            return
+        }
+
+        // This is the core #1544 journey: the press both expands the folder
+        // and writes the selection through `mirroredSelection` — the same
+        // setter step that updates the live mirror — and the Left command
+        // must observe that selection and collapse the folder. (The
+        // safety-net `onChange` for writes made outside the sidebar has no
+        // distinct collapse case of its own: any external write equal to
+        // the current selection is a no-op, and one that differs moves the
+        // collapse target. Its coverage lives in the initial-seed branch
+        // exercised by the reload case below.)
+        guard await waitFor(seconds: 2, until: {
+            Self.responder(in: fixture.hosting) != nil
+        }) else {
+            Issue.record("sidebar responder never appeared")
+            return
+        }
+
+        #expect(
+            await dispatchCommand(.left, in: fixture.hosting) {
+                alphaRow.accessibilityValue() as? String
+                    == Strings.a11ySidebarDisclosureCollapsed
+            },
+            "Left must collapse the folder opened by the press"
+        )
+    }
+
+    @Test("A re-mounted sidebar seeds the mirror, so Down continues past the selection")
+    func mirrorSeededWhenViewReinsertedWithLiveSelection() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.tearDown() }
+
+        guard await waitFor(seconds: 3, until: {
+            Self.row(named: "fileNode_alpha", in: fixture.hosting) != nil
+        }) else {
+            Issue.record("file tree never appeared")
+            return
+        }
+
+        // Select alpha externally while the first sidebar is mounted.
+        let alpha = try #require(
+            fixture.projectManager.workspace.rootNodes
+                .first { $0.name == "alpha" }
+        )
+        fixture.selectExternally(alpha)
+
+        // Leave and return from the search branch: the returning SidebarView
+        // owns a *fresh* @State navigation, while the harness-side selection
+        // state (the ContentView stand-in) still holds alpha.
+        fixture.projectManager.searchProvider.query = "inside"
+        guard await waitFor(seconds: 3, until: {
+            Self.row(named: "fileNode_alpha", in: fixture.hosting) == nil
+        }) else {
+            Issue.record("search branch did not replace the file tree")
+            return
+        }
+        fixture.projectManager.searchProvider.query = ""
+        let alphaRow = await waitFor(seconds: 3, until: {
+            Self.row(named: "fileNode_alpha", in: fixture.hosting)
+        })
+        guard let alphaRow else {
+            Issue.record("file tree did not return after clearing the query")
+            return
+        }
+        guard await waitFor(seconds: 2, until: {
+            alphaRow.isAccessibilitySelected()
+        }) else {
+            Issue.record("binding selection was not restored to the row")
+            return
+        }
+
+        // The search-branch transition briefly mounts transitional sidebar
+        // epochs; dispatching the command to *every* mounted responder until
+        // the effect lands makes the check immune to which epoch survives.
+        // This case pins the *behaviour* with a live seed — Down continues
+        // from the selected row after a re-mount — not the seed itself:
+        // a stale-epoch dispatch can re-select alpha through the mirroring
+        // writer, so a missing initial seed alone would not necessarily
+        // fail this wait. The seed's deterministic red/green is pinned by
+        // reconcileAfterReloadPreservesExternalSelection below.
+        let betaRow = await waitFor(seconds: 3, until: {
+            Self.row(named: "fileNode_beta", in: fixture.hosting)
+        })
+        guard let betaRow else {
+            Issue.record("beta row not found")
+            return
+        }
+        #expect(
+            await dispatchCommand(
+                .down,
+                in: fixture.hosting,
+                until: { betaRow.isAccessibilitySelected() }
+            ),
+            "Down should select the row after the externally selected folder"
+        )
+        #expect(
+            await waitFor(seconds: 1, until: { !alphaRow.isAccessibilitySelected() }),
+            "Down must not re-select the previously selected row"
+        )
+    }
+
+    @Test("Reload reconciliation preserves an external selection across a re-mount")
+    func reconcileAfterReloadPreservesExternalSelection() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.tearDown() }
+
+        guard await waitFor(seconds: 3, until: {
+            Self.row(named: "fileNode_root-file.swift", in: fixture.hosting)
+                != nil
+        }) else {
+            Issue.record("file tree never appeared")
+            return
+        }
+
+        let rootFile = try #require(
+            fixture.projectManager.workspace.rootNodes
+                .first { $0.name == "root-file.swift" }
+        )
+        fixture.selectExternally(rootFile)
+
+        // Re-mount the sidebar, then trigger the production refresh path:
+        // a file appears on disk and the workspace reloads the tree, which
+        // routes through reconcileSelectionAfterReload.
+        fixture.projectManager.searchProvider.query = "inside"
+        guard await waitFor(seconds: 3, until: {
+            Self.row(named: "fileNode_root-file.swift", in: fixture.hosting)
+                == nil
+        }) else {
+            Issue.record("search branch did not replace the file tree")
+            return
+        }
+        fixture.projectManager.searchProvider.query = ""
+        guard let rootFileRow = await waitFor(seconds: 3, until: {
+            Self.row(named: "fileNode_root-file.swift", in: fixture.hosting)
+        }) else {
+            Issue.record("file tree did not return after clearing the query")
+            return
+        }
+        guard await waitFor(seconds: 2, until: {
+            rootFileRow.isAccessibilitySelected()
+        }) else {
+            Issue.record("binding selection was not restored to the row")
+            return
+        }
+
+        let revisionBefore = fixture.projectManager.workspace.rootNodesRevision
+        try "// fresh".write(
+            to: fixture.directory.appendingPathComponent("fresh-file.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        fixture.projectManager.workspace.refreshFileTree()
+        guard await waitFor(seconds: 5, until: {
+            fixture.projectManager.workspace.rootNodesRevision
+                > revisionBefore
+        }) else {
+            Issue.record("workspace never reloaded the tree")
+            return
+        }
+
+        #expect(
+            await waitFor(seconds: 3, until: {
+                rootFileRow.isAccessibilitySelected()
+            }),
+            "Reload reconciliation must keep the externally written selection"
+        )
+    }
+
+    // MARK: - Fixture
+
+    private final class Fixture {
+        let projectManager: ProjectManager
+        let hosting: NSHostingView<AnyView>
+        let window: NSWindow
+        let directory: URL
+        private let external: ExternalSelectionWriter
+
+        init(
+            projectManager: ProjectManager,
+            hosting: NSHostingView<AnyView>,
+            window: NSWindow,
+            directory: URL,
+            external: ExternalSelectionWriter
+        ) {
+            self.projectManager = projectManager
+            self.hosting = hosting
+            self.window = window
+            self.directory = directory
+            self.external = external
+        }
+
+        /// Writes the selection the way sidebar-external writers do: the
+        /// harness host applies it to its `@State`, exactly like
+        /// `ContentView.syncSidebarSelection` writes `selectedNode`.
+        func selectExternally(_ node: FileNode?) {
+            external.write(node)
+        }
+
+        func tearDown() {
+            projectManager.workspace.suspend()
+            window.contentView = nil
+            window.close()
+            try? FileManager.default.removeItem(at: directory)
+        }
+    }
+
+    /// Stand-in for ContentView's `@State var selectedNode`: the harness
+    /// host owns the state, and external writers signal through this
+    /// observable channel so the write lands in real SwiftUI state with a
+    /// real invalidation pass — not in a plain box the view graph cannot
+    /// observe.
+    @Observable
+    final class ExternalSelectionWriter {
+        private(set) var node: FileNode?
+        private(set) var generation = 0
+
+        func write(_ node: FileNode?) {
+            self.node = node
+            generation &+= 1
+        }
+    }
+
+    /// The hosted ContentView stand-in: owns the selection `@State`, feeds
+    /// `SidebarSearchableContent` exactly as the project window does, and
+    /// applies external selection writes to that state on their own graph
+    /// pass.
+    private struct HarnessHost: View {
+        @State private var selection: FileNode?
+        let projectManager: ProjectManager
+        let external: ExternalSelectionWriter
+
+        var body: some View {
+            SidebarSearchableContent(
+                selectedNode: $selection,
+                onFileOpen: { _, _ in }
+            )
+            .environment(projectManager)
+            .environment(projectManager.workspace)
+            .environment(projectManager.paneManager)
+            .environment(projectManager.primaryTabManager)
+            .environment(ProjectRegistry())
+            .frame(minWidth: 700, minHeight: 480)
+            .onChange(of: external.generation) { _, _ in
+                selection = external.node
+            }
+        }
+    }
+
+    private func makeFixture() async throws -> Fixture {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-1544-mirror-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("alpha"),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("beta"),
+            withIntermediateDirectories: true
+        )
+        try "// alpha".write(
+            to: dir.appendingPathComponent("alpha/inside-alpha.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "// beta".write(
+            to: dir.appendingPathComponent("beta/inside-beta.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "// root".write(
+            to: dir.appendingPathComponent("root-file.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let projectManager = ProjectManager()
+        projectManager.workspace.loadDirectory(url: dir)
+        let published = await waitFor(seconds: 5) {
+            projectManager.workspace.rootNodes.contains { $0.name == "alpha" }
+        }
+        guard published else {
+            projectManager.workspace.suspend()
+            try? FileManager.default.removeItem(at: dir)
+            throw CocoaError(.fileNoSuchFile)
+        }
+
+        let external = ExternalSelectionWriter()
+        let rootView = HarnessHost(
+            projectManager: projectManager,
+            external: external
+        )
+
+        let hosting = NSHostingView(rootView: AnyView(rootView))
+        hosting.frame = NSRect(x: 0, y: 0, width: 700, height: 480)
+        let window = HostedTestWindow(
+            contentRect: hosting.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = hosting
+        // Ordered in off-screen, never made key: `NSApp.keyWindow` is
+        // process-wide state other hosted suites assert against.
+        window.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
+        window.orderFront(nil)
+        return Fixture(
+            projectManager: projectManager,
+            hosting: hosting,
+            window: window,
+            directory: dir,
+            external: external
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Dispatches `command` to every mounted sidebar responder on each
+    /// runloop hop until `condition` holds or the deadline passes. A hosted
+    /// mount can briefly keep transitional sidebar epochs with stale
+    /// bindings; delivering to all of them makes the observable effect
+    /// independent of which epoch happens to be reachable first.
+    ///
+    /// The check runs *before* each dispatch: if the previous dispatch has
+    /// already produced the effect but its render has not committed yet,
+    /// dispatching again would overshoot the target row and clamp to the
+    /// last row, failing a condition that was actually met.
+    private func dispatchCommand(
+        _ command: SidebarKeyboardCommand,
+        in hosting: NSHostingView<AnyView>,
+        until condition: @escaping () -> Bool
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            await hopRunloop()
+            if condition() {
+                return true
+            }
+            Self.forEachResponder(in: hosting) {
+                $0.onCommand?(command)
+            }
+        }
+        return false
+    }
+
+    private static func forEachResponder(
+        in view: NSView,
+        _ body: (SidebarKeyboardResponderView) -> Void
+    ) {
+        if let responder = view as? SidebarKeyboardResponderView {
+            body(responder)
+        }
+        for subview in view.subviews {
+            forEachResponder(in: subview, body)
+        }
+    }
+
+    /// Wall-clock bounded wait: hops the runloop until `condition` holds or
+    /// the deadline passes. Hop counts are not a budget — a loaded runner
+    /// can need many hops before SwiftUI commits one update.
+    private func waitFor<T>(
+        seconds: TimeInterval,
+        until condition: @escaping () -> T?
+    ) async -> T? {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline {
+            await hopRunloop()
+            if let value = condition() {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private func waitFor(
+        seconds: TimeInterval,
+        until condition: @escaping () -> Bool
+    ) async -> Bool {
+        await waitFor(seconds: seconds) { condition() ? true : nil } != nil
+    }
+
+    private func hopRunloop() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
+    }
+
+    private static func row(
+        named identifier: String,
+        in view: NSView
+    ) -> SidebarAccessibilityRowView? {
+        if let row = view as? SidebarAccessibilityRowView,
+           row.accessibilityIdentifier() == identifier {
+            return row
+        }
+        for subview in view.subviews {
+            if let row = row(named: identifier, in: subview) {
+                return row
+            }
+        }
+        return nil
+    }
+
+    private static func responder(in view: NSView) -> SidebarKeyboardResponderView? {
+        if let responder = view as? SidebarKeyboardResponderView {
+            return responder
+        }
+        for subview in view.subviews {
+            if let responder = responder(in: subview) {
+                return responder
+            }
+        }
+        return nil
+    }
+}
+
+/// Off-screen hosted window that could become key but never does here.
+private final class HostedTestWindow: NSWindow {
+    override var canBecomeKey: Bool { true }
+}

--- a/PineTests/SidebarTreeNavigationTests.swift
+++ b/PineTests/SidebarTreeNavigationTests.swift
@@ -785,6 +785,71 @@ struct SidebarTreeNavigationTests {
         ) == nil)
     }
 
+    // MARK: - Live keyboard selection (#1544)
+
+    @Test("Left collapses the live mirrored selection, not a stale snapshot")
+    func leftArrowCollapsesLiveSelectionMirror() throws {
+        let root = try makeTree(files: [
+            "alpha/inside-alpha.swift": "",
+            "root-file.swift": "",
+        ])
+        defer { removeTree(root) }
+
+        let nodes = loadedRootNodes(root)
+        let alpha = try requireNode("alpha", in: nodes)
+        let expansion = SidebarExpansionState()
+        expansion.setExpanded(alpha.url, true)
+        let rows = SidebarTreeFlattener.visibleRows(
+            rootNodes: nodes,
+            expansion: expansion
+        )
+        let navigation = SidebarTreeNavigation()
+
+        // A pointer click on the folder expands it and writes the live
+        // mirror synchronously — this is what `SidebarView.mirroredSelection`
+        // does inside the row binding's setter.
+        navigation.currentSelection = alpha
+
+        // The stale-epoch failure mode of #1544: the key handler read its
+        // captured binding snapshot, which was still nil at dispatch time,
+        // and the collapse silently vanished. (`rows` is a snapshot taken
+        // before any collapse below, so both calls flatten the same tree.)
+        #expect(
+            navigation.handleLeftArrow(
+                current: nil,
+                rows: rows,
+                expansion: expansion
+            ) == nil,
+            "A stale nil snapshot cannot collapse anything"
+        )
+
+        // The keyboard path now reads the live model, so the collapse lands
+        // and the selection stays on the folder.
+        let target = navigation.handleLeftArrow(
+            current: navigation.currentSelection,
+            rows: rows,
+            expansion: expansion
+        )
+        #expect(target === alpha)
+        #expect(!expansion.isExpanded(alpha.url))
+    }
+
+    @Test("The live selection mirror starts empty and tracks writes verbatim")
+    func currentSelectionMirrorLifecycle() throws {
+        let navigation = SidebarTreeNavigation()
+        #expect(navigation.currentSelection == nil)
+
+        let root = try makeTree(files: ["a.swift": ""])
+        defer { removeTree(root) }
+        let node = try requireNode("a.swift", in: loadedRootNodes(root))
+
+        navigation.currentSelection = node
+        #expect(navigation.currentSelection === node)
+
+        navigation.currentSelection = nil
+        #expect(navigation.currentSelection == nil)
+    }
+
     // MARK: - Fixtures
 
     private func typeMatch(


### PR DESCRIPTION
Fixes #1544

## Summary

Left-arrow over an expanded sidebar folder silently did nothing ~30-50% of the time (user-facing: collapse lost about every third press). The keyboard path now reads selection from a live `@Observable` mirror instead of a `@Binding` snapshot.

## Root cause (probe telemetry, three instrumentation rounds)

The external probes saw the key delivered with the correct first responder and the command path alive — because it was: `.onKeyPress` closures dispatch through a **snapshot of the view structure**, and the `@Binding` read inside a stale-epoch snapshot returns the pre-click value. Left arrived at `handleLeftArrow` with `current == nil` while the row still rendered expanded, returned "handled", and the key was silently swallowed. One-run identity probes proved a single SidebarView/window/storage (ObjectIdentifiers matched byte-for-byte); an `.onChange(of: selectedNode)` observer on the owning view made the flake disappear — because it forced the graph re-invalidation the stale closure was waiting for.

## The fix

- `SidebarTreeNavigation.currentSelection` — live selection mirror on the `@Observable` model the closures reach through `@State` storage (a reference shared across every epoch of the view's identity). All 8 navigation commands + Return/Space + type-select read it.
- `selectSidebarRow(_:)` — the single writer: binding (render highlight) and mirror (keyboard path) update in the same setter step. Row binding, `navigate(to:)`, rename-deferral, scrollToNodeID and reload reconciliation all go through it.
- `.onChange(of: selectedFile, initial: true)` — safety net for writes made outside the sidebar (tab sync, Reveal in Sidebar) and **re-seed on re-mount**: after the search branch destroys/recreates SidebarView with fresh `@State navigation`, the initial seed keeps the mirror in step with the live binding; without it, a background reload reconciliation would erase the visible selection.

## Evidence

Local A/B on a machine where the flake is deterministic (10 probe iterations per run, same machine, same day):

| Tree | Probe collapses lost |
|---|---|
| main | **10/10** |
| main + observer-only (diagnostic) | 0/20 |
| main + this fix | **0/20**, re-validated 0/10 on the 2.6.3 base |

Earlier one-run CI A/B ([run 33604452434](https://github.com/batonogov/pine/actions/runs/33604452434)): the escape-claim relocation alone did **not** move the loss rate (49/100 vs 35/100) — that candidate lives separately in #1596 as cleanup + coverage. The final arbiter for this PR is the `SidebarFolderClickTests` shard run in CI.

## Tests

- `SidebarLiveSelectionMirrorTests` (hosted, `.serialized`): reproduces the stale-snapshot phenomenon itself in a real window and pins the fix — press → Left collapses; re-mount after search keeps Down continuing from the selected row; **reload after re-mount keeps the externally-written selection — deterministically red without `initial: true`** (verified red, then fixed).
- `SidebarTreeNavigationTests`: mirror storage semantics and left-collapse from the live model.

## Review trail

Three independent fresh-context reviews (correctness/architecture, concurrency/lifecycle, tests/UX) plus a verification pass. Resolved along the way: the un-seeded re-mount hole (P1 — keyboard blindness + reconcile erasure), writers bypassing the mirror, `stateless` docstring drift, wrong wire in comments (environment vs `@State` storage), test determinism (check-before-dispatch against overshoot flake). `SidebarCollapseFlakeProbeUITests` is intentionally kept for this PR's CI validation; it gets removed by a follow-up chore once #1544 closes.

## Ready to merge

When CI is fully green (including the Welcome & Session shard that carried the flake).