### PR TITLE
test: replace main-actor wait budgets with a shared bounded-wait helper

### DIFF
--- a/.claude/rules/concurrency.md
+++ b/.claude/rules/concurrency.md
@@ -37,3 +37,9 @@ Pine uses GCD for background work, bridged to async/await via `withCheckedContin
 **Reentrancy / exclusivity:**
 
 - **Reentrancy / exclusivity** — never post a `NotificationCenter` notification inside a function that holds an `inout` (e.g. `tabs: inout [EditorTab]`) exclusive access. `NotificationCenter.post` delivers observers synchronously on the main queue; an observer that writes the same store re-enters the live access and Swift aborts the process (`_swift_reportExclusivityConflict`, Pine #1066 and the #1047/#1051/#1056/#1058 family). Safe pattern: RETURN the payload (e.g. `SaveOutcome.reload` / `ReloadedTab`) and let the caller post AFTER the `inout` scope ends — see `TabExternalChangeDetector.reloadTab` and `TabPersistence.saveTabContent`. For `.onReceive` / `@objc` observers, defer `@State`/`@Observable` mutations to the next runloop via `DispatchQueue.main.async`. The `check-no-post-under-inout.py` guard enforces the `inout`-post sub-pattern at pre-commit and CI; if you legitimately defer a post inside an `inout` function, mark the line `// reentrancy-safe`
+
+**Bounded waits in tests (`PineTests/**`, #1568):**
+
+- A wait for main-actor work must poll the condition through `waitUntilMainActor` (`PineTests/BoundedMainActorWait.swift`) with a generous ceiling. Swift Testing runs suites in parallel and every hop back onto the main actor queues behind `@MainActor` neighbours — a suite hosting a SwiftUI view holds the actor for ~80 ms per test — so a budget tuned on an idle machine measures the scheduler, not the code, and fails only in a full parallel run while passing in isolation.
+- The ceiling is a stuck-operation tripwire, not a stopwatch: never tune it down because the test "usually finishes in milliseconds", and never fix a flaky wait by adding an unconditional `sleep`.
+- If the point of a test is *speed*, the measurement belongs in `PinePerformanceTests`, not in a suite that runs beside arbitrary neighbours.

--- a/PineTests/AgentInboxTests.swift
+++ b/PineTests/AgentInboxTests.swift
@@ -55,19 +55,26 @@ private actor BlockingInboxProjectCanonicalizer {
 
     /// Waits for the recovery path to reach canonicalization.
     ///
-    /// The budget is generous on purpose. `recoverAgentTaskFromInbox` runs on
-    /// the main actor, and Swift Testing runs suites in parallel, so the 200 ms
-    /// this used to allow was really a race against however busy the main
-    /// actor happened to be — any `@MainActor` neighbour that hosts a view for
-    /// a fifth of a second turned this into a failure with nothing wrong in
-    /// either test. Still bounded, so a genuinely stuck recovery still fails
-    /// rather than hanging the suite (#1533).
+    /// Same contract as `waitUntilMainActor` (#1568), kept local only because
+    /// `entered` is actor-isolated and cannot be polled from a `@MainActor`
+    /// closure: the ceiling is a wall-clock bound, generous on purpose.
+    /// `recoverAgentTaskFromInbox` runs on the main actor, and Swift Testing
+    /// runs suites in parallel, so a tight number would really race however
+    /// busy the main actor happened to be — any `@MainActor` neighbour that
+    /// hosts a view for a fifth of a second could turn this into a failure
+    /// with nothing wrong in either test. Still bounded, so a genuinely
+    /// stuck recovery fails rather than hanging the suite (#1533). The
+    /// previous iteration budget (`0..<5_000` × 1 ms) had no wall-clock
+    /// meaning at all; a cancelled caller now stops instead of spinning.
     func waitUntilEntered() async -> Bool {
-        for _ in 0..<5_000 {
-            if entered { return true }
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(5))
+        while !entered {
+            if Task.isCancelled { return false }
+            guard clock.now < deadline else { return false }
             try? await Task.sleep(for: .milliseconds(1))
         }
-        return entered
+        return true
     }
 
     func release() {
@@ -791,10 +798,10 @@ struct AgentInboxTests {
                 activateApplication: { _ in }
             )
         }
-        for _ in 0..<100 where !cancellationWaitEntered {
-            try? await Task.sleep(for: .milliseconds(5))
-        }
-        try #require(cancellationWaitEntered)
+        try #require(
+            await waitUntilMainActor { cancellationWaitEntered },
+            "cancelled recovery must reach its presentation wait"
+        )
         projectRegistry.runBackgroundReclamationPassForTesting()
         expectRetainedBackgroundState()
         cancelledRecovery.cancel()
@@ -983,10 +990,10 @@ struct AgentInboxTests {
                 activateApplication: { _ in }
             )
         }
