### PR TITLE
feat(agent): rediscover agent worktrees left behind by a closed project

### DIFF
--- a/Pine/Agent/AgentWorktreeManagerModel.swift
+++ b/Pine/Agent/AgentWorktreeManagerModel.swift
@@ -104,6 +104,10 @@ final class AgentWorktreeManagerModel {
     /// remove`, not two.
     private(set) var isBusy = false
     private(set) var message: AgentWorktreeManagerMessage?
+    /// The listing load (#1563) is still reading the repository — the sheet
+    /// shows progress, not the empty state, for its duration. Lowered only by
+    /// ``refresh(_:)``, so a caller cannot forget to end it.
+    private(set) var isListing = false
 
     @ObservationIgnored private let service: any AgentWorktreeManaging
     @ObservationIgnored
@@ -133,12 +137,20 @@ final class AgentWorktreeManagerModel {
 
     // MARK: - Listing
 
+    /// Marks the listing load as started, so the sheet shows progress
+    /// instead of the empty state while the repository is being read
+    /// (#1563). ``refresh(_:)`` ends it together with installing the rows.
+    func beginListing() {
+        isListing = true
+    }
+
     /// Replaces the list and re-reads every row's working-tree state.
     ///
     /// Rows appear immediately as ``AgentWorktreeRowStatus/checking`` so the
     /// sheet is never empty while git runs. A refresh that started earlier and
     /// finishes later is discarded by generation, not by luck.
     func refresh(_ worktrees: [AgentManagedWorktree]) async {
+        isListing = false
         refreshGeneration += 1
         let generation = refreshGeneration
         rows = worktrees.map {

--- a/Pine/Agent/AgentWorktreeService.swift
+++ b/Pine/Agent/AgentWorktreeService.swift
@@ -23,11 +23,71 @@ nonisolated struct AgentManagedWorktree: Codable, Sendable, Equatable {
     let managedRoot: URL
     let worktreeRoot: URL
     let branchName: String
-    let baseCommit: String
+    /// Commit the worktree was created from. Not recoverable from disk, so a
+    /// record rebuilt by discovery carries `nil` — no downstream path reads
+    /// it (`remove`, `inspectRemoval`, `previewIntegration`, `integrate` all
+    /// work from the live refs).
+    let baseCommit: String?
     /// Filesystem-instance proof captured by the worktree service before the
     /// managed identity leaves its serialized creation boundary. Consumers
     /// must revalidate it off the main actor before admitting the worktree.
-    let repositoryProof: RecentAgentTaskRepositoryProof
+    /// `nil` only for entries discovery rebuilt that the validator cannot
+    /// currently vouch for; registry admission fails closed on those.
+    let repositoryProof: RecentAgentTaskRepositoryProof?
+}
+
+/// One block of `git worktree list --porcelain -z` output (#1563).
+nonisolated struct AgentWorktreeListEntry: Equatable, Sendable {
+    /// Canonical working-tree path exactly as git printed it.
+    let path: String
+    /// Branch with the `refs/heads/` prefix stripped. `nil` for detached,
+    /// bare, or otherwise branch-less blocks.
+    let branch: String?
+}
+
+nonisolated enum AgentWorktreeListParser {
+    /// Splits porcelain output into one entry per worktree block. Attributes
+    /// this consumer ignores (`HEAD`, `locked`, reasons) are skipped; a block
+    /// without a `branch` record yields a `nil` branch rather than a guess.
+    static func entries(inPorcelainOutput output: String) -> [AgentWorktreeListEntry] {
+        var entries: [AgentWorktreeListEntry] = []
+        var path: String?
+        var branch: String?
+        func closeBlock() {
+            defer {
+                path = nil
+                branch = nil
+            }
+            guard let openPath = path else { return }
+            entries.append(
+                AgentWorktreeListEntry(path: openPath, branch: branch)
+            )
+        }
+        for record in output.split(separator: "\0", omittingEmptySubsequences: false) {
+            let field = String(record)
+            if field.isEmpty {
+                closeBlock()
+            } else if field.hasPrefix("worktree ") {
+                closeBlock()
+                path = String(field.dropFirst("worktree ".count))
+            } else if field.hasPrefix("branch refs/heads/") {
+                branch = String(field.dropFirst("branch refs/heads/".count))
+            }
+        }
+        closeBlock()
+        return entries
+    }
+
+    /// The task UUID a managed directory is named with — the exact
+    /// lowercase spelling `create` writes. Anything else (a different case,
+    /// a dashed-less blob, a human name) is not a Pine task directory.
+    static func taskID(forLowercaseUUIDName name: String) -> UUID? {
+        guard name == name.lowercased(),
+              let taskID = UUID(uuidString: name) else {
+            return nil
+        }
+        return taskID
+    }
 }
 
 nonisolated enum AgentWorktreeCreateFailure: Error, Sendable, Equatable {
@@ -175,11 +235,14 @@ actor AgentWorktreeService {
                 ) else {
             return .failed(.invalidRepository)
         }
-        guard let managedRoot = secureExistingDirectory(request.managedRoot)
+        guard let managedRoot = Self.secureExistingDirectory(
+            request.managedRoot,
+            fileManager: fileManager
+        )
         else {
             return .failed(.unsafeManagedRoot)
         }
-        guard !isWithin(managedRoot, root: repository) else {
+        guard !Self.isWithin(managedRoot, root: repository) else {
             return .failed(.managedRootInsideRepository)
         }
         guard await isValidBranch(
@@ -252,6 +315,177 @@ actor AgentWorktreeService {
             baseCommit: baseCommit,
             repositoryProof: finalRepositoryProof
         ))
+    }
+
+    // MARK: - Discovery (#1563)
+
+    /// Rebuilds managed-worktree records for a repository by asking git what
+    /// it still holds, instead of trusting one window's memory.
+    ///
+    /// A project close drops the window's worktree records on purpose while
+    /// the checkouts and their branches survive; this is how those leftovers
+    /// become reachable again. Two sources are combined:
+    ///
+    /// 1. `git worktree list --porcelain -z`, filtered to entries whose
+    ///    parent directory is `managedRoot` and whose last path component is
+    ///    the lowercase task UUID `create` named the destination with. The
+    ///    branch comes from git — a checkout git recognises but that sits
+    ///    detached is labelled `detached`, never a fabricated ref;
+    ///    `baseCommit` is not recoverable and stays `nil`.
+    /// 2. UUID-named directories under `managedRoot` that git says nothing
+    ///    about — interrupted or manually broken checkouts. They are reported
+    ///    with no branch (their task UUID names the row) and no proof, so
+    ///    the manager lists them as unavailable instead of silently hiding
+    ///    them.
+    ///
+    /// Discovery only *adds candidates*; it never admits them. Every
+    /// downstream mutation still passes `secureManagedWorktree`, which
+    /// rejects anything outside the managed root and every symlinked path
+    /// component, exactly as it does for records captured at creation.
+    func discoverManagedWorktrees(
+        repositoryRoot: URL,
+        managedRoot: URL
+    ) async -> [AgentManagedWorktree] {
+        guard let repository = await canonicalRepository(repositoryRoot) else {
+            return []
+        }
+        let listing = await runner.run(
+            ["worktree", "list", "--porcelain", "-z"],
+            repository
+        )
+        guard listing.succeeded else { return [] }
+        let output = listing.output
+        let suppliedRoot = managedRoot.standardizedFileURL
+        return await runOnBackground(qos: .userInitiated) {
+            // `FileManager.default` is the thread-safe process singleton the
+            // service itself holds; capturing the actor's instance here would
+            // cross isolation with a type this SDK does not mark Sendable.
+            Self.discoveredWorktrees(
+                porcelainOutput: output,
+                repository: repository,
+                suppliedRoot: suppliedRoot,
+                fileManager: .default
+            )
+        }
+    }
+
+    /// Label for a worktree git recognises but that no longer sits on a
+    /// branch. Shown verbatim — it is git's own term, not a fabricated ref.
+    private static let detachedBranchLabel = "detached"
+
+    /// Pure rebuild over one porcelain listing and one directory scan. Runs
+    /// off the actor inside `runOnBackground`'s autorelease pool (#1509).
+    private static func discoveredWorktrees(
+        porcelainOutput: String,
+        repository: URL,
+        suppliedRoot: URL,
+        fileManager: FileManager
+    ) -> [AgentManagedWorktree] {
+        // The same admission rule `create` applies: a root that does not
+        // exist as a directory, or sits inside the repository, is not a
+        // managed root this service would have written.
+        guard let root = secureExistingDirectory(
+            suppliedRoot,
+            fileManager: fileManager
+        ), !isWithin(root, root: repository) else {
+            return []
+        }
+        // Git prints canonical paths with symlinks resolved, while records
+        // captured at creation keep the spelling the caller supplied. Compare
+        // against the resolved root, rebuild with the supplied one, and the
+        // discovered twin matches its live record exactly.
+        let resolvedRoot = root.resolvingSymlinksInPath().standardizedFileURL
+
+        var recognized: [AgentManagedWorktree] = []
+        var listedNames = Set<String>()
+        for entry in AgentWorktreeListParser.entries(
+            inPorcelainOutput: porcelainOutput
+        ) {
+            let listedRoot = URL(
+                fileURLWithPath: entry.path,
+                isDirectory: true
+            ).standardizedFileURL
+            let name = listedRoot.lastPathComponent
+            guard listedRoot.deletingLastPathComponent() == resolvedRoot,
+                  let taskID = AgentWorktreeListParser.taskID(
+                      forLowercaseUUIDName: name
+                  ) else { continue }
+            listedNames.insert(name)
+            // A checkout git recognises but that is detached (or bare) has
+            // no branch to recover. It is labelled for exactly what it is —
+            // never the task UUID pretending to be a branch name, which the
+            // removal confirmation would then quote back as one.
+            recognized.append(discoveredWorktree(
+                taskID: taskID,
+                branchName: entry.branch ?? Self.detachedBranchLabel,
+                gitRecognizes: true,
+                repository: repository,
+                managedRoot: root
+            ))
+        }
+
+        // UUID-named directories git said nothing about. Shown, not acted
+        // on: their rows come back unavailable because no git command will
+        // inspect them, and the fail-closed service paths refuse them anyway.
+        var unrecognized: [AgentManagedWorktree] = []
+        let children = (try? fileManager.contentsOfDirectory(
+            atPath: root.path
+        )) ?? []
+        for name in children.sorted() {
+            let child = root.appendingPathComponent(name, isDirectory: true)
+            guard let taskID = AgentWorktreeListParser.taskID(
+                forLowercaseUUIDName: name
+            ), !listedNames.contains(name) else { continue }
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(
+                atPath: child.path,
+                isDirectory: &isDirectory
+            ), isDirectory.boolValue else { continue }
+            unrecognized.append(discoveredWorktree(
+                taskID: taskID,
+                branchName: name,
+                gitRecognizes: false,
+                repository: repository,
+                managedRoot: root
+            ))
+        }
+
+        return recognized + unrecognized
+    }
+
+    /// One rebuilt record. `baseCommit` is never invented, and a proof is
+    /// only claimed for a worktree git currently recognises — recomputed
+    /// live, the same value `create` captured, never a remembered one.
+    private static func discoveredWorktree(
+        taskID: UUID,
+        branchName: String,
+        gitRecognizes: Bool,
+        repository: URL,
+        managedRoot: URL
+    ) -> AgentManagedWorktree {
+        // The validated directory name is the task UUID, so the rebuilt root
+        // is exactly the destination spelling `create` used.
+        let worktreeRoot = managedRoot.appendingPathComponent(
+            taskID.uuidString.lowercased(),
+            isDirectory: true
+        ).standardizedFileURL
+        let identity = AgentTaskProjectIdentity(
+            canonicalProjectPath: repository.path,
+            canonicalWorktreePath: worktreeRoot.path
+        )
+        return AgentManagedWorktree(
+            taskID: taskID,
+            repositoryRoot: repository,
+            managedRoot: managedRoot,
+            worktreeRoot: worktreeRoot,
+            branchName: branchName,
+            baseCommit: nil,
+            repositoryProof: gitRecognizes
+                ? RecentAgentTaskFilesystemValidator.repositoryProof(
+                    for: identity
+                )
+                : nil
+        )
     }
 
     func inspectRemoval(
@@ -427,7 +661,10 @@ actor AgentWorktreeService {
     }
 
     private func canonicalRepository(_ candidate: URL) async -> URL? {
-        guard let directory = secureExistingDirectory(candidate) else {
+        guard let directory = Self.secureExistingDirectory(
+            candidate,
+            fileManager: fileManager
+        ) else {
             return nil
         }
         let result = await runner.run([
@@ -437,7 +674,7 @@ actor AgentWorktreeService {
               let path = singleLine(result.output) else { return nil }
         let canonical = URL(fileURLWithPath: path, isDirectory: true)
             .resolvingSymlinksInPath().standardizedFileURL
-        return secureExistingDirectory(canonical)
+        return Self.secureExistingDirectory(canonical, fileManager: fileManager)
     }
 
     private func isValidBranch(
@@ -542,20 +779,29 @@ actor AgentWorktreeService {
     private func secureManagedWorktree(
         _ worktree: AgentManagedWorktree
     ) -> Bool {
-        guard let managedRoot = secureExistingDirectory(worktree.managedRoot),
-              let worktreeRoot = secureExistingDirectory(worktree.worktreeRoot),
+        guard let managedRoot = Self.secureExistingDirectory(
+                  worktree.managedRoot,
+                  fileManager: fileManager
+              ),
+              let worktreeRoot = Self.secureExistingDirectory(
+                  worktree.worktreeRoot,
+                  fileManager: fileManager
+              ),
               managedRoot == worktree.managedRoot.standardizedFileURL,
               worktreeRoot == worktree.worktreeRoot.standardizedFileURL,
               worktreeRoot.deletingLastPathComponent() == managedRoot else {
             return false
         }
-        return isWithin(worktreeRoot, root: managedRoot)
+        return Self.isWithin(worktreeRoot, root: managedRoot)
     }
 
     /// Rejects every symlink component instead of merely resolving it. This
     /// prevents a managed destination from silently moving between review and
     /// mutation.
-    private func secureExistingDirectory(_ url: URL) -> URL? {
+    private static func secureExistingDirectory(
+        _ url: URL,
+        fileManager: FileManager
+    ) -> URL? {
         let supplied = url.standardizedFileURL
         guard supplied.isFileURL,
               supplied.path.hasPrefix("/"),
@@ -566,7 +812,8 @@ actor AgentWorktreeService {
         // `/var` and `/tmp` are Apple's stable system aliases into `/private`,
         // and Foundation may return either spelling for temporary directories.
         // Every other symlink component remains rejected.
-        guard pathComponentsContainNoSymlink(supplied.path) else {
+        guard pathComponentsContainNoSymlink(supplied.path, fileManager: fileManager)
+        else {
             return nil
         }
         var isDirectory: ObjCBool = false
@@ -577,12 +824,15 @@ actor AgentWorktreeService {
         return supplied
     }
 
-    private func isSymbolicLink(_ path: String) -> Bool {
+    private static func isSymbolicLink(_ path: String) -> Bool {
         var info = stat()
         return lstat(path, &info) == 0 && (info.st_mode & S_IFMT) == S_IFLNK
     }
 
-    private func pathComponentsContainNoSymlink(_ path: String) -> Bool {
+    private static func pathComponentsContainNoSymlink(
+        _ path: String,
+        fileManager: FileManager
+    ) -> Bool {
         var current = ""
         for component in URL(fileURLWithPath: path).pathComponents {
             if component == "/" {
@@ -606,7 +856,7 @@ actor AgentWorktreeService {
         return true
     }
 
-    private func isWithin(_ candidate: URL, root: URL) -> Bool {
+    private static func isWithin(_ candidate: URL, root: URL) -> Bool {
         let candidatePath = candidate.standardizedFileURL.path
         let rootPath = root.standardizedFileURL.path
         return candidatePath == rootPath

--- a/Pine/Agent/AgentWorktreesView.swift
+++ b/Pine/Agent/AgentWorktreesView.swift
@@ -3,9 +3,11 @@
 //  Pine
 //
 //  The sheet behind Agent ▸ Manage Agent Worktrees (#1524). Lists the git
-//  worktrees Pine created for agent tasks in this window, with the branch and
-//  the working-tree state of each, and offers the two things the app could
-//  previously only do to itself: merge one back, or delete it.
+//  worktrees Pine created for agent tasks in this window — plus the ones a
+//  project close dropped from the record while their directories stayed on
+//  disk, rebuilt by discovery (#1563) — with the branch and the working-tree
+//  state of each, and offers the two things the app could previously only do
+//  to itself: merge one back, or delete it.
 //
 
 import AppKit
@@ -64,7 +66,8 @@ struct AgentWorktreesView: View {
         .task {
             let model = model ?? makeModel()
             self.model = model
-            await model.refresh(session.allManagedWorktrees)
+            model.beginListing()
+            await model.refresh(await session.worktreeManagerListing())
         }
         .alert(
             Strings.agentWorktreesRemoveTitle,
@@ -152,20 +155,29 @@ struct AgentWorktreesView: View {
     private var content: some View {
         let presentations = rowPresentations
         if presentations.isEmpty {
-            VStack(spacing: 6) {
-                Image(systemName: MenuIcons.agentWorktrees)
-                    .font(.system(size: 30))
-                    .foregroundStyle(.secondary)
-                Text(Strings.agentWorktreesEmptyTitle)
-                    .font(.headline)
-                    .foregroundStyle(.secondary)
-                Text(Strings.agentWorktreesEmptyMessage)
-                    .font(.system(size: 12))
-                    .foregroundStyle(.tertiary)
-                    .multilineTextAlignment(.center)
+            if model?.isListing == true {
+                // Discovery is still reading the repository (#1563): show
+                // work in progress, not an empty list that would be a lie
+                // for as long as the git call runs.
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                VStack(spacing: 6) {
+                    Image(systemName: MenuIcons.agentWorktrees)
+                        .font(.system(size: 30))
+                        .foregroundStyle(.secondary)
+                    Text(Strings.agentWorktreesEmptyTitle)
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                    Text(Strings.agentWorktreesEmptyMessage)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.tertiary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(24)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding(24)
         } else {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {

--- a/Pine/ProjectWindowSession.swift
+++ b/Pine/ProjectWindowSession.swift
@@ -138,6 +138,11 @@ final class ProjectWindowSession {
     @ObservationIgnored private let defaults: UserDefaults
     @ObservationIgnored private let worktreeService: AgentWorktreeService
     @ObservationIgnored private let toolResolver: ExternalToolResolver
+    /// Derives the managed root for a repository. Injectable so the discovery
+    /// path can be pointed at a fixture directory in tests; production uses
+    /// ``managedRoot(for:)``.
+    @ObservationIgnored
+    private let managedRootResolver: @Sendable (URL) -> URL
     @ObservationIgnored private var backgroundLeases: [URL: UUID] = [:]
     @ObservationIgnored private var pendingRestoredActiveURL: URL?
     @ObservationIgnored private var didRestore = false
@@ -154,13 +159,17 @@ final class ProjectWindowSession {
         initialProjectURL: URL,
         defaults: UserDefaults = .standard,
         worktreeService: AgentWorktreeService = AgentWorktreeService(),
-        toolResolver: ExternalToolResolver = .fromEnvironment()
+        toolResolver: ExternalToolResolver = .fromEnvironment(),
+        managedRootResolver: @escaping @Sendable (URL) -> URL = {
+            ProjectWindowSession.managedRoot(for: $0)
+        }
     ) {
         let initial = initialProjectURL.standardizedFileURL
         requestedProjectURL = initial
         self.defaults = defaults
         self.worktreeService = worktreeService
         self.toolResolver = toolResolver
+        self.managedRootResolver = managedRootResolver
         let anchor = Self.persistenceAnchor(
             for: initial,
             defaults: defaults
@@ -234,10 +243,69 @@ final class ProjectWindowSession {
     }
 
     /// Every agent worktree this window holds, grouped under its project and
-    /// ordered the same way the switcher orders them. This is what the
-    /// worktree manager lists.
+    /// ordered the same way the switcher orders them. The worktree manager
+    /// starts from this and adds what discovery rebuilds from disk.
     var allManagedWorktrees: [AgentManagedWorktree] {
         groups.flatMap(\.worktrees)
+    }
+
+    /// Worktrees the manager sheet lists (#1563): this window's live record,
+    /// merged with what discovery rebuilds under the active repository's
+    /// managed root.
+    ///
+    /// ``closeProject(_:registry:)`` drops a project's worktree records
+    /// deliberately — they are its children in the switcher and leave with
+    /// it — while their directories and branches stay on disk. Asking the
+    /// repository directly here is what makes those leftovers listable,
+    /// mergeable and removable again after the project is reopened, without
+    /// resurrecting them as switcher rows: discovery does not adopt anything
+    /// into ``managedWorktrees``.
+    func worktreeManagerListing() async -> [AgentManagedWorktree] {
+        let repository = activeRepositoryURL.standardizedFileURL
+        // When the active row itself is a worktree, its record carries the
+        // exact managed root `launchAgent` created it under. The resolver
+        // hashes a repository path, and the spelling it is handed can differ
+        // from the canonical one inside the record (a symlinked anchor) —
+        // hashing the wrong one silently empties discovery exactly when the
+        // user is sitting in a worktree.
+        let managedRoot = managedWorktrees[activeProjectURL]?.managedRoot
+            ?? managedRootResolver(repository)
+        let discovered = await worktreeService.discoverManagedWorktrees(
+            repositoryRoot: repository,
+            managedRoot: managedRoot
+        )
+        return Self.mergedWorktreeListing(
+            live: allManagedWorktrees,
+            discovered: discovered
+        )
+    }
+
+    /// Union of the live record and the discovered set, keyed by standardized
+    /// worktree root. A worktree this window still holds is listed once, and
+    /// its live entry — the one carrying the creation-time base commit and
+    /// repository proof — is the entry shown. Discovered rows are appended
+    /// in the record's own reading order (branch, then task), so the list
+    /// does not switch ordering rules halfway down.
+    ///
+    /// - Important: entries returned here are *listing-only*. They must
+    ///   never be adopted into ``managedWorktrees`` or otherwise persisted —
+    ///   a persisted worktree with a `nil` base commit or proof does not
+    ///   decode in older builds, which would quietly cost the window its
+    ///   saved state on downgrade.
+    nonisolated static func mergedWorktreeListing(
+        live: [AgentManagedWorktree],
+        discovered: [AgentManagedWorktree]
+    ) -> [AgentManagedWorktree] {
+        var seen = Set(live.map { $0.worktreeRoot.standardizedFileURL })
+        var merged = live
+        for worktree in discovered.sorted(by: { lhs, rhs in
+            (lhs.branchName, lhs.taskID.uuidString)
+                < (rhs.branchName, rhs.taskID.uuidString)
+        }) where seen.insert(worktree.worktreeRoot.standardizedFileURL)
+            .inserted {
+            merged.append(worktree)
+        }
+        return merged
     }
 
     /// The git-facing service, narrowed to what a management surface may do
@@ -910,20 +978,31 @@ final class ProjectWindowSession {
         return "projectWindowSession.\(hex)"
     }
 
-    nonisolated private static func prepareManagedRoot(
-        for repository: URL
-    ) throws -> URL {
+    /// The managed root Pine derives for one repository's working tree: a
+    /// SHA-256-derived directory under Application Support (#1524). Creates
+    /// nothing and reads no directory contents — callers that only need to
+    /// read (worktree discovery, #1563) stay side-effect free. The closing
+    /// `standardizedFileURL` may consult the filesystem to normalize the
+    /// path (#1590); that is one cheap lookup, not directory I/O.
+    nonisolated static func managedRoot(for repository: URL) -> URL {
         let digest = SHA256.hash(data: Data(repository.path.utf8))
         let name = digest.prefix(12).map {
             String(format: "%02x", $0)
         }.joined()
-        let root = FileManager.default.urls(
+        return FileManager.default.urls(
             for: .applicationSupportDirectory,
             in: .userDomainMask
         )[0]
             .appendingPathComponent("Pine", isDirectory: true)
             .appendingPathComponent("AgentWorktrees", isDirectory: true)
             .appendingPathComponent(name, isDirectory: true)
+            .standardizedFileURL
+    }
+
+    nonisolated private static func prepareManagedRoot(
+        for repository: URL
+    ) throws -> URL {
+        let root = managedRoot(for: repository)
         try FileManager.default.createDirectory(
             at: root,
             withIntermediateDirectories: true,

--- a/PineTests/AgentWorktreeDiscoveryTests.swift
+++ b/PineTests/AgentWorktreeDiscoveryTests.swift
@@ -1,0 +1,686 @@
+//
+//  AgentWorktreeDiscoveryTests.swift
+//  PineTests
+//
+//  #1563. Closing a project drops its agent worktrees from the window's
+//  record while their directories and branches stay on disk. Discovery reads
+//  the repository back when the manager opens, so those orphans remain
+//  listable, mergeable and removable through the #1524 paths.
+//
+
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Agent worktree discovery", .serialized)
+struct AgentWorktreeDiscoveryTests {
+    // MARK: - Porcelain parsing
+
+    @Test("Porcelain parsing reads paths, branches, and detachment")
+    func porcelainParsingReadsPathsBranchesAndDetachment() {
+        let output = [
+            "worktree /repos/primary",
+            "HEAD 1111111111111111111111111111111111111111",
+            "branch refs/heads/main",
+            "",
+            "worktree /managed/00000000-0000-0000-0000-000000000021",
+            "HEAD 2222222222222222222222222222222222222222",
+            "branch refs/heads/pine/agent/codex/11111111",
+            "locked some reason",
+            "",
+            "worktree /managed/00000000-0000-0000-0000-000000000022",
+            "HEAD 3333333333333333333333333333333333333333",
+            "detached",
+            "",
+            "worktree /repos/bare",
+            "bare",
+            "",
+        ].joined(separator: "\0")
+
+        let entries = AgentWorktreeListParser.entries(inPorcelainOutput: output)
+
+        #expect(entries == [
+            AgentWorktreeListEntry(
+                path: "/repos/primary",
+                branch: "main"
+            ),
+            AgentWorktreeListEntry(
+                path: "/managed/00000000-0000-0000-0000-000000000021",
+                branch: "pine/agent/codex/11111111"
+            ),
+            AgentWorktreeListEntry(
+                path: "/managed/00000000-0000-0000-0000-000000000022",
+                branch: nil
+            ),
+            AgentWorktreeListEntry(path: "/repos/bare", branch: nil),
+        ])
+    }
+
+    @Test("A branch record before any worktree record is dropped")
+    func orphanedBranchRecordIsDropped() {
+        let malformed = [
+            "branch refs/heads/stray",
+            "",
+            "worktree /managed/00000000-0000-0000-0000-000000000023",
+            "HEAD 4444444444444444444444444444444444444444",
+            "branch refs/heads/pine/agent/codex/22222222",
+            "",
+        ].joined(separator: "\0")
+
+        let entries = AgentWorktreeListParser.entries(
+            inPorcelainOutput: malformed
+        )
+
+        #expect(entries == [
+            AgentWorktreeListEntry(
+                path: "/managed/00000000-0000-0000-0000-000000000023",
+                branch: "pine/agent/codex/22222222"
+            )
+        ])
+    }
+
+    @Test("Only a canonical lowercase UUID names a task directory")
+    func onlyLowercaseUUIDNamesATaskDirectory() {
+        #expect(
+            AgentWorktreeListParser.taskID(
+                forLowercaseUUIDName: "00000000-0000-0000-0000-000000000021"
+            ) == id(0x21)
+        )
+        #expect(
+            AgentWorktreeListParser.taskID(forLowercaseUUIDName: "notes") == nil
+        )
+        // Uppercase spelling is not what `AgentWorktreeService.create` writes.
+        #expect(
+            AgentWorktreeListParser.taskID(
+                forLowercaseUUIDName: "00000000-0000-0000-0000-00000000000A"
+            ) == nil
+        )
+        #expect(
+            AgentWorktreeListParser.taskID(
+                forLowercaseUUIDName: "00000000000000000000000000000021"
+            ) == nil
+        )
+        #expect(AgentWorktreeListParser.taskID(forLowercaseUUIDName: "") == nil)
+    }
+
+    // MARK: - Managed-root derivation
+
+    @Test("The managed root is the SHA-derived path under Application Support")
+    func managedRootIsTheShaDerivedPath() {
+        let repository = URL(
+            fileURLWithPath: "/Users/tester/Projects/pine",
+            isDirectory: true
+        )
+        let digest = SHA256.hash(data: Data(repository.path.utf8))
+        let expected = digest.prefix(12).map {
+            String(format: "%02x", $0)
+        }.joined()
+
+        let root = ProjectWindowSession.managedRoot(for: repository)
+
+        #expect(
+            Array(root.pathComponents.suffix(3))
+                == ["Pine", "AgentWorktrees", expected]
+        )
+        #expect(
+            root.deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                == FileManager.default.urls(
+                    for: .applicationSupportDirectory,
+                    in: .userDomainMask
+                )[0]
+        )
+        // Pure derivation: the directory is not created.
+        #expect(
+            !FileManager.default.fileExists(atPath: root.path)
+        )
+    }
+
+    // MARK: - Merge with the live record
+
+    @Test("The merged listing keeps each worktree once and prefers the record")
+    func mergedListingKeepsEachWorktreeOnce() {
+        let live = makeDiscoveredWorktree(
+            taskID: id(0x31),
+            branch: "pine/agent/codex/aaaabbbb",
+            baseCommit: String(repeating: "a", count: 40)
+        )
+        // What discovery would rebuild for the same checkout: same root, but
+        // without the creation-time base commit.
+        let twin = makeDiscoveredWorktree(
+            taskID: id(0x31),
+            branch: "pine/agent/codex/aaaabbbb",
+            baseCommit: nil
+        )
+        let orphan = makeDiscoveredWorktree(
+            taskID: id(0x32),
+            branch: "pine/agent/codex/ccccdddd",
+            baseCommit: nil
+        )
+
+        let merged = ProjectWindowSession.mergedWorktreeListing(
+            live: [live],
+            discovered: [twin, orphan]
+        )
+
+        #expect(merged.count == 2)
+        // The live entry — the one carrying the creation-time facts — wins.
+        #expect(merged.first { $0.taskID == live.taskID } == live)
+        #expect(merged.contains(orphan))
+    }
+
+    // MARK: - Service discovery
+
+    @Test("Discovery finds an orphan a project close left behind")
+    func discoveryFindsAnOrphanAProjectCloseLeftBehind() async throws {
+        let fixture = try DiscoveryFixture()
+        defer { fixture.cleanup() }
+        let service = AgentWorktreeService()
+        let live = try await fixture.createWorktree(
+            service, taskID: id(0x41), branch: "pine/agent/codex/aaaabbbb"
+        )
+        let orphan = try await fixture.createWorktree(
+            service, taskID: id(0x42), branch: "pine/agent/codex/ccccdddd"
+        )
+
+        let discovered = await service.discoverManagedWorktrees(
+            repositoryRoot: fixture.repository,
+            managedRoot: fixture.managedRoot
+        )
+
+        #expect(discovered.map(\.taskID) == [id(0x41), id(0x42)])
+        for worktree in [live, orphan] {
+            let rebuilt = try #require(
+                discovered.first { $0.taskID == worktree.taskID }
+            )
+            #expect(rebuilt.branchName == worktree.branchName)
+            #expect(rebuilt.worktreeRoot == worktree.worktreeRoot)
+            #expect(rebuilt.managedRoot == worktree.managedRoot)
+            #expect(
+                rebuilt.repositoryRoot.resolvingSymlinksInPath()
+                    == worktree.repositoryRoot.resolvingSymlinksInPath()
+            )
+            // baseCommit is not recoverable from disk and nothing downstream
+            // reads it; discovery must not invent one.
+            #expect(rebuilt.baseCommit == nil)
+            #expect(rebuilt.repositoryProof?.hasExactWorktreeInstance == true)
+        }
+
+        // The #1524 merge path runs on the rebuilt record alone: a close
+        // survivor must be integratable without the creation-time base
+        // commit ever existing.
+        try Data("agent result\n".utf8).write(
+            to: orphan.worktreeRoot.appendingPathComponent("tracked.txt")
+        )
+        try fixture.git(["add", "--", "tracked.txt"], at: orphan.worktreeRoot)
+        try fixture.git(
+            ["commit", "-m", "agent result"],
+            at: orphan.worktreeRoot
+        )
+        let rebuiltOrphan = try #require(
+            discovered.first { $0.taskID == id(0x42) }
+        )
+        let preview = await service.previewIntegration(
+            rebuiltOrphan,
+            previewID: id(0x43)
+        )
+        guard case .ready(let ready) = preview else {
+            Issue.record("Expected a merge preview from a discovered record")
+            return
+        }
+        #expect(ready.changedPaths == ["tracked.txt"])
+        #expect(!ready.hasConflicts)
+    }
+
+    @Test("Discovery ignores worktrees outside the managed root")
+    func discoveryIgnoresWorktreesOutsideTheManagedRoot() async throws {
+        let fixture = try DiscoveryFixture()
+        defer { fixture.cleanup() }
+        let service = AgentWorktreeService()
+        _ = try await fixture.createWorktree(
+            service, taskID: id(0x51), branch: "pine/agent/codex/aaaabbbb"
+        )
+        // A worktree with a task-UUID name, but rooted outside the managed
+        // directory: not Pine's for this repository.
+        try fixture.git([
+            "worktree", "add", "--no-track", "-b", "elsewhere/one", "--",
+            fixture.outside.appendingPathComponent(
+                id(0x52).uuidString.lowercased(),
+                isDirectory: true
+            ).path, "HEAD",
+        ])
+
+        let discovered = await service.discoverManagedWorktrees(
+            repositoryRoot: fixture.repository,
+            managedRoot: fixture.managedRoot
+        )
+
+        // The primary checkout and the outside worktree are both registered
+        // with the repository; neither may be listed.
+        #expect(discovered.map(\.taskID) == [id(0x51)])
+    }
+
+    @Test("Discovery ignores directories that are not task UUIDs")
+    func discoveryIgnoresDirectoriesThatAreNotTaskUUIDs() async throws {
+        let fixture = try DiscoveryFixture()
+        defer { fixture.cleanup() }
+        let service = AgentWorktreeService()
+        _ = try await fixture.createWorktree(
+            service, taskID: id(0x61), branch: "pine/agent/codex/aaaabbbb"
+        )
+        // Registered with git and under the managed root, but not named by a
+        // task UUID.
+        try fixture.git([
+            "worktree", "add", "--no-track", "-b", "stray/one", "--",
+            fixture.managedRoot.appendingPathComponent(
+                "notes",
+                isDirectory: true
+            ).path, "HEAD",
+        ])
+        try FileManager.default.createDirectory(
+            at: fixture.managedRoot.appendingPathComponent(
+                "leftovers",
+                isDirectory: true
+            ),
+            withIntermediateDirectories: false
+        )
+        try Data("junk".utf8).write(
+            to: fixture.managedRoot.appendingPathComponent(".DS_Store")
+        )
+
+        let discovered = await service.discoverManagedWorktrees(
+            repositoryRoot: fixture.repository,
+            managedRoot: fixture.managedRoot
+        )
+
+        #expect(discovered.map(\.taskID) == [id(0x61)])
+    }
+
+    @Test("Directories git does not recognise are reported, not hidden")
+    func directoriesGitDoesNotRecognizeAreReported() async throws {
+        let fixture = try DiscoveryFixture()
+        defer { fixture.cleanup() }
+        let service = AgentWorktreeService()
+        _ = try await fixture.createWorktree(
+            service, taskID: id(0x71), branch: "pine/agent/codex/aaaabbbb"
+        )
+        // A task directory with no worktree behind it: an interrupted or
+        // manually broken checkout.
+        let leftover = fixture.managedRoot.appendingPathComponent(
+            id(0x72).uuidString.lowercased(),
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: leftover,
+            withIntermediateDirectories: false
+        )
+        try Data("work\n".utf8).write(to: leftover.appendingPathComponent("draft.txt"))
+        // A registered worktree the agent detached: the branch is gone from
+        // git's records, the directory is still Pine's.
+        let detached = try await fixture.createWorktree(
+            service, taskID: id(0x73), branch: "pine/agent/codex/bbbbcccc"
+        )
+        try fixture.git(["checkout", "--detach"], at: detached.worktreeRoot)
+
+        let discovered = await service.discoverManagedWorktrees(
+            repositoryRoot: fixture.repository,
+            managedRoot: fixture.managedRoot
+        )
+
+        #expect(discovered.count == 3)
+        #expect(
+            Set(discovered.map(\.taskID))
+                == Set([id(0x71), id(0x72), id(0x73)])
+        )
+        // A detached checkout git recognises is labelled for what it is —
+        // never the task UUID, which the removal confirmation would quote
+        // back as a branch name — and keeps its live proof.
+        let detachedEntry = try #require(
+            discovered.first { $0.taskID == id(0x73) }
+        )
+        #expect(detachedEntry.branchName == "detached")
+        #expect(detachedEntry.baseCommit == nil)
+        #expect(detachedEntry.repositoryProof?.hasExactWorktreeInstance == true)
+        // A directory git says nothing about keeps the task UUID as its
+        // identity and claims no proof.
+        let leftoverEntry = try #require(
+            discovered.first { $0.taskID == id(0x72) }
+        )
+        #expect(leftoverEntry.branchName == id(0x72).uuidString.lowercased())
+        #expect(leftoverEntry.baseCommit == nil)
+        #expect(leftoverEntry.repositoryProof == nil)
+        #expect(
+            leftoverEntry.worktreeRoot
+                == fixture.managedRoot.appendingPathComponent(
+                    id(0x72).uuidString.lowercased(),
+                    isDirectory: true
+                ).standardizedFileURL
+        )
+    }
+
+    @Test("A repository with no managed root discovers nothing")
+    func repositoryWithNoManagedRootDiscoversNothing() async throws {
+        let fixture = try DiscoveryFixture()
+        defer { fixture.cleanup() }
+        let service = AgentWorktreeService()
+        _ = try await fixture.createWorktree(
+            service, taskID: id(0x81), branch: "pine/agent/codex/aaaabbbb"
+        )
+
+        let discovered = await service.discoverManagedWorktrees(
+            repositoryRoot: fixture.repository,
+            managedRoot: fixture.root.appendingPathComponent(
+                "absent",
+                isDirectory: true
+            )
+        )
+
+        #expect(discovered.isEmpty)
+    }
+
+    @Test("Discovery refuses a managed root inside the repository")
+    func discoveryRefusesARootInsideTheRepository() async throws {
+        let fixture = try DiscoveryFixture()
+        defer { fixture.cleanup() }
+        let inner = fixture.repository.appendingPathComponent(
+            "inner-managed",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: inner,
+            withIntermediateDirectories: false
+        )
+
+        let discovered = await AgentWorktreeService()
+            .discoverManagedWorktrees(
+                repositoryRoot: fixture.repository,
+                managedRoot: inner
+            )
+
+        #expect(discovered.isEmpty)
+    }
+
+    // MARK: - Manager rows
+
+    @Test("A directory git does not recognise is shown as unavailable")
+    @MainActor
+    func unrecognizedDirectoryIsUnavailableInTheManager() async throws {
+        let fixture = try DiscoveryFixture()
+        defer { fixture.cleanup() }
+        let service = AgentWorktreeService()
+        _ = try await fixture.createWorktree(
+            service, taskID: id(0x91), branch: "pine/agent/codex/aaaabbbb"
+        )
+        let leftover = fixture.managedRoot.appendingPathComponent(
+            id(0x92).uuidString.lowercased(),
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: leftover,
+            withIntermediateDirectories: false
+        )
+        let discovered = await service.discoverManagedWorktrees(
+            repositoryRoot: fixture.repository,
+            managedRoot: fixture.managedRoot
+        )
+        let model = AgentWorktreeManagerModel(service: service)
+
+        // While the listing loads the sheet must not claim the list is empty.
+        model.beginListing()
+        #expect(model.isListing)
+        await model.refresh(discovered)
+        #expect(!model.isListing)
+
+        #expect(
+            model.rows.first { $0.worktree.taskID == id(0x91) }?.status
+                == .clean
+        )
+        #expect(
+            model.rows.first { $0.worktree.taskID == id(0x92) }?.status
+                == .unavailable
+        )
+    }
+
+    // MARK: - Session listing
+
+    @Test("The manager listing merges the live record with disk discovery")
+    @MainActor
+    func managerListingMergesRecordWithDiscovery() async throws {
+        let fixture = try DiscoveryFixture()
+        defer { fixture.cleanup() }
+        let service = AgentWorktreeService()
+        let live = try await fixture.createWorktree(
+            service, taskID: id(0xA1), branch: "pine/agent/codex/aaaabbbb"
+        )
+        // What a project close left behind: on disk and registered, absent
+        // from this window's record.
+        let orphan = try await fixture.createWorktree(
+            service, taskID: id(0xA2), branch: "pine/agent/codex/ccccdddd"
+        )
+        let session = ProjectWindowSession(
+            initialProjectURL: fixture.repository,
+            defaults: fixture.defaults,
+            worktreeService: service,
+            managedRootResolver: { _ in fixture.managedRoot }
+        )
+        session.adoptWorktreeForTesting(live)
+
+        let listing = await session.worktreeManagerListing()
+
+        #expect(listing.map(\.taskID) == [id(0xA1), id(0xA2)])
+        // Discovery lists the orphan without re-adopting it into the window's
+        // record: the switcher keeps showing only what the user opened.
+        #expect(session.allManagedWorktrees.map(\.taskID) == [id(0xA1)])
+        // Persisted-state invariant: a discovered entry must never enter the
+        // record — a persisted worktree with a nil base commit or proof would
+        // not decode in older builds.
+        #expect(
+            session.managedWorktrees[
+                orphan.worktreeRoot.standardizedFileURL
+            ] == nil
+        )
+
+        // Once the orphan is part of the record again, it is listed once and
+        // the record's entry — the one with the base commit — is the one shown.
+        session.adoptWorktreeForTesting(orphan)
+        let merged = await session.worktreeManagerListing()
+        #expect(merged.count == 2)
+        let shownOrphan = try #require(
+            merged.first { $0.taskID == id(0xA2) }
+        )
+        #expect(shownOrphan == orphan)
+    }
+
+    @Test("Listing uses the active worktree record's managed root")
+    @MainActor
+    func managerListingUsesTheActiveWorktreeRecordRoot() async throws {
+        let fixture = try DiscoveryFixture()
+        defer { fixture.cleanup() }
+        let service = AgentWorktreeService()
+        // A window sitting inside a worktree: the record's managed root is
+        // the only spelling guaranteed to match what `launchAgent` used. The
+        // resolver here deliberately answers with a wrong, non-existent root.
+        let live = try await fixture.createWorktree(
+            service, taskID: id(0xC1), branch: "pine/agent/codex/aaaabbbb"
+        )
+        _ = try await fixture.createWorktree(
+            service, taskID: id(0xC2), branch: "pine/agent/codex/ccccdddd"
+        )
+        let session = ProjectWindowSession(
+            initialProjectURL: live.worktreeRoot,
+            defaults: fixture.defaults,
+            worktreeService: service,
+            managedRootResolver: { _ in
+                fixture.root.appendingPathComponent(
+                    "wrong-root",
+                    isDirectory: true
+                )
+            }
+        )
+        session.adoptWorktreeForTesting(live)
+
+        let listing = await session.worktreeManagerListing()
+
+        // Hashing the resolver's answer would discover nothing; the record's
+        // root finds the orphan.
+        #expect(
+            Set(listing.map(\.taskID)) == Set([id(0xC1), id(0xC2)])
+        )
+    }
+
+    @Test("A repository with no managed root lists only the live record")
+    @MainActor
+    func managerListingWithoutAManagedRoot() async throws {
+        let fixture = try DiscoveryFixture()
+        defer { fixture.cleanup() }
+        let service = AgentWorktreeService()
+        let live = try await fixture.createWorktree(
+            service, taskID: id(0xB1), branch: "pine/agent/codex/aaaabbbb"
+        )
+        let session = ProjectWindowSession(
+            initialProjectURL: fixture.repository,
+            defaults: fixture.defaults,
+            worktreeService: service,
+            managedRootResolver: { _ in
+                fixture.root.appendingPathComponent(
+                    "absent",
+                    isDirectory: true
+                )
+            }
+        )
+        session.adoptWorktreeForTesting(live)
+
+        let listing = await session.worktreeManagerListing()
+
+        #expect(listing.map(\.taskID) == [id(0xB1)])
+    }
+}
+
+// MARK: - Fixtures
+
+private func id(_ value: UInt8) -> UUID {
+    UUID(uuid: (
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, value
+    ))
+}
+
+private func makeDiscoveredWorktree(
+    taskID: UUID,
+    branch: String,
+    baseCommit: String?
+) -> AgentManagedWorktree {
+    let managedRoot = URL(
+        fileURLWithPath: "/tmp/pine-discovery-managed",
+        isDirectory: true
+    )
+    return AgentManagedWorktree(
+        taskID: taskID,
+        repositoryRoot: URL(
+            fileURLWithPath: "/tmp/pine-discovery-repository",
+            isDirectory: true
+        ),
+        managedRoot: managedRoot,
+        worktreeRoot: managedRoot.appendingPathComponent(
+            taskID.uuidString.lowercased(),
+            isDirectory: true
+        ),
+        branchName: branch,
+        baseCommit: baseCommit,
+        repositoryProof: RecentAgentTaskRepositoryProof(
+            commonDirectoryDevice: 1,
+            commonDirectoryInode: 2,
+            commonDirectoryGeneration: 3,
+            commonDirectoryBirthSeconds: 4,
+            commonDirectoryBirthNanoseconds: 5
+        )
+    )
+}
+
+private enum DiscoveryFixtureError: Error {
+    case commandFailed
+}
+
+private final class DiscoveryFixture {
+    let root: URL
+    let repository: URL
+    let managedRoot: URL
+    let outside: URL
+    let defaults: UserDefaults
+    private let suiteName: String
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "PineAgentWorktreeDiscovery-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        repository = root.appendingPathComponent("repository", isDirectory: true)
+        managedRoot = root.appendingPathComponent("managed", isDirectory: true)
+        outside = root.appendingPathComponent("outside", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: repository,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: managedRoot,
+            withIntermediateDirectories: false
+        )
+        try FileManager.default.createDirectory(
+            at: outside,
+            withIntermediateDirectories: false
+        )
+        suiteName = "AgentWorktreeDiscoveryTests.\(UUID().uuidString)"
+        defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        _ = try git(["init", "-b", "main"], at: repository)
+        _ = try git(["config", "user.email", "pine-tests@example.invalid"])
+        _ = try git(["config", "user.name", "Pine Tests"])
+        try Data("base\n".utf8).write(
+            to: repository.appendingPathComponent("tracked.txt")
+        )
+        _ = try git(["add", "--", "tracked.txt"])
+        _ = try git(["commit", "-m", "base"])
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func cleanup() {
+        defaults.removePersistentDomain(forName: suiteName)
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func createWorktree(
+        _ service: AgentWorktreeService,
+        taskID: UUID,
+        branch: String
+    ) async throws -> AgentManagedWorktree {
+        let result = await service.create(AgentWorktreeCreateRequest(
+            taskID: taskID,
+            repositoryRoot: repository,
+            managedRoot: managedRoot,
+            branchName: branch,
+            startPoint: "HEAD"
+        ))
+        guard case .created(let worktree) = result else {
+            throw DiscoveryFixtureError.commandFailed
+        }
+        return worktree
+    }
+
+    @discardableResult
+    func git(
+        _ arguments: [String],
+        at directory: URL? = nil
+    ) throws -> String {
+        let result = GitCommand.run(arguments, at: directory ?? repository)
+        guard result.succeeded else {
+            throw DiscoveryFixtureError.commandFailed
+        }
+        return result.output
+    }
+}


### PR DESCRIPTION
Closes #1563. Split out: #1603, #1604.

## Summary

The worktree manager merges its live records with an on-disk discovery, run when the sheet opens:

- `git worktree list --porcelain -z` plus a scan of the managed root; only entries whose parent is that root and whose name is a lowercase task UUID are kept. All git work runs in the actor, scans and proofs in `runOnBackground` with an autorelease pool (#1509).
- Rebuilt records carry a **live** `repositoryProof`; `baseCommit` stays nil — nothing in production reads it (verified by grep at review; remove/inspect/integrate work from live refs). Discovery never adopts anything into `managedWorktrees`: persisted state is byte-identical in shape, and an explicit doc invariant + test assert keep it that way.
- A git-recognized **detached** worktree is labelled with git's own term ("detached", verbatim) and keeps a live proof; its Integrate fails closed (`sourceBranchChanged`) as before. Directories git does not recognize surface as unavailable instead of silently hiding.
- The managed root comes from the active worktree's own record when one exists, falling back to the resolver — a symlinked anchor can no longer hash a different root and silently empty discovery exactly when the user sits in a worktree (round-2 review find).
- The sheet shows a progress indicator while discovery runs (`beginListing`/`isListing`), restoring the model's documented "never empty while git runs" invariant (round-2 review find).
- One sort order `(branchName, taskID)` across live and discovered rows.

15 new tests in `AgentWorktreeDiscoveryTests` run against a real git fixture — porcelain parsing (detached/bare/locked/garbage), the UUID gate, dedup with live records winning, the close→reopen reproduction, merge-preview through the confirmed path on a nil-baseCommit record, and the record-root + persist invariants.

## Review gate

Three independent lenses, then a fix round, then a dedicated round-2 verifier:

| Lens | Round 1 | Round 2 |
|---|---|---|
| Correctness & architecture | parser verified against real `--porcelain -z` output incl. symlink experiment; dedup byte-exactness proven by a real create→discover test; F1 fake-branch label and F2 root-spelling asymmetry found (P3 each) | 7/7 CLOSED |
| Concurrency & lifecycle | actor isolation, `runOnBackground` + autorelease, Sendable captures, `.task` cancellation cascade, secureManagedWorktree semantics byte-identical after static-ization, no second admission door | clean; P2: empty-state flash (documented model invariant violated) → fixed |
| Tests, UX & docs | all 5 acceptance scenarios covered, RED-provable, suite 5.75s serialized (comparable to existing fixtures), alert text from #1524 now truthful | merge-path test added (closes AC2 fully), sort unified |

Known limits, deliberately out of scope: prunable rows (#1603), cross-window records (#1604), discovery keyed to path spelling for a plain (non-worktree) repo opened through a different symlink spelling — fail-closed (no wrong rows, orphans just not found).

## Local verification

- Suites (one at a time): AgentWorktreeDiscoveryTests 15/15, AgentWorktreeServiceTests 9/9, AgentWorktreeManagerModelTests 16/16, ProjectWindowSessionTests 12/12, ProjectCloseTests 13/13
- `swiftlint --strict` — 0 violations; live-parser cross-check against `git worktree list` output on this machine
- Environment: macOS 27.0 (26A5425a), Xcode 27.0 (27A5252f), SDK 27.0 (26A5419a), git 2.54 — local runs on this runtime are not a pass/fail signal (#1509); CI (macOS 26, git ≥2.47) is authoritative

## Merge notes

- No file overlap with the other wave-1 branches (menus/i18n/a11y).
- Manual pass worth doing: close a project with a live agent worktree → reopen → Agent ▸ Manage Agent Worktrees — the orphan is listed with its branch and integrates/removes through the existing confirmations.