### PR TITLE
docs(agent): document why the createWelcomeHost Task.yield() is safe

### DIFF
--- a/Pine/Agent/AgentInboxPresentationCoordinator.swift
+++ b/Pine/Agent/AgentInboxPresentationCoordinator.swift
@@ -228,6 +228,42 @@ final class AgentInboxPresentationCoordinator {
     /// The answer when no existing window can host the Inbox: create Welcome
     /// first, so the Inbox still has a stable, discoverable anchor (#1486), and
     /// hold this one request until that window mounts it.
+    ///
+    /// The `Task.yield()` before the request reaches the router is an
+    /// optimization, never a correctness wait (#1535). The guarantee comes
+    /// from the router, not from the yield: a request for a host with no
+    /// registered anchor answers `.queued` and is kept against that window,
+    /// and `register` delivers it the moment the anchor mounts — one runloop
+    /// turn later, so layout can size the anchor before the popover pins to
+    /// it. A yield that resolves "too early" leaves the request queued and
+    /// delivered on registration; one that resolves "late enough" presents
+    /// directly, leaning on `awaitAgentInboxWelcomeHost` only ever yielding
+    /// a visible, laid-out window. Both suspension orders converge on one
+    /// popover, and each ending is covered by tests that register the
+    /// anchor after the request or before it: the queued ending by the
+    /// router's queued-delivery cases ("a request waits for a newly mounted
+    /// window anchor", "a rebuilt anchor inherits the request exactly once,
+    /// never twice") and by "no eligible window creates Welcome exactly
+    /// once per request", which registers the anchor only after the request
+    /// has settled; the direct ending by "repeated requests while Welcome
+    /// mounts present exactly once", which registers it beforehand. Nothing
+    /// asserts which ending happened — precisely what separates this from
+    /// the yield-as-wait defects #1521 fixed under #1518's guidance, where
+    /// a test asserted on state the yield was hoped to have produced.
+    ///
+    /// The yield becomes load-bearing — and must be replaced with an
+    /// injectable suspension, a sibling
+    /// `waitForAgentInboxWelcomeAnchor()` on the environment in the shape
+    /// of `ProjectManager.recoveryOfferListingSeam` — only if a test
+    /// starts asserting on the path taken rather than the end state,
+    /// `requestPresentation(in:)` stops queueing for an unregistered
+    /// host or `register` stops delivering the queued request,
+    /// ordering-sensitive work appears between the yield and the
+    /// request, or the anchor wait `awaitQueuedAnchor` documents is
+    /// extended to this path as an in-task wait — today this task ends
+    /// at `requestPresentation`; the request merely sits armed on the
+    /// router. Do not copy this yield where no counterpart makes both
+    /// suspension orders converge.
     @discardableResult
     private func createWelcomeHost(
         in environment: any AgentInboxHostEnvironment
@@ -241,8 +277,10 @@ final class AgentInboxPresentationCoordinator {
             let host = await environment.awaitAgentInboxWelcomeHost()
             guard !Task.isCancelled, let host else { return }
             self.prepare(host, in: environment)
-            // One more turn so the freshly raised Welcome window's SwiftUI
-            // anchor can mount before the request reaches the router.
+            // One more turn so the freshly raised Welcome window's anchor
+            // can mount first — an optimization, never a correctness wait:
+            // the router's queued delivery makes both suspension orders
+            // converge (see the doc above and #1535).
             await Task.yield()
             guard !Task.isCancelled else { return }
             self.router.requestPresentation(in: host)


### PR DESCRIPTION
Closes #1535.

## Summary

The two-line comment above the `Task.yield()` in `AgentInboxPresentationCoordinator.createWelcomeHost` looked exactly like the yield-as-wait defects #1521 fixed, sending every auditor into an hour of re-derivation. The yield is an optimization, never a correctness wait: the router queues a request for an unregistered host and delivers it on `register` one runloop turn later, so both suspension orders converge on one popover.

The reasoning now lives as a doc comment on `createWelcomeHost` (in the style of the `awaitQueuedAnchor` long-form doc in the same file); four lines remain above the yield pointing to it. The doc lists:

- why both endings are correct, and which test covers each (the queued ending — the router's queued-delivery cases plus the coordinator test that registers the anchor after `settle()`; the direct ending — the test that registers it beforehand);
- that nothing asserts which ending happened — the line separating this from the #1521/#1518 yield-as-wait class;
- the four conditions under which the yield becomes load-bearing and must be replaced with an injectable suspension shaped like `ProjectManager.recoveryOfferListingSeam`;
- a do-not-copy clause (four `Task.yield()` sites remain in production code; this reasoning does not transfer to them).

Comment-only: no behavioural change, no new strings, no API changes.

## Review gate

Independent fresh-context review before push, three lenses against the local candidate diff:

| Lens | Result |
|---|---|
| Correctness & architecture | clean; every claim verified against router/test code; noted the 28-line inline exceeded codebase norms (≥2× the longest inline) — addressed by moving the long-form into the doc comment |
| Concurrency & lifecycle | clean; queueing/retention, exactly-once delivery, delivery generation guards, cancellation between yield and request, and both yield orders verified against `AgentInboxPopoverPresenter` and the test suites; three P3 wording findings — all addressed (condition 4 disambiguated as an in-task wait; the direct ending's second premise named; do-not-copy clause added) |
| Tests, docs & localization | clean; all referenced tests exist verbatim and assert end state, not path; test-attribution P3 — addressed by listing which test covers which ending; no localization surface touched |

All findings were P3 (wording/placement); no P0–P2 was raised by any lens. Every finding was addressed rather than deferred.

## Local verification

- `swiftc -parse` (arm64-apple-macos26.0, Xcode-beta toolchain): OK
- `swiftlint lint` (`DEVELOPER_DIR=/Applications/Xcode-beta.app`): 0 violations
- `git diff --check`: clean
- Diff is strictly comment-only (verified line-by-line by two reviewers independently)
- Unit/UI suites not run: no behavioural change, no test touched

Environment: macOS 27.0 (26A5425a), Xcode-beta.app, macOS 26 SDK — local runs on this runtime are not a pass/fail signal per #1509; CI is authoritative.

## Merge notes

- Merge order: independent of everything else in flight; can merge any time CI is green.
- No UI surface changed — nothing to try by hand.