-        for _ in 0..<200 where !firstWaitEntered {
-            try? await Task.sleep(for: .milliseconds(2))
-        }
-        try #require(firstWaitEntered)
+        try #require(
+            await waitUntilMainActor { firstWaitEntered },
+            "first recovery must reach its presentation wait"
+        )
 
         let window = makeEligibleProjectWindow()
         defer {
@@ -1104,10 +1111,10 @@ struct AgentInboxTests {
                 activateApplication: { _ in }
             )
         }
-        for _ in 0..<200 where !blocker.hasEntered {
-            try? await Task.sleep(for: .milliseconds(2))
-        }
-        try #require(blocker.hasEntered)
+        try #require(
+            await waitUntilMainActor { blocker.hasEntered },
+            "vendor resume must reach its canonicalization blocker"
+        )
 
         projectRegistry.closeProjectWindow(
             canonical,
@@ -1257,10 +1264,10 @@ struct AgentInboxTests {
         _ taskID: UUID,
         in registry: AgentTaskRegistry
     ) async throws {
-        for _ in 0..<200 where registry.task(for: taskID) == nil {
-            try await Task.sleep(for: .milliseconds(1))
-        }
-        _ = try #require(registry.task(for: taskID))
+        try #require(
+            await waitUntilMainActor { registry.task(for: taskID) != nil },
+            "persisted task must finish loading"
+        )
     }
 
     private func assertBackgroundRecoveryState(

--- a/PineTests/BackgroundProjectLifecycleTests.swift
+++ b/PineTests/BackgroundProjectLifecycleTests.swift
@@ -842,13 +842,16 @@ struct BackgroundProjectLifecycleTests {
         )
     }
 
+    /// Background reclamation lands on the main actor, which parallel
+    /// suites contend for — the 500 ms this used to allow measured the
+    /// scheduler, not the reclamation (#1568). The shared helper keeps a
+    /// generous ceiling so a stuck reclamation still fails.
     private func waitUntil(
         _ condition: @escaping @MainActor () -> Bool
     ) async {
-        for _ in 0..<100 {
-            if condition() { return }
-            try? await Task.sleep(for: .milliseconds(5))
+        guard await waitUntilMainActor(condition) else {
+            Issue.record("Timed out waiting for background reclamation")
+            return
         }
-        Issue.record("Timed out waiting for background reclamation")
     }
 }

--- a/PineTests/BoundedMainActorWait.swift
+++ b/PineTests/BoundedMainActorWait.swift
@@ -1,0 +1,69 @@
+//
+//  BoundedMainActorWait.swift
+//  PineTests
+//
+//  Shared bounded wait for conditions that flip on the main actor (#1568).
+//
+
+import Foundation
+
+/// Polls a main-actor condition at a short interval under a generous ceiling.
+///
+/// ## Why the ceiling must be generous
+///
+/// Swift Testing runs suites in parallel, and every hop back onto the main
+/// actor queues behind whatever `@MainActor` neighbours happen to be running.
+/// A suite that hosts a SwiftUI view holds the main actor for roughly 80 ms
+/// per test, so a wait budget tuned on an idle machine — a few hundred
+/// milliseconds — does not measure the code under test. It measures how busy
+/// the scheduler was, fails only in a full parallel run, and passes in
+/// isolation, which is what makes it expensive to diagnose (#1568).
+///
+/// A wait for main-actor work therefore has two jobs that must not be
+/// conflated:
+///
+/// - **Completeness** — notice the condition promptly. The 1 ms poll interval
+///   does this: the condition is observed within one main-actor turn of it
+///   becoming true.
+/// - **Stuck detection** — still fail instead of hanging when the operation
+///   is genuinely broken. That is all the ceiling is: a tripwire, not a
+///   stopwatch. The 5 s default tolerates dozens of hosted-view neighbours
+///   while bounding a hung operation.
+///
+/// Consequences for call sites:
+///
+/// - Never tune the ceiling down because the test "usually finishes in
+///   milliseconds" — that is exactly the idle-machine assumption this helper
+///   exists to retire.
+/// - If the point of a test is *speed*, the measurement belongs in
+///   `PinePerformanceTests`, not in a suite that runs beside arbitrary
+///   neighbours.
+/// - Never replace a wait with an unconditional `sleep`; either poll the
+///   condition with this helper or signal completion explicitly through a
+///   continuation.
+///
+/// - Returns: `true` once the condition held, `false` if the ceiling was
+///   reached or the calling task was cancelled. Record the result with
+///   `#require`/`#expect` at the call site so a failure carries the caller's
+///   source location and intent.
+///
+///   Cancellation is checked explicitly at the top of every iteration: in a
+///   cancelled task `Task.sleep` throws before sleeping at all, and a `try?`
+///   would swallow that, turning the poll into a hot spin on the main actor
+///   until the ceiling expires. A cancelled caller returns `false`
+///   immediately instead (same pattern as the SourceKit-LSP smoke wait).
+@MainActor
+func waitUntilMainActor(
+    _ condition: @MainActor () -> Bool,
+    ceiling: Duration = .seconds(5),
+    pollInterval: Duration = .milliseconds(1)
+) async -> Bool {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: ceiling)
+    while !condition() {
+        if Task.isCancelled { return false }
+        guard clock.now < deadline else { return false }
+        try? await Task.sleep(for: pollInterval)
+    }
+    return true
+}

--- a/PineTests/BoundedMainActorWaitTests.swift
+++ b/PineTests/BoundedMainActorWaitTests.swift
@@ -1,0 +1,78 @@
+//
+//  BoundedMainActorWaitTests.swift
+//  PineTests
+//
+//  Contract tests for the shared bounded wait (#1568). Ceilings here are
+//  deliberately small so the suite stays fast; the default 5 s ceiling is
+//  only ever exercised on the failure path and is not tested.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("BoundedMainActorWait")
+@MainActor
+struct BoundedMainActorWaitTests {
+    @Test("An already-true condition returns true without sleeping")
+    func alreadyTrueConditionReturnsImmediately() async {
+        let result = await waitUntilMainActor(
+            { true },
+            ceiling: .milliseconds(50)
+        )
+
+        #expect(result)
+    }
+
+    @Test("A never-true condition exhausts an explicit small ceiling")
+    func neverTrueConditionReturnsFalse() async {
+        let result = await waitUntilMainActor(
+            { false },
+            ceiling: .milliseconds(50)
+        )
+
+        #expect(!result)
+    }
+
+    @Test("A condition that flips mid-wait is noticed")
+    func flippingConditionIsNoticed() async {
+        var satisfied = false
+        let flipper = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(20))
+            satisfied = true
+        }
+
+        let result = await waitUntilMainActor(
+            { satisfied },
+            ceiling: .seconds(5)
+        )
+
+        #expect(result)
+        _ = await flipper.value
+    }
+
+    @Test("A cancelled caller returns false promptly instead of spinning")
+    func cancelledCallerStopsPromptly() async {
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+        let waiter = Task { @MainActor in
+            await waitUntilMainActor(
+                { false },
+                ceiling: .seconds(10)
+            )
+        }
+        // Give the waiter one poll iteration, then cancel it. Without the
+        // explicit Task.isCancelled check, the swallowed CancellationError
+        // would spin the poll hot until the 10 s ceiling and this test
+        // would exceed the 5 s bound below.
+        try? await Task.sleep(for: .milliseconds(10))
+        waiter.cancel()
+
+        let result = await waiter.value
+        let elapsed = startedAt.duration(to: clock.now)
+
+        #expect(!result)
+        #expect(elapsed < .seconds(5))
+    }
+}

--- a/PineTests/CommandOverlayRouterTests.swift
+++ b/PineTests/CommandOverlayRouterTests.swift
@@ -523,17 +523,16 @@ struct CommandOverlayRouterTests {
 
     /// Waits without blocking the main actor so the router's deliberately
     /// deferred AppKit restoration and command delivery can complete.
+    /// Delegates to the shared bounded wait (#1568).
     private func waitUntil(
         timeout: Duration = .seconds(1),
         condition: @MainActor () -> Bool
     ) async -> Bool {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: timeout)
-        while !condition() {
-            guard clock.now < deadline else { return false }
-            try? await Task.sleep(for: .milliseconds(5))
-        }
-        return true
+        await waitUntilMainActor(
+            condition,
+            ceiling: timeout,
+            pollInterval: .milliseconds(5)
+        )
     }
 }
 

--- a/PineTests/LSPTransportTests.swift
+++ b/PineTests/LSPTransportTests.swift
@@ -302,6 +302,22 @@ struct LSPMessageStreamParserTests {
 @Suite("LSP Process Transport Tests", .serialized)
 @MainActor
 struct LSPProcessTransportTests {
+    /// Ceiling for teardown timings in this suite: a tripwire that still
+    /// fails a hung child, not a stopwatch. Process teardown hops through
+    /// the main actor, and parallel suites contend for it — a tighter number
+    /// here measures the scheduler, not the code (#1568).
+    private static let teardownCeiling: Duration = .seconds(10)
+
+    /// The starvation trip-wire pair, named so their relation is checked
+    /// in one place: `starvationBudget` MUST stay below
+    /// `starvationReleaseDelay`. A regressed `terminateAsync` that waits
+    /// behind the saturated utility queue returns only when the saturation
+    /// releases, so it exceeds the budget and fails the test; a healthy
+    /// run finishes far inside the budget. Both stay generous enough that
+    /// parallel-suite contention cannot fail a healthy run (#1568).
+    private static let starvationBudget: Duration = .seconds(5)
+    private static let starvationReleaseDelay: TimeInterval = 5.25
+
     @Test("Stdout descriptor setup succeeds or fails closed")
     func configuresNonblockingDescriptor() {
         let pipe = Pipe()
@@ -819,7 +835,7 @@ struct LSPProcessTransportTests {
         #expect(!(await start.value))
 
         let elapsed = startedAt.duration(to: clock.now)
-        #expect(elapsed < .seconds(2))
+        #expect(elapsed < Self.teardownCeiling)
         #expect(client.state == .failed)
         #expect(client.pendingRequestCount == 0)
         #expect(!client.transport.isRunning)
@@ -871,7 +887,7 @@ struct LSPProcessTransportTests {
         #expect(!(await start.value))
 
         let elapsed = startedAt.duration(to: clock.now)
-        #expect(elapsed < .seconds(2))
+        #expect(elapsed < Self.teardownCeiling)
         #expect(client.state == .failed)
         #expect(client.pendingRequestCount == 0)
         #expect(!client.transport.isRunning)
@@ -1040,7 +1056,7 @@ struct LSPProcessTransportTests {
         #expect(!didShutDownGracefully)
         let elapsed = startedAt.duration(to: clock.now)
 
-        #expect(elapsed < .seconds(2))
+        #expect(elapsed < Self.teardownCeiling)
         #expect(client.state == .exited)
         #expect(!client.transport.isRunning)
         #expect(client.pendingRequestCount == 0)
@@ -1075,7 +1091,7 @@ struct LSPProcessTransportTests {
         transport.terminate(timeout: 0.1)
         let elapsed = startedAt.duration(to: clock.now)
 
-        #expect(elapsed < .seconds(2))
+        #expect(elapsed < Self.teardownCeiling)
         #expect(!transport.isRunning)
         if let processID {
             #expect(!isProcessAlive(processID))
@@ -1102,15 +1118,16 @@ struct LSPProcessTransportTests {
         defer { saturation.release() }
         await saturation.waitUntilSaturated()
         // Keeps the pre-fix implementation from hanging indefinitely while
-        // its terminate block waits behind the saturated utility queue.
-        saturation.release(after: 2.25)
+        // its terminate block waits behind the saturated utility queue. The
+        // budget/release relation is documented on the named pair above.
+        saturation.release(after: Self.starvationReleaseDelay)
 
         let clock = ContinuousClock()
         let startedAt = clock.now
         await transport.terminateAsync(timeout: 0.1)
         let elapsed = startedAt.duration(to: clock.now)
 
-        #expect(elapsed < .seconds(2))
+        #expect(elapsed < Self.starvationBudget)
         #expect(!transport.isRunning)
         #expect(!isProcessAlive(processID))
     }
@@ -1188,16 +1205,10 @@ private final class RecordingLSPTransportDelegate: LSPTransportDelegate {
 
 @MainActor
 private func waitUntil(
-    timeout: Duration = .seconds(2),
+    timeout: Duration = .seconds(5),
     condition: @MainActor () -> Bool
 ) async -> Bool {
-    let clock = ContinuousClock()
-    let deadline = clock.now.advanced(by: timeout)
-    while !condition() {
-        guard clock.now < deadline else { return false }
-        try? await Task.sleep(for: .milliseconds(10))
-    }
-    return true
+    await waitUntilMainActor(condition, ceiling: timeout, pollInterval: .milliseconds(10))
 }
 
 private func isProcessAlive(_ processID: pid_t) -> Bool {

--- a/PineTests/LayoutStabilityTests.swift
+++ b/PineTests/LayoutStabilityTests.swift
@@ -83,6 +83,15 @@ struct LayoutStabilityTests {
         // Documents the contract used by `isLoadingFalseAfterEmptyDir`:
         // calling `waitForLoadingComplete()` on a fresh manager must not
         // suspend at all.
+        //
+        // Triage (#1568): the 100 ms bound is a no-suspend tripwire, not a
+        // stopwatch. The idle path never releases the main actor — the
+        // continuation is resumed synchronously inside
+        // `withCheckedContinuation` while the caller still owns it — so
+        // parallel neighbours cannot inflate this the way they can a real
+        // main-actor wait. That fast path is a runtime behaviour rather than
+        // a documented contract: if it ever disappears and this starts
+        // flaking under a full run, migrate to `waitUntilMainActor`.
         let workspace = WorkspaceManager()
         let start = ContinuousClock.now
         await workspace.waitForLoadingComplete()
@@ -106,7 +115,10 @@ struct LayoutStabilityTests {
         await workspace.waitForLoadingComplete()
         #expect(!workspace.isLoading)
 
-        // Subsequent waits must be no-ops (idle path).
+        // Subsequent waits must be no-ops (idle path). The 100 ms bound is
+        // the same no-suspend tripwire as in
+        // `waitForLoadingCompleteIsNoOpWhenIdle` — see the triage note there
+        // (#1568).
         let start = ContinuousClock.now
         for _ in 0..<5 {
             await workspace.waitForLoadingComplete()

--- a/PineTests/NativeFileWindowMenuTests.swift
+++ b/PineTests/NativeFileWindowMenuTests.swift
@@ -551,12 +551,15 @@ struct NativeFileWindowMenuTests {
         }
 
         projectManager.openFileFromMenu()
-        for _ in 0..<20
-        where !firstTabManager.tabs.contains(where: {
-            $0.fileURL == file
-        }) {
-            try await Task.sleep(for: .milliseconds(10))
-        }
+        // The deferred open lands on the main actor; wait under a generous
+        // ceiling instead of a 200 ms iteration budget that measured the
+        // scheduler under a parallel run (#1568).
+        try #require(
+            await waitUntilMainActor {
+                firstTabManager.tabs.contains(where: { $0.fileURL == file })
+            },
+            "menu open must land in the first pane's tab manager"
+        )
 
         #expect(chooserRoot == root)
         #expect(firstTabManager.tabs.contains(where: { $0.fileURL == file }))
@@ -761,9 +764,13 @@ struct NativeFileWindowMenuTests {
                 continuation.resume()
             }
         }
-        for _ in 0..<200 where openedURL == nil {
-            try? await Task.sleep(for: .milliseconds(2))
-        }
+        // The deferred open runs on the main actor; the wait needs a
+        // ceiling that tolerates parallel neighbours, not a 400 ms
+        // iteration budget tuned on an idle machine (#1568).
+        try #require(
+            await waitUntilMainActor { openedURL != nil },
+            "deferred Open Recent fallback must run"
+        )
 
         let canonical = delegate.registry.canonicalProjectURL(directory)
         #expect(openedURL == canonical)

--- a/PineTests/ProgressTrackerLeakTests.swift
+++ b/PineTests/ProgressTrackerLeakTests.swift
@@ -147,15 +147,13 @@ struct ProgressTrackerLeakTests {
         // Wait for dir2's load to complete
         await manager.waitForLoadingComplete()
 
-        // The cancelled dir1 task's cleanup runs asynchronously on MainActor.
-        // Poll briefly for its endOperation to land.
-        for _ in 0..<20 {
-            if tracker.activeOperationCount == 0 { break }
-            try await Task.sleep(for: .milliseconds(50))
+        // The cancelled dir1 task's cleanup runs asynchronously on MainActor;
+        // wait for its endOperation to land under a generous ceiling (#1568).
+        let cleanupLanded = await waitUntilMainActor {
+            tracker.activeOperationCount == 0
         }
-
         #expect(
-            tracker.activeOperationCount == 0,
+            cleanupLanded,
             "Cancelled load must not leak progress operations; found \(tracker.activeOperationCount) active"
         )
     }
@@ -192,14 +190,13 @@ struct ProgressTrackerLeakTests {
         // Wait for the last refresh to settle
         await manager.waitForLoadingComplete()
 
-        // Poll briefly for any cancelled task cleanup to land
-        for _ in 0..<20 {
-            if tracker.activeOperationCount == 0 { break }
-            try await Task.sleep(for: .milliseconds(50))
+        // Cancelled-refresh cleanup lands on MainActor; wait under a
+        // generous ceiling (#1568).
+        let cleanupLanded = await waitUntilMainActor {
+            tracker.activeOperationCount == 0
         }
-
         #expect(
-            tracker.activeOperationCount == 0,
+            cleanupLanded,
             "Rapid refreshes must not leak progress operations; found \(tracker.activeOperationCount) active"
         )
     }
@@ -226,14 +223,13 @@ struct ProgressTrackerLeakTests {
 
         await manager.waitForLoadingComplete()
 
-        // Poll briefly for any cancelled task cleanup to land
-        for _ in 0..<20 {
-            if tracker.activeOperationCount == 0 { break }
-            try await Task.sleep(for: .milliseconds(50))
+        // Cancelled-task cleanup lands on MainActor; wait under a generous
+        // ceiling (#1568).
+        let cleanupLanded = await waitUntilMainActor {
+            tracker.activeOperationCount == 0
         }
-
         #expect(
-            tracker.activeOperationCount == 0,
+            cleanupLanded,
             "loadDirectory + refreshFileTreeAsync must not leak; found \(tracker.activeOperationCount) active"
         )
     }

--- a/PineTests/QuickTerminalAgentDetectionTests.swift
+++ b/PineTests/QuickTerminalAgentDetectionTests.swift
@@ -1604,11 +1604,13 @@ struct QuickTerminalAgentDetectionTests {
             worktree.path,
         ], at: repository)
         await gate.release()
-        for _ in 0..<200
-        where tab.isStartValidationPendingForTesting {
-            try? await Task.sleep(for: .milliseconds(2))
-        }
-        #expect(!tab.isStartValidationPendingForTesting)
+        // Start validation finishes on the main actor; wait for it under a
+        // generous ceiling instead of a 400 ms iteration budget that
+        // measured the scheduler under a parallel run (#1568).
+        try #require(
+            await waitUntilMainActor { !tab.isStartValidationPendingForTesting },
+            "start validation must finish after the gate is released"
+        )
         #expect(!tab.isProcessRunning)
     }
 

--- a/PineTests/UserTaskRunnerTests.swift
+++ b/PineTests/UserTaskRunnerTests.swift
@@ -1094,7 +1094,12 @@ nonisolated struct UserTaskRunnerTests {
         let completion = await probe.waitForCompletion()
         let elapsed = startedAt.duration(to: clock.now)
 
-        #expect(elapsed < .seconds(3))
+        // Ceiling, not stopwatch: the escaped-descendant cleanup competes
+        // with parallel suites for the main actor, so the budget stays
+        // generous. It catches a late return; a truly hung cleanup holds
+        // `waitForCompletion` until the suite's `.timeLimit` — this bound
+        // never has to detect that (#1568).
+        #expect(elapsed < .seconds(10))
         #expect(completion.outcome.succeeded)
         #expect(!completion.cancelled)
         if let childProcessID {
@@ -1143,8 +1148,11 @@ nonisolated struct UserTaskRunnerTests {
         // Darwin has no public kill-process-tree primitive. A daemon that
         // double-forks and calls setsid between 25 ms identity snapshots can
         // escape; the supported guarantee is bounded return plus cleanup of
-        // every identity Pine actually observed.
-        #expect(elapsed < .seconds(3))
+        // every identity Pine actually observed. The elapsed ceiling catches
+        // a late return; a truly hung cleanup holds `waitForCompletion`
+        // until the suite's `.timeLimit`, and the runner's own 3 s timeout
+        // already reports itself via `outcome.timedOut` (#1568).
+        #expect(elapsed < .seconds(10))
         #expect(!completion.outcome.timedOut)
 
         if let childProcessID = await waitForProcessID(at: childPIDURL) {

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -920,8 +920,14 @@ struct WindowLifecycleTests {
                 .applicationQuitFailure,
             ]
         )
+        // The probe clock starts before `confirmApplicationTermination` is
+        // even entered, and reaching the deadline arming point hops the main
+        // actor, which parallel suites contend for. The ceiling only has to
+        // prove the 25 ms machine deadline beat the 10 s hung save — 1 s was
+        // a stopwatch number tuned on an idle machine (#1568).
         #expect(
-            deadlineProbe.elapsedNanoseconds.map { $0 < 1_000_000_000 } == true
+            deadlineProbe.elapsedNanoseconds
+                .map { $0 < 5_000_000_000 } == true
         )
         #expect(project.hasUnsavedChanges)
         await project.workspace.waitForLoadingComplete()


### PR DESCRIPTION
Closes #1568. Split out: #1605 (remaining background-flip budgets + QuickOpen perf move), #1606, #1607 (product-race candidates the audit surfaced).

## Summary

A fixed budget on a **main-actor** wait measures the scheduler, not the code: Swift Testing runs suites in parallel, a hosted-view neighbour holds the actor for ~80 ms per test, and a budget tuned on an idle machine fails only in a full run while passing in isolation. Reproduced on base during review: `LSPProcessTransportTests/initializeTimeoutCleanupDoesNotBlockMainActor` elapsed 3.85s against a 2s budget under parallel load; passes with this diff.

- **`waitUntilMainActor`** (`PineTests/BoundedMainActorWait.swift`): 1 ms condition polling under a 5 s ceiling that exists solely to fail a stuck operation. Cancellation is checked every iteration — a cancelled `Task.sleep` throws *before* sleeping, and a swallowed error would hot-spin the main actor to the ceiling (round-1 review find, P1).
- **The rule lives where the next author loads it**: a new section in `.claude/rules/concurrency.md` (auto-loaded for `PineTests/**`) plus the helper's doc comment.
- 4 contract tests for the helper itself, including a cancellation test that is red on the un-fixed spin.
- Migrations: 15 main-actor-bound poll loops → helper; LSP teardown ceilings → named `teardownCeiling` (10s); the starvation detector keeps its **budget-below-release** ordering as named constants (5s/5.25s — same 250 ms detection margin as before); runner ceilings 3s→10s with the timing intent still carried by `outcome.timedOut`; `WindowLifecycleTests` probe ceiling 1s→5s keeps 25ms ≪ 5s ≪ 10s discrimination.
- No product code touched. No budget loses its bound.

## Triage table (acceptance criterion 1)

**Migrated to the helper:** AgentInboxTests ×4 (:794, :986, :1107, :1260) + `waitUntilEntered` (:66 — iteration budget had no wall-clock meaning; actor-isolated condition keeps a local twin of the contract); BackgroundProjectLifecycleTests (:845); NativeFileWindowMenuTests (:554, :764); QuickTerminalAgentDetectionTests (:1607); ProgressTrackerLeakTests ×3; CommandOverlayRouterTests (delegation, params preserved); LSPTransportTests private `waitUntil` (default 2s→5s).

**Left as-is, verdict at review:** AgentReleaseGateTests:134, GitCommandTests ×5, GitStatusProviderTests ×2, ExternalFileFormatterTests ×3, SymbolCoordinatorTests:146, RecoveryManagerTests:916, QuickOpenProviderTests:417 (all off-main or sync-owned-thread); LayoutStabilityTests:90,115 (no-suspend fast-path — commented in-tree with the migration trigger); DockMenu/TabManager/TabAutoSave/MenuSaveReentrancy/ContextFileWriter/Sidebar*/WorkspaceManager (≥2s ceilings for light main-flips); yield/turn-based/continuation waiters (not wall-clock).

**Split out:** #1605.

## Review gate

Three lenses + fix round + round-2 verifier. The verifier confirmed all 8 round-1 items CLOSED and independently re-checked that **no detector was blinded**: every raised ceiling still fails its regression (release-delay ordering, `outcome.timedOut`, nil-mapping, `.timeLimit(1min)` hang bound). Round-1 finds: P1 cancellation hot-spin (fixed), P2 helper tests / consolidation / rule placement / missed sites (all fixed).

## Local verification

All touched suites green one at a time (`dd-issue-1568`): BoundedMainActorWaitTests 4/4, AgentInboxTests 23, LSPProcessTransportTests, UserTaskRunnerTests, WindowLifecycleTests, NativeFileWindowMenuTests 20, BackgroundProjectLifecycleTests, QuickTerminalAgentDetectionTests 26, ProgressTrackerLeakTests 5, CommandOverlayRouterTests 26, LayoutStabilityTests. Parallel A/B with hosted-view neighbours: base 4 failures → diff a strict subset, new failures zero. `swiftlint --strict` clean. Environment: macOS 27.0 (26A5425a), Xcode 27.0 — CI (macOS 26) is authoritative for the full-run claim.

## Merge notes

- Touches `.claude/rules/concurrency.md` (+6 lines) — no overlap with other wave-1 branches.
- CI-time worst case: ~+2min on an already-red run (ceilings only matter on failure paths); green path ≈ +0